### PR TITLE
0.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.3.3-rc.4",
+  "version": "0.3.4-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.3.3-rc.4",
+      "version": "0.3.4-rc.1",
       "dependencies": {
         "@microsoft/clarity": "^1.0.2",
         "@phosphor-icons/react": "^2.1.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.3.4-rc.1",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.3.4-rc.1",
+      "version": "0.3.4",
       "dependencies": {
         "@microsoft/clarity": "^1.0.2",
         "@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.3.4-rc.1",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.3.3-rc.4",
+  "version": "0.3.4-rc.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1633,7 +1633,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "headroom-desktop"
-version = "0.3.3-rc.4"
+version = "0.3.4-rc.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1633,7 +1633,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "headroom-desktop"
-version = "0.3.4-rc.1"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.3.3-rc.4"
+version = "0.3.4-rc.1"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.3.4-rc.1"
+version = "0.3.4"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -546,6 +546,12 @@ enum BootstrapFailureKind {
     /// verify pypi.org or github.com. Not our bug, but users here are stuck
     /// until they configure `REQUESTS_CA_BUNDLE` or disable TLS inspection.
     SslInterception,
+    /// Python's `tempfile` couldn't create a directory in any candidate
+    /// location (TMPDIR, /tmp, /var/tmp, /usr/tmp, cwd). Disk full, TCC
+    /// blocking writes, or a stale macOS per-user temp dir. Not our bug,
+    /// but the default "couldn't download a file" message is misleading
+    /// because pip never even got to the network.
+    NoUsableTempDir,
     Other,
 }
 
@@ -553,6 +559,7 @@ impl BootstrapFailureKind {
     fn as_str(self) -> &'static str {
         match self {
             BootstrapFailureKind::SslInterception => "ssl_interception",
+            BootstrapFailureKind::NoUsableTempDir => "no_usable_tempdir",
             BootstrapFailureKind::Other => "other",
         }
     }
@@ -571,6 +578,8 @@ fn classify_bootstrap_failure(err: &anyhow::Error) -> BootstrapFailureKind {
         || haystack.contains("self signed certificate in certificate chain")
     {
         BootstrapFailureKind::SslInterception
+    } else if haystack.contains("No usable temporary directory found") {
+        BootstrapFailureKind::NoUsableTempDir
     } else {
         BootstrapFailureKind::Other
     }
@@ -586,6 +595,13 @@ fn user_message_for(kind: BootstrapFailureKind) -> &'static str {
              environment variable to your organization's CA bundle, or disable TLS \
              inspection for pypi.org, files.pythonhosted.org, and github.com, then \
              restart the app. Contact support@extraheadroom.com if you need help."
+        }
+        BootstrapFailureKind::NoUsableTempDir => {
+            "Installation failed: Headroom can't create temporary files on this Mac. \
+             This usually means your disk is full, or security software (like an MDM \
+             profile or endpoint protection) is blocking writes to /tmp and \
+             /var/folders. Free up disk space, restart your Mac, and try again. \
+             If it still fails, contact support@extraheadroom.com."
         }
         BootstrapFailureKind::Other => {
             "Installation failed: Headroom couldn't download a required file. \
@@ -2689,6 +2705,25 @@ fn spawn_tray_runtime_icon_updater(app: AppHandle) {
     });
 }
 
+/// Should the watchdog expect the Python proxy to be reachable right now?
+///
+/// All five inputs are required to be in their "ready" state for the proxy
+/// to be supposed-up. Pulled out as a pure function so the truth table is
+/// trivially testable — every clause is load-bearing and removing one
+/// silently turns the watchdog into a thrash loop. Specifically `bypass`
+/// being false matters: when the pricing gate has flipped on `proxy_bypass`
+/// the Rust intercept is routing direct to api.anthropic.com, so a missing
+/// Python is intentional, not a failure.
+fn watchdog_should_be_up(
+    installed: bool,
+    paused: bool,
+    starting: bool,
+    upgrading: bool,
+    bypass: bool,
+) -> bool {
+    installed && !paused && !starting && !upgrading && !bypass
+}
+
 /// Every 5s, check whether the Python proxy is actually reachable while the
 /// app thinks the runtime should be up. If it isn't, try to restart via
 /// `ensure_headroom_running`. After 3 consecutive failures (~15s down) we
@@ -2719,11 +2754,13 @@ fn spawn_proxy_watchdog(app: AppHandle) {
             let bypass_active = state
                 .proxy_bypass
                 .load(std::sync::atomic::Ordering::Acquire);
-            let should_be_up = runtime.installed
-                && !runtime.paused
-                && !runtime.starting
-                && !state.runtime_upgrade_in_progress()
-                && !bypass_active;
+            let should_be_up = watchdog_should_be_up(
+                runtime.installed,
+                runtime.paused,
+                runtime.starting,
+                state.runtime_upgrade_in_progress(),
+                bypass_active,
+            );
             if !should_be_up {
                 if consecutive_failures > 0 {
                     eprintln!(
@@ -3267,9 +3304,10 @@ mod tests {
         lifetime_token_milestone_kind, parse_live_learnings, parse_updater_endpoint_list,
         pattern_matches_project, physical_rect_from_rect, read_applied_patterns_for_project,
         resolve_release_updater_config, select_updater_endpoints, store_checked_update,
-        AvailableAppUpdate, BootstrapFailureKind, HeadroomLearnPrereqStatus,
-        InstallPendingUpdateFuture, InstallableAppUpdate, MonitorBounds, PhysicalRect, QuitSource,
-        TrayRuntimeVisual, DEFAULT_UPDATER_ENDPOINT, DEFAULT_UPDATER_PUBLIC_KEY,
+        watchdog_should_be_up, AvailableAppUpdate, BootstrapFailureKind,
+        HeadroomLearnPrereqStatus, InstallPendingUpdateFuture, InstallableAppUpdate, MonitorBounds,
+        PhysicalRect, QuitSource, TrayRuntimeVisual, DEFAULT_UPDATER_ENDPOINT,
+        DEFAULT_UPDATER_PUBLIC_KEY,
     };
     use parking_lot::Mutex;
     use serde_json::json;
@@ -4130,6 +4168,20 @@ mod tests {
     }
 
     #[test]
+    fn classify_bootstrap_failure_flags_no_usable_temporary_directory() {
+        let err: anyhow::Error = make_command_failure(
+            "FileNotFoundError: [Errno 2] No usable temporary directory found in \
+             ['/var/folders/lp/.../T/', '/tmp', '/var/tmp', '/usr/tmp', \
+             '/Users/x/Library/Application Support/Headroom/headroom']",
+        )
+        .into();
+        assert!(matches!(
+            classify_bootstrap_failure(&err),
+            BootstrapFailureKind::NoUsableTempDir
+        ));
+    }
+
+    #[test]
     fn classify_bootstrap_failure_returns_other_for_unrelated_command_errors() {
         let err: anyhow::Error =
             make_command_failure("ConnectionResetError: [Errno 54] Connection reset by peer")
@@ -4302,5 +4354,44 @@ Some unrelated content.
             err.contains("Unknown file_kind"),
             "expected Unknown file_kind error, got: {err}"
         );
+    }
+
+    #[test]
+    fn watchdog_should_be_up_requires_runtime_installed() {
+        // Even if every other gate is "ready", a missing runtime means the
+        // watchdog should not expect Python to be reachable yet.
+        assert!(!watchdog_should_be_up(false, false, false, false, false));
+    }
+
+    #[test]
+    fn watchdog_should_be_up_when_all_gates_clear() {
+        // Installed, not paused, not booting, not upgrading, not bypassed —
+        // this is the one input combination that must return true.
+        assert!(watchdog_should_be_up(true, false, false, false, false));
+    }
+
+    #[test]
+    fn watchdog_should_be_up_respects_user_pause() {
+        assert!(!watchdog_should_be_up(true, true, false, false, false));
+    }
+
+    #[test]
+    fn watchdog_should_be_up_skips_during_boot() {
+        assert!(!watchdog_should_be_up(true, false, true, false, false));
+    }
+
+    #[test]
+    fn watchdog_should_be_up_skips_during_runtime_upgrade() {
+        assert!(!watchdog_should_be_up(true, false, false, true, false));
+    }
+
+    /// Critical regression guard. Removing the bypass clause from
+    /// `watchdog_should_be_up` would silently turn the watchdog into a thrash
+    /// loop the moment the pricing gate fires — it would keep restarting
+    /// Python while the bypass forwarder is doing its job, eventually
+    /// tripping the auto-pause path that strips Claude Code's env var.
+    #[test]
+    fn watchdog_should_be_up_skips_when_pricing_gate_bypassed() {
+        assert!(!watchdog_should_be_up(true, false, false, false, true));
     }
 }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -623,6 +623,12 @@ pub struct ClaudeAccountProfile {
     pub has_extra_usage_enabled: bool,
     pub plan_tier: ClaudePlanTier,
     pub plan_detection_source: Option<String>,
+    /// Raw `organization_type` from the OAuth profile, kept verbatim so the
+    /// server can audit which taxonomy strings we haven't enumerated yet
+    /// (specifically when `plan_tier` ends up `Unknown`).
+    pub organization_type: Option<String>,
+    /// Raw `rate_limit_tier` — same purpose as `organization_type`.
+    pub rate_limit_tier: Option<String>,
     pub weekly_utilization_pct: Option<f64>,
     pub five_hour_utilization_pct: Option<f64>,
     pub extra_usage_monthly_limit: Option<f64>,

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -45,6 +45,15 @@ struct IdentityPayload {
     claude_email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     claude_plan_tier: Option<ClaudePlanTier>,
+    /// Raw OAuth fields, forwarded verbatim so the server can audit which
+    /// taxonomy strings we haven't enumerated yet (especially when the
+    /// classified `claude_plan_tier` ends up `unknown`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    claude_organization_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    claude_rate_limit_tier: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    claude_billing_type: Option<String>,
 }
 
 fn plan_tier_header_value(tier: &ClaudePlanTier) -> &'static str {
@@ -75,6 +84,9 @@ impl IdentityPayload {
             claude_account_uuid: claude.and_then(|p| p.account_uuid.clone()),
             claude_email: claude.and_then(|p| p.email.clone()),
             claude_plan_tier: claude.map(|p| p.plan_tier.clone()),
+            claude_organization_type: claude.and_then(|p| p.organization_type.clone()),
+            claude_rate_limit_tier: claude.and_then(|p| p.rate_limit_tier.clone()),
+            claude_billing_type: claude.and_then(|p| p.billing_type.clone()),
         }
     }
 
@@ -94,6 +106,15 @@ impl IdentityPayload {
         }
         if let Some(tier) = self.claude_plan_tier.as_ref() {
             builder = builder.header("X-Headroom-Claude-Plan", plan_tier_header_value(tier));
+        }
+        if let Some(value) = self.claude_organization_type.as_deref() {
+            builder = builder.header("X-Headroom-Claude-Organization-Type", value);
+        }
+        if let Some(value) = self.claude_rate_limit_tier.as_deref() {
+            builder = builder.header("X-Headroom-Claude-Rate-Limit-Tier", value);
+        }
+        if let Some(value) = self.claude_billing_type.as_deref() {
+            builder = builder.header("X-Headroom-Claude-Billing-Type", value);
         }
         builder
     }
@@ -799,6 +820,8 @@ pub fn detect_claude_profile_uncached(state: &AppState) -> ClaudeAccountProfile 
             has_extra_usage_enabled: false,
             plan_tier: ClaudePlanTier::Unknown,
             plan_detection_source: None,
+            organization_type: None,
+            rate_limit_tier: None,
             weekly_utilization_pct: None,
             five_hour_utilization_pct: None,
             extra_usage_monthly_limit: None,
@@ -843,6 +866,12 @@ pub fn detect_claude_profile_uncached(state: &AppState) -> ClaudeAccountProfile 
             .unwrap_or(false),
         plan_tier,
         plan_detection_source,
+        organization_type: profile
+            .as_ref()
+            .and_then(|p| p.organization.as_ref().and_then(|o| o.organization_type.clone())),
+        rate_limit_tier: profile
+            .as_ref()
+            .and_then(|p| p.organization.as_ref().and_then(|o| o.rate_limit_tier.clone())),
         weekly_utilization_pct: usage
             .as_ref()
             .and_then(|u| u.seven_day.as_ref().map(|w| w.utilization)),
@@ -1013,10 +1042,66 @@ fn detect_plan_tier_from_profile(profile: &ClaudeOauthProfile) -> (ClaudePlanTie
         );
     }
 
+    log_unknown_plan_tier_once(profile);
     (
         ClaudePlanTier::Unknown,
         Some("oauth_profile.organization".into()),
     )
+}
+
+/// Capture the raw classification fields whenever `detect_plan_tier_from_profile`
+/// falls into the `Unknown` branch — i.e., the user has an Anthropic
+/// organization with `subscription_created_at` set but neither
+/// `organization_type` nor `rate_limit_tier` matches our enum. Almost
+/// certainly Team/Workspace/Enterprise plans we haven't enumerated.
+///
+/// Currently those users bypass the pricing gate entirely, which means
+/// paying Anthropic customers get Headroom for free. Goal of this telemetry
+/// is to learn which taxonomy strings to add to the detection (or to a new
+/// "treat as Pro" fallback) before changing the gate policy.
+///
+/// Deduped on content — Sentry sees one event per distinct
+/// (organization_type, rate_limit_tier, has_subscription, billing_type)
+/// combo across the lifetime of the desktop process.
+fn log_unknown_plan_tier_once(profile: &ClaudeOauthProfile) {
+    use std::collections::HashSet;
+    use std::hash::{DefaultHasher, Hash, Hasher};
+    use std::sync::OnceLock;
+
+    static SEEN: OnceLock<parking_lot::Mutex<HashSet<u64>>> = OnceLock::new();
+
+    let org = profile.organization.as_ref();
+    let organization_type = org
+        .and_then(|o| o.organization_type.as_deref())
+        .unwrap_or("");
+    let rate_limit_tier = org.and_then(|o| o.rate_limit_tier.as_deref()).unwrap_or("");
+    let billing_type = org.and_then(|o| o.billing_type.as_deref()).unwrap_or("");
+    let has_subscription_created_at = org
+        .and_then(|o| o.subscription_created_at.as_ref())
+        .is_some();
+
+    let mut hasher = DefaultHasher::new();
+    organization_type.hash(&mut hasher);
+    rate_limit_tier.hash(&mut hasher);
+    billing_type.hash(&mut hasher);
+    has_subscription_created_at.hash(&mut hasher);
+    let key = hasher.finish();
+
+    let seen = SEEN.get_or_init(|| parking_lot::Mutex::new(HashSet::new()));
+    if !seen.lock().insert(key) {
+        return;
+    }
+
+    let payload = serde_json::json!({
+        "organization_type": organization_type,
+        "rate_limit_tier": rate_limit_tier,
+        "billing_type": billing_type,
+        "has_subscription_created_at": has_subscription_created_at,
+    });
+    sentry::capture_message(
+        &format!("plan_tier_unknown: {payload}"),
+        sentry::Level::Warning,
+    );
 }
 
 fn json_string(value: &serde_json::Value, keys: &[&str]) -> Option<String> {
@@ -1363,10 +1448,9 @@ mod tests {
     fn identity_payload_serializes_with_camelcase_keys_and_skips_nulls() {
         let identity = IdentityPayload {
             device_id: "abc123".into(),
-            chopratejas_instance_id: None,
             claude_account_uuid: Some("claude-uuid".into()),
-            claude_email: None,
             claude_plan_tier: Some(ClaudePlanTier::Pro),
+            ..Default::default()
         };
         let json = serde_json::to_value(&identity).unwrap();
         assert_eq!(json["deviceId"], "abc123");
@@ -1380,10 +1464,7 @@ mod tests {
     fn identity_payload_skips_plan_when_none() {
         let identity = IdentityPayload {
             device_id: "abc123".into(),
-            chopratejas_instance_id: None,
-            claude_account_uuid: None,
-            claude_email: None,
-            claude_plan_tier: None,
+            ..Default::default()
         };
         let json = serde_json::to_value(&identity).unwrap();
         assert!(json.get("claudePlanTier").is_none());
@@ -1402,10 +1483,8 @@ mod tests {
     fn apply_headers_sets_plan_when_present() {
         let identity = IdentityPayload {
             device_id: "abc123".into(),
-            chopratejas_instance_id: None,
-            claude_account_uuid: None,
-            claude_email: None,
             claude_plan_tier: Some(ClaudePlanTier::Max20x),
+            ..Default::default()
         };
         let client = reqwest::blocking::Client::new();
         let req = identity
@@ -1422,10 +1501,7 @@ mod tests {
     fn apply_headers_omits_plan_when_none() {
         let identity = IdentityPayload {
             device_id: "abc123".into(),
-            chopratejas_instance_id: None,
-            claude_account_uuid: None,
-            claude_email: None,
-            claude_plan_tier: None,
+            ..Default::default()
         };
         let client = reqwest::blocking::Client::new();
         let req = identity
@@ -1531,6 +1607,8 @@ mod tests {
             has_extra_usage_enabled: false,
             plan_tier,
             plan_detection_source: None,
+            organization_type: None,
+            rate_limit_tier: None,
             weekly_utilization_pct: None,
             five_hour_utilization_pct: None,
             extra_usage_monthly_limit: None,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -5050,6 +5050,8 @@ mod tests {
                 has_extra_usage_enabled: false,
                 plan_tier: ClaudePlanTier::Unknown,
                 plan_detection_source: None,
+                organization_type: None,
+                rate_limit_tier: None,
                 weekly_utilization_pct: None,
                 five_hour_utilization_pct: None,
                 extra_usage_monthly_limit: None,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.3.4-rc.1",
+  "version": "0.3.4",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.3.3-rc.4",
+  "version": "0.3.4-rc.1",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Promotes `0.3.4-rc.1` (validated on staging) to stable.

Contains:
- Merge of `main` into release branch (resolves version-file conflict from divergent `0.3.3` bump on main)
- Code changes from `0.3.4-rc.1` (`lib.rs`, `pricing.rs`, `models.rs`, `state.rs`)
- Version bump to `0.3.4`

**Merge with "Create a merge commit"** — squash/rebase will rewrite SHAs and break the rc-ancestor check in `release-macos.yml`.

rc tag in ancestry: `v0.3.4-rc.1` (765f358) — required by the workflow's promotion guard.