### PR TITLE
Release 0.3.5

### DIFF
--- a/.github/release-notes/0.3.5.md
+++ b/.github/release-notes/0.3.5.md
@@ -1,0 +1,1 @@
+Bugfixes

--- a/README.md
+++ b/README.md
@@ -143,10 +143,10 @@ Use `./scripts/bump-version.sh <version>` to update all four version files at on
 
 Two release channels are wired into CI:
 
-- **`main`** — stable channel. Users on the default download get updates from here. Version must be plain `X.Y.Z`.
+- **`main`** — stable channel. Users on the default download get updates from here. Version must be plain `X.Y.Z`. Branch-protected: direct pushes are rejected; changes land via PR only.
 - **`staging`** — release candidate channel. Installs via a separate build pointing at the rolling `staging` GitHub release. Version must be `X.Y.Z-rc.N`.
 
-Work happens on `feature/*` branches, which merge into `staging` for testing, which merges into `main` for promotion. `main` is fast-forward only from `staging`.
+Work happens on `feature/*` branches, which merge into `staging` for testing. Stable promotions land on `main` via a release PR (see below).
 
 **Release candidate flow:**
 
@@ -157,14 +157,21 @@ Work happens on `feature/*` branches, which merge into `staging` for testing, wh
 
 **Promoting to stable:**
 
-1. Fast-forward merge `staging` → `main`.
-2. Bump version to plain `X.Y.Z` (strip `-rc.N`) and push. `.github/workflows/release-macos.yml` publishes the stable release.
-3. The main workflow **enforces** that a `vX.Y.Z-rc.N` prerelease exists whose commit is an ancestor of the stable commit. If not, the build fails. This guarantees stable only ships code that was tested via the staging channel.
-4. After the stable build is published, the main workflow re-points the rolling `staging` release at the stable DMG. The staging machine receives that as an update, installs it, and — because the new version is plain `X.Y.Z` — automatically switches to the stable endpoint for all future checks.
+`main` is branch-protected, so promotions go through a release PR. The merge **must** be a merge commit (not squash, not rebase) so the staging commits — including the rc tag's commit — remain in `main`'s history and the rc-ancestor check passes.
+
+1. From the verified `staging` tip, cut a release branch: `git checkout -b release/X.Y.Z staging`.
+2. On that branch, run `./scripts/bump-version.sh X.Y.Z` (strips `-rc.N`), commit, push.
+3. Open a PR from `release/X.Y.Z` into `main`.
+4. Merge with **"Create a merge commit"**. `.github/workflows/release-macos.yml` triggers on the push to `main` and publishes the stable release.
+5. The main workflow **enforces** that a `vX.Y.Z-rc.N` prerelease exists whose commit is an ancestor of the stable (merge) commit. If not, the build fails. This guarantees stable only ships code that was tested via the staging channel.
+6. After the stable build is published, the main workflow re-points the rolling `staging` release at the stable DMG. The staging machine receives that as an update, installs it, and — because the new version is plain `X.Y.Z` — automatically switches to the stable endpoint for all future checks.
+7. Delete the `release/X.Y.Z` branch.
+
+> Recommended: in **Settings → General → Pull Requests**, leave only "Allow merge commits" enabled and disable squash and rebase merges. The rc-ancestor check already rejects squashed/rebased promotions at build time, but disabling them at the repo level prevents an accidental click that lands a broken bump on `main`.
 
 **Bypassing the rc check:**
 
-For hotfixes where a staging cycle is impractical, include `[skip-rc-check]` in the commit message that bumps the version on `main`. Use sparingly — the guard exists to prevent untested stable releases.
+For hotfixes where a staging cycle is impractical, include `[skip-rc-check]` in the **PR merge commit message** (the workflow reads the merge commit's message, not the bump commit's). Easiest path: put `[skip-rc-check]` in the PR title or first body line so GitHub includes it in the auto-generated merge commit. Use sparingly — the guard exists to prevent untested stable releases.
 
 ## Development
 

--- a/docs/beta-smoke-test.md
+++ b/docs/beta-smoke-test.md
@@ -1,0 +1,66 @@
+# Beta smoke test
+
+After installing a new beta (`-rc.N`) build, paste this file into Claude Code and ask it to run the checks. Each check has a single expected signal — if any fail, stop and investigate before promoting to stable.
+
+## Setup
+
+1. Quit and relaunch Headroom from Applications.
+2. Confirm the tray icon appears in the menu bar.
+3. Open the dashboard window once (so the proxy is fully booted).
+
+## Checks
+
+Claude: run each block and report PASS / FAIL with the observed value.
+
+### 1. Version matches the new beta
+```bash
+ls ~/Applications/Headroom.app/Contents/Info.plist >/dev/null && \
+  /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" /Applications/Headroom.app/Contents/Info.plist
+```
+Expect: the `-rc.N` version you just installed.
+
+### 2. Proxy is intercepting this conversation
+Send a trivial prompt ("say hi"), then:
+```bash
+/usr/bin/python3 -c "import json; d=json.load(open('/Users/garmlucassen/Library/Application Support/Headroom/config/activity-facts.json')); print(d['lastTransformation']['observedAt'])"
+```
+Expect: a UTC timestamp within the last minute. (The proxy log file mtime is not a reliable signal — it can lag by minutes between heartbeats.)
+
+### 3. Activity facts updated
+```bash
+stat -f '%Sm' ~/Library/Application\ Support/Headroom/config/activity-facts.json
+```
+Expect: mtime within the last minute (after step 2).
+
+### 4. RTK is on PATH and reports savings
+```bash
+rtk --version && rtk gain | head -5
+```
+Expect: a version line and a gain summary, no "command not found".
+
+### 5. MCP retrieve tool is available (only if memory tools are enabled)
+First check whether the proxy was started with memory tools:
+```bash
+ls ~/Library/Application\ Support/Headroom/headroom/logs/ | grep -E 'no-memory-tools' >/dev/null && echo 'memory tools DISABLED — skip this check' || echo 'memory tools enabled — run check'
+```
+If enabled, have Claude call `mcp__headroom__headroom_retrieve` with any small query and expect a tool result (not "No such tool available").
+
+### 6. Tray → Dashboard renders
+Click the tray icon, open the dashboard. Expect savings chart and per-client stats render without a blank/error state.
+
+### 7. Pause / resume cleanly strips and restores interception
+In Settings, toggle Pause then Resume. After Pause, `cat ~/.claude/settings.json | grep -c headroom-rtk-rewrite` should return `0`; after Resume it should return `1`.
+
+## Inspecting the proxy directly
+
+When inspecting the running proxy by hand (e.g. checking `/stats`), wrap `curl` with `rtk proxy` to bypass RTK's output filtering — otherwise large JSON responses get summarized into a type-shape view that looks like a broken endpoint:
+
+```bash
+rtk proxy curl -s http://127.0.0.1:6768/stats | jq .summary
+```
+
+## When something fails
+
+- Proxy log silent → check `~/Library/Application Support/Headroom/headroom/logs/` for a newer log file or a crash file.
+- RTK missing → check the managed block in `~/.zshrc` / `~/.zprofile` is intact and the shell has been reloaded.
+- MCP tool missing → restart Claude Code; the MCP server registration happens at session start.

--- a/docs/macos-release.md
+++ b/docs/macos-release.md
@@ -216,7 +216,7 @@ There are two channels with separate GitHub Actions workflows:
 
 - Feature work happens on `feature/*` branches.
 - Feature branches merge into `staging` for release-candidate builds.
-- `staging` fast-forwards into `main` for stable promotion.
+- `main` is branch-protected (no direct pushes). Stable promotion goes through a release PR from a `release/X.Y.Z` branch (cut from the verified `staging` tip, with the version bumped to plain `X.Y.Z`) into `main`. Merge with **"Create a merge commit"** — squash and rebase merges rewrite the staging SHAs and break the rc-ancestor check below. See the README for the full step-by-step.
 
 ### Staging workflow
 
@@ -242,7 +242,7 @@ The stable workflow refuses to run unless:
 1. The version is plain `X.Y.Z` (no `-rc` suffix).
 2. A `vX.Y.Z-rc.N` prerelease exists on GitHub whose tagged commit is an ancestor of the commit being released. This enforces that stable only ships code that was tested via the staging channel.
 
-To bypass the guard for emergency hotfixes, include `[skip-rc-check]` in the commit message that bumps the version on `main`.
+To bypass the guard for emergency hotfixes, include `[skip-rc-check]` in the **PR merge commit message** (the workflow reads the merge commit on `main`, not the bump commit on the release branch). Putting `[skip-rc-check]` in the PR title or first body line is the easiest way — GitHub copies it into the auto-generated merge commit.
 
 ### Final update-flow verification
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.3.4",
+  "version": "0.3.5-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.3.4",
+      "version": "0.3.5-rc.1",
       "dependencies": {
         "@microsoft/clarity": "^1.0.2",
         "@phosphor-icons/react": "^2.1.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.3.5-rc.2",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.3.5-rc.2",
+      "version": "0.3.5",
       "dependencies": {
         "@microsoft/clarity": "^1.0.2",
         "@phosphor-icons/react": "^2.1.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.3.5-rc.1",
+  "version": "0.3.5-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.3.5-rc.1",
+      "version": "0.3.5-rc.2",
       "dependencies": {
         "@microsoft/clarity": "^1.0.2",
         "@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.3.5-rc.2",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.3.4",
+  "version": "0.3.5-rc.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.3.5-rc.1",
+  "version": "0.3.5-rc.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1633,7 +1633,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "headroom-desktop"
-version = "0.3.5-rc.2"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1633,7 +1633,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "headroom-desktop"
-version = "0.3.4"
+version = "0.3.5-rc.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1633,7 +1633,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "headroom-desktop"
-version = "0.3.5-rc.1"
+version = "0.3.5-rc.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.3.5-rc.2"
+version = "0.3.5"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.3.4"
+version = "0.3.5-rc.1"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.3.5-rc.1"
+version = "0.3.5-rc.2"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -703,6 +703,18 @@ pub(crate) fn capture_headroom_start_failure(context: &str, err: &anyhow::Error)
     }
 }
 
+/// Diagnostic snapshot taken at the moment a boot-validation failure is
+/// captured. Distinguishes "the new proxy never spawned" (tracked_child=false)
+/// from "spawned but crashed before writing logs" (no new log) from "spawned
+/// and bound but unreachable" (port_bound=true, log written, /livez never
+/// answered). None for install-phase failures where no proxy launch happened.
+#[derive(Default, Clone, Copy)]
+pub(crate) struct UpgradeBootDiagnostics {
+    pub tracked_child: bool,
+    pub new_proxy_log_written: bool,
+    pub proxy_port_bound: bool,
+}
+
 /// Report a runtime upgrade failure to Sentry. `phase` is "install" for
 /// pip/smoke-test failures, "boot_validation" for "installed but didn't boot".
 /// `outcome` is the BootValidationOutcome label when phase is boot_validation.
@@ -715,6 +727,7 @@ pub(crate) fn capture_upgrade_failure(
     target_version: Option<&str>,
     fallback_version: Option<&str>,
     log_tail: Option<&str>,
+    boot_diagnostics: Option<UpgradeBootDiagnostics>,
 ) {
     let technical_err = format!("{err:#}");
     let cmd_failure = err
@@ -768,6 +781,20 @@ pub(crate) fn capture_upgrade_failure(
             }
             if let Some(tail) = log_tail_capped.as_deref() {
                 scope.set_extra("log_tail", tail.into());
+            }
+            if let Some(diag) = boot_diagnostics {
+                scope.set_tag("tracked_child", if diag.tracked_child { "true" } else { "false" });
+                scope.set_tag(
+                    "new_proxy_log_written",
+                    if diag.new_proxy_log_written { "true" } else { "false" },
+                );
+                scope.set_tag(
+                    "proxy_port_bound",
+                    if diag.proxy_port_bound { "true" } else { "false" },
+                );
+                scope.set_extra("tracked_child", diag.tracked_child.into());
+                scope.set_extra("new_proxy_log_written", diag.new_proxy_log_written.into());
+                scope.set_extra("proxy_port_bound", diag.proxy_port_bound.into());
             }
             if let Some(failure) = cmd_failure {
                 scope.set_extra("program", failure.program.clone().into());
@@ -1899,29 +1926,49 @@ pub fn run() {
             use tauri_plugin_deep_link::DeepLinkExt;
             let deep_link_app = app.handle().clone();
             app.deep_link().on_open_url(move |event| {
-                for url in event.urls() {
-                    if url.scheme() == "headroom" {
-                        eprintln!("deep link received: {url}");
-                        let app_handle = deep_link_app.clone();
-                        let _ = show_launcher_window(&app_handle);
-                        // Run the reconciliation on a worker thread — the
-                        // deep-link callback is on the main thread and we
-                        // don't want pricing's blocking HTTP call there.
-                        std::thread::spawn(move || {
-                            let state: tauri::State<'_, AppState> = app_handle.state();
-                            match pricing::get_pricing_status(&state) {
-                                Ok(status) => {
-                                    state.apply_pricing_gate_status(&status);
-                                    let _ = app_handle.emit("pricing-refreshed", &status);
+                // NOTE: do NOT use `eprintln!`/`println!` here. When macOS
+                // launches the app fresh via a URL scheme, stderr is not
+                // connected to a valid fd and any write panics with EIO.
+                //
+                // This callback is invoked synchronously from tao's
+                // `application:openURLs:` handler, which is `extern "C"` —
+                // any panic that escapes here aborts the whole process via
+                // `panic_cannot_unwind`. Wrap the body in `catch_unwind` so
+                // an internal failure degrades gracefully instead.
+                let deep_link_app = deep_link_app.clone();
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    for url in event.urls() {
+                        if url.scheme() == "headroom" {
+                            let app_handle = deep_link_app.clone();
+                            let _ = show_launcher_window(&app_handle);
+                            // Run the reconciliation on a worker thread — the
+                            // deep-link callback is on the main thread and we
+                            // don't want pricing's blocking HTTP call there.
+                            std::thread::spawn(move || {
+                                let state: tauri::State<'_, AppState> = app_handle.state();
+                                match pricing::get_pricing_status(&state) {
+                                    Ok(status) => {
+                                        state.apply_pricing_gate_status(&status);
+                                        let _ = app_handle.emit("pricing-refreshed", &status);
+                                    }
+                                    Err(err) => {
+                                        sentry::capture_message(
+                                            &format!("deep link pricing refresh failed: {err}"),
+                                            sentry::Level::Warning,
+                                        );
+                                    }
                                 }
-                                Err(err) => eprintln!(
-                                    "deep link pricing refresh failed: {err}"
-                                ),
-                            }
-                        });
-                        // Only handle the first headroom:// URL in the batch.
-                        break;
+                            });
+                            // Only handle the first headroom:// URL in the batch.
+                            break;
+                        }
                     }
+                }));
+                if result.is_err() {
+                    sentry::capture_message(
+                        "deep link callback panicked",
+                        sentry::Level::Error,
+                    );
                 }
             });
             Ok(())
@@ -2356,25 +2403,51 @@ fn execute_headroom_learn_run(state: &AppState, project_path: &str) -> HeadroomL
                 } else {
                     output_tail.join("\n")
                 };
+                let exit_code_str = output
+                    .status
+                    .code()
+                    .map(|c| c.to_string())
+                    .unwrap_or_else(|| "signal".into());
+                // First non-empty line of stderr (or stdout if stderr empty),
+                // truncated, used both in the message and the fingerprint so
+                // events group by failure mode instead of the capture-site stack.
+                let signature_source = if !stderr.trim().is_empty() {
+                    stderr.as_str()
+                } else {
+                    stdout.as_str()
+                };
+                let signature: String = signature_source
+                    .lines()
+                    .map(str::trim)
+                    .find(|l| !l.is_empty())
+                    .unwrap_or("no output")
+                    .chars()
+                    .take(160)
+                    .collect();
+                let stderr_head: String = stderr.chars().take(2000).collect();
+                let stdout_head: String = stdout.chars().take(2000).collect();
+                let claude_cli_path = claude_cli::detect_claude_cli()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_else(|| "not_found".into());
+                let summary_msg = format!(
+                    "headroom learn failed (exit={exit_code_str}) {signature}"
+                );
+                let fingerprint: [&str; 3] =
+                    ["headroom_learn", exit_code_str.as_str(), signature.as_str()];
                 sentry::with_scope(
                     |scope| {
                         scope.set_tag("flow", "headroom_learn");
-                        scope.set_context(
-                            "learn",
-                            sentry::protocol::Context::Other(
-                                [
-                                    ("exit_status".into(), output.status.to_string().into()),
-                                    ("output_tail".into(), fail_tail.clone().into()),
-                                ]
-                                .into(),
-                            ),
-                        );
+                        scope.set_tag("exit_code", &exit_code_str);
+                        scope.set_extra("exit_status", output.status.to_string().into());
+                        scope.set_extra("output_tail", fail_tail.clone().into());
+                        scope.set_extra("stderr_head", stderr_head.into());
+                        scope.set_extra("stdout_head", stdout_head.into());
+                        scope.set_extra("claude_cli_path", claude_cli_path.into());
+                        scope.set_extra("project_name", project_name.to_string().into());
+                        scope.set_fingerprint(Some(fingerprint.as_slice()));
                     },
                     || {
-                        sentry::capture_message(
-                            "headroom learn exited with non-zero status",
-                            sentry::Level::Error,
-                        )
+                        sentry::capture_message(&summary_msg, sentry::Level::Error);
                     },
                 );
                 (
@@ -2540,7 +2613,10 @@ fn spawn_tray_runtime_icon_updater(app: AppHandle) {
     let icons = match build_tray_runtime_icons() {
         Ok(icons) => icons,
         Err(err) => {
-            eprintln!("failed to build runtime tray icons: {err}");
+            sentry::capture_message(
+                &format!("failed to build runtime tray icons: {err}"),
+                sentry::Level::Warning,
+            );
             return;
         }
     };
@@ -3070,9 +3146,9 @@ fn toggle_main_window(app: &AppHandle, anchor_rect: Option<Rect>) -> tauri::Resu
 
     hide_launcher_window(app)?;
 
-    let window = app
-        .get_webview_window("main")
-        .expect("main window should exist");
+    let Some(window) = app.get_webview_window("main") else {
+        return Err(tauri::Error::WebviewNotFound);
+    };
 
     if window.is_visible()? {
         window.hide()?;
@@ -3094,7 +3170,6 @@ fn ensure_runtime_ready_for_tray(app: &AppHandle) {
     match state.ensure_headroom_running() {
         Ok(()) => port_conflict::note_proxy_started(app),
         Err(err) => {
-            eprintln!("failed to ensure headroom runtime for tray: {err}");
             // Tray open is in-session (not a fresh launch); pass false so the
             // launch counter is preserved instead of double-counting clicks.
             let handled = port_conflict::note_proxy_failed(app, &err, false);
@@ -3121,9 +3196,9 @@ fn complete_setup_wizard(state: tauri::State<'_, AppState>) {
 }
 
 fn show_main_window(app: &AppHandle, anchor_rect: Option<Rect>) -> tauri::Result<()> {
-    let window = app
-        .get_webview_window("main")
-        .expect("main window should exist");
+    let Some(window) = app.get_webview_window("main") else {
+        return Err(tauri::Error::WebviewNotFound);
+    };
 
     if let Some(rect) = anchor_rect {
         position_tray_window(&window, rect)?;
@@ -3136,9 +3211,9 @@ fn show_main_window(app: &AppHandle, anchor_rect: Option<Rect>) -> tauri::Result
 }
 
 fn show_launcher_window(app: &AppHandle) -> tauri::Result<()> {
-    let window = app
-        .get_webview_window("launcher")
-        .expect("launcher window should exist");
+    let Some(window) = app.get_webview_window("launcher") else {
+        return Err(tauri::Error::WebviewNotFound);
+    };
 
     let _ = window.center();
     window.show()?;

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -154,7 +154,9 @@ struct ClaudeOauthProfileOrganization {
     has_extra_usage_enabled: bool,
     /// e.g. "claude_pro", "claude_max", "claude_enterprise"
     organization_type: Option<String>,
-    /// e.g. "default_claude_ai", "claude_max_5x", "claude_max_20x"
+    /// e.g. "default_claude_ai", "claude_max_5x", "claude_max_20x",
+    /// "default_claude_max_x5", "default_claude_max_x20" (Anthropic ships both
+    /// the `_5x`/`_20x` and `_x5`/`_x20` orderings in the wild)
     rate_limit_tier: Option<String>,
 }
 
@@ -982,13 +984,15 @@ fn detect_plan_tier_from_profile(profile: &ClaudeOauthProfile) -> (ClaudePlanTie
 
     if let Some(rate_limit_tier) = org.rate_limit_tier.as_deref() {
         let normalized = rate_limit_tier.trim().to_ascii_lowercase();
-        if normalized.contains("20x") {
+        // Anthropic ships both orderings in the wild: "claude_max_20x" and
+        // "default_claude_max_x20" (same for 5x/x5). Match either.
+        if normalized.contains("20x") || normalized.contains("x20") {
             return (
                 ClaudePlanTier::Max20x,
                 Some("oauth_profile.organization.rateLimitTier".into()),
             );
         }
-        if normalized.contains("5x") {
+        if normalized.contains("5x") || normalized.contains("x5") {
             return (
                 ClaudePlanTier::Max5x,
                 Some("oauth_profile.organization.rateLimitTier".into()),
@@ -1987,6 +1991,32 @@ mod tests {
         assert!(matches!(
             detect_plan_tier_from_profile(&p).0,
             ClaudePlanTier::Max5x
+        ));
+    }
+
+    #[test]
+    fn detect_plan_tier_rate_limit_x5_variant_is_max5x() {
+        let p = oauth_profile(
+            Some("default_claude_max_x5"),
+            Some("default_claude"),
+            Some(Utc::now()),
+        );
+        assert!(matches!(
+            detect_plan_tier_from_profile(&p).0,
+            ClaudePlanTier::Max5x
+        ));
+    }
+
+    #[test]
+    fn detect_plan_tier_rate_limit_x20_variant_is_max20x() {
+        let p = oauth_profile(
+            Some("default_claude_max_x20"),
+            Some("default_claude"),
+            Some(Utc::now()),
+        );
+        assert!(matches!(
+            detect_plan_tier_from_profile(&p).0,
+            ClaudePlanTier::Max20x
         ));
     }
 

--- a/src-tauri/src/proxy_intercept.rs
+++ b/src-tauri/src/proxy_intercept.rs
@@ -218,6 +218,19 @@ async fn forward_direct_to_anthropic(
         return;
     };
 
+    // These paths are served by the local Python proxy, not Anthropic. In
+    // bypass mode the proxy is intentionally down, so reply 503 instead of
+    // forwarding upstream (which would either fail noisily or, worse, hit a
+    // real Anthropic endpoint that happens to share the path).
+    // Denylist (not allowlist) so future Anthropic API versions like /v2/*
+    // continue to forward automatically without requiring a desktop update.
+    if is_local_proxy_path(&parsed.path) {
+        let _ = client
+            .write_all(b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n")
+            .await;
+        return;
+    }
+
     let body = match parsed.content_length {
         Some(total) if total > leftover_body.len() => {
             let mut body = Vec::with_capacity(total);
@@ -439,6 +452,30 @@ where
 
 fn find_header_end(buf: &[u8]) -> Option<usize> {
     buf.windows(4).position(|w| w == b"\r\n\r\n")
+}
+
+/// Paths served by the local Python proxy (not Anthropic). Matches the prefix
+/// so sub-paths (e.g. `/transformations/feed`) and query strings are covered,
+/// while preventing partial matches (e.g. `/healthcheck` does not match
+/// `/health`).
+fn is_local_proxy_path(path: &str) -> bool {
+    const LOCAL_PREFIXES: &[&str] = &[
+        "/readyz",
+        "/livez",
+        "/health",
+        "/stats",
+        "/transformations",
+        "/dashboard",
+        "/debug",
+        "/subscription-window",
+        "/quota",
+        "/metrics",
+        "/cache",
+    ];
+    LOCAL_PREFIXES.iter().any(|prefix| {
+        path.strip_prefix(prefix)
+            .is_some_and(|rest| rest.is_empty() || rest.starts_with('/') || rest.starts_with('?'))
+    })
 }
 
 /// Return true if the request's Host header targets the loopback listener

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -223,6 +223,63 @@ fn proxy_port_accepts_connection() -> bool {
     tcp_port_accepts_connection(addr, std::time::Duration::from_secs(1))
 }
 
+/// Parse the `ps -p PID -o time=` accumulated CPU time format.
+/// macOS `ps` emits this as `MM:SS.ss`, `HH:MM:SS`, or `D-HH:MM:SS`
+/// depending on duration. Returns whole seconds; sub-second precision
+/// is dropped (we only care about per-tick advancement, which is
+/// always >=1s of CPU work to register).
+fn parse_ps_cpu_time(raw: &str) -> Option<u64> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let (days, rest) = match trimmed.split_once('-') {
+        Some((d, r)) => (d.parse::<u64>().ok()?, r),
+        None => (0u64, trimmed),
+    };
+    let parts: Vec<&str> = rest.split(':').collect();
+    let (h, m, s_raw) = match parts.as_slice() {
+        [h, m, s] => (h.parse::<u64>().ok()?, m.parse::<u64>().ok()?, *s),
+        [m, s] => (0u64, m.parse::<u64>().ok()?, *s),
+        _ => return None,
+    };
+    // Drop fractional seconds.
+    let s_whole = s_raw.split('.').next()?.parse::<u64>().ok()?;
+    Some(days * 86400 + h * 3600 + m * 60 + s_whole)
+}
+
+/// Read accumulated CPU time (seconds) for ``pid`` via macOS `ps`.
+/// Returns None if the process is gone or `ps` fails. Cheap enough
+/// to call on a 500ms boot-validation tick — fork+exec of a tiny
+/// system binary, no I/O beyond the kernel proc table.
+fn tracked_process_cpu_time_secs(pid: u32) -> Option<u64> {
+    let output = Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "time="])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_ps_cpu_time(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// Whether the tracked process's accumulated CPU time advanced since
+/// the previous observation. Catches the "alive but silent" case —
+/// e.g. ONNX graph compile, model load, any synchronous CPU-bound
+/// work in the proxy's lifespan startup that produces no log writes,
+/// no HF cache growth, and doesn't yet bind :6768. Treats the first
+/// observation (None → Some(>0)) as growth so a process that's
+/// already burned cycles before we started polling counts as active;
+/// None → Some(0) is "just spawned, not yet doing work" and is NOT
+/// growth (matches `hf_cache_grew` semantics).
+fn cpu_time_advanced(prev: Option<u64>, current: Option<u64>) -> bool {
+    match (prev, current) {
+        (Some(p), Some(c)) => c > p,
+        (None, Some(c)) => c > 0,
+        _ => false,
+    }
+}
+
 /// Pure decision function for the boot-validation stall guard.
 /// Extracted from the polling loop so it can be tested without
 /// mocking the filesystem, the network, and a clock.
@@ -646,6 +703,13 @@ impl AppState {
         // an implementation detail tracked in the failure record only.
         let previous_app_version = self.launch_profile.lock().last_launched_app_version.clone();
 
+        // Snapshot the newest proxy log mtime BEFORE we stop the old proxy and
+        // install the new one. At failure time we compare against this to tell
+        // "the new proxy wrote some logs (so it at least started python)" from
+        // "the new proxy never produced any log activity (likely failed to
+        // spawn or crashed pre-import)".
+        let pre_upgrade_log_mtime = newest_proxy_log_mtime(&self.tool_manager.logs_dir());
+
         *self.runtime_upgrade_in_progress.lock() = true;
         self.invalidate_runtime_status_cache();
 
@@ -755,6 +819,7 @@ impl AppState {
                     Some(duration_ms),
                     Some(target_version.as_str()),
                     installed_version.as_deref(),
+                    None,
                     None,
                 );
                 analytics::track_event(
@@ -911,6 +976,23 @@ impl AppState {
         let log_tail = crate::tool_manager::newest_proxy_log_path(&self.tool_manager.logs_dir())
             .map(|path| crate::tool_manager::tail_log_file(&path, 30))
             .filter(|s| !s.is_empty());
+
+        // Diagnostics for Sentry — capture before stop_headroom() tears down
+        // the tracked child and the proxy port. These three booleans
+        // distinguish the failure modes that all surface as "Stalled":
+        //   tracked_child=false → ensure_headroom_running silently no-op'd
+        //   new_proxy_log_written=false → spawn happened but python never
+        //                                 reached the logging setup
+        //   proxy_port_bound=false → uvicorn never reached its bind() call
+        let boot_diagnostics = crate::UpgradeBootDiagnostics {
+            tracked_child: self.headroom_process.lock().is_some(),
+            new_proxy_log_written: log_mtime_advanced(
+                pre_upgrade_log_mtime,
+                newest_proxy_log_mtime(&self.tool_manager.logs_dir()),
+            ),
+            proxy_port_bound: proxy_port_accepts_connection(),
+        };
+
         self.stop_headroom();
         let rollback_result = if needs_commit_or_rollback {
             self.tool_manager.rollback_headroom_upgrade()
@@ -990,6 +1072,7 @@ impl AppState {
             Some(target_version.as_str()),
             installed_version.as_deref(),
             log_tail.as_deref(),
+            Some(boot_diagnostics),
         );
         analytics::track_event(
             app,
@@ -1096,9 +1179,10 @@ impl AppState {
     /// stall threshold, or `RUNTIME_UPGRADE_BOOT_MAX_SECS` elapses. On each
     /// pass through the loop, emits a progress update via `on_progress`.
     ///
-    /// "Activity" is the union of three signals: (1) a write to any
+    /// "Activity" is the union of four signals: (1) a write to any
     /// ``headroom-proxy*.log`` file, (2) growth in the HuggingFace hub
-    /// cache, and (3) a successful TCP connect to ``127.0.0.1:6768``.
+    /// cache, (3) a successful TCP connect to ``127.0.0.1:6768``, and
+    /// (4) advancement of the tracked child's accumulated CPU time.
     /// Any one resets the silence timer. The HF signal is what keeps
     /// slow-but-progressing first-run downloads from being killed —
     /// when transformers/huggingface_hub is silently pulling multi-GB
@@ -1110,7 +1194,12 @@ impl AppState {
     /// upstream) — the kernel still completes ``accept()`` even when
     /// uvicorn isn't draining the socket, so a successful connect
     /// proves the python process is alive even though no HTTP
-    /// endpoint answers.
+    /// endpoint answers. The CPU-time signal covers a fourth case
+    /// that all three above miss: lifespan-phase work that's neither
+    /// writing logs nor downloading models nor yet bound to the port,
+    /// e.g. ONNX graph compilation or eager-loading already-cached
+    /// models. As long as the python process is burning CPU, it's
+    /// not deadlocked.
     fn wait_for_boot_validation<F>(&self, mut on_progress: F) -> BootValidationOutcome
     where
         F: FnMut(std::time::Duration, bool),
@@ -1136,12 +1225,19 @@ impl AppState {
         // 50k entries is well above any healthy first-run install.
         const HF_CACHE_WALK_CAP: usize = 50_000;
 
+        // Capture the tracked PID once at loop entry. If `headroom_process`
+        // is None now (e.g. ensure_headroom_running short-circuited or the
+        // spawn errored), it stays None for the duration — capturing once
+        // avoids re-acquiring the lock every 500ms.
+        let tracked_pid: Option<u32> = self.headroom_process.lock().as_ref().map(|c| c.id());
+
         let start = Instant::now();
         let mut last_log_activity = start;
         let mut last_seen_mtime = newest_proxy_log_mtime(&logs_dir);
         let mut last_hf_size = hf_cache
             .as_deref()
             .map(|p| total_dir_size_bytes(p, HF_CACHE_WALK_CAP));
+        let mut last_cpu_secs: Option<u64> = tracked_pid.and_then(tracked_process_cpu_time_secs);
         let mut last_progress = Instant::now()
             .checked_sub(Duration::from_secs(5))
             .unwrap_or_else(Instant::now);
@@ -1197,9 +1293,30 @@ impl AppState {
                 last_log_activity = Instant::now();
             }
 
+            // Refresh CPU-time observation. Catches lifespan-phase work
+            // that's invisible to the three signals above — e.g. ONNX
+            // graph compile or eager-loading pre-cached models, which
+            // can sit silent for >90s while the python process is hot
+            // on a CPU. Only fires for the tracked child; if we don't
+            // own a Child handle (rare — ensure_headroom_running
+            // short-circuited or errored), this signal is unavailable
+            // and we lean on the other three.
+            let mut cpu_advanced = false;
+            if let Some(pid) = tracked_pid {
+                let current_cpu_secs = tracked_process_cpu_time_secs(pid);
+                if cpu_time_advanced(last_cpu_secs, current_cpu_secs) {
+                    last_log_activity = Instant::now();
+                    cpu_advanced = true;
+                }
+                last_cpu_secs = current_cpu_secs;
+            }
+
             let activity_age = last_log_activity.elapsed();
             let has_recent_activity = activity_age < silence
-                && (current_mtime.is_some() || last_hf_size.unwrap_or(0) > 0 || port_bound);
+                && (current_mtime.is_some()
+                    || last_hf_size.unwrap_or(0) > 0
+                    || port_bound
+                    || cpu_advanced);
 
             // Past grace period and nothing has moved in either signal
             // for the silence window → treat as stalled.
@@ -4443,10 +4560,10 @@ mod tests {
     use super::{
         aggregate_weekly_totals, apply_bootstrap_step, begin_bootstrap_transition,
         boot_validation_stalled, bootstrap_complete_state, bootstrap_failed_state,
-        classify_startup_error, hf_cache_grew, lifetime_token_milestones_crossed,
-        lifetime_usd_milestones_crossed, log_mtime_advanced, merge_daily_savings,
-        merge_hourly_savings, most_recent_monday, parse_headroom_stats_from_json,
-        parse_headroom_stats_history_from_json, tcp_port_accepts_connection,
+        classify_startup_error, cpu_time_advanced, hf_cache_grew,
+        lifetime_token_milestones_crossed, lifetime_usd_milestones_crossed, log_mtime_advanced,
+        merge_daily_savings, merge_hourly_savings, most_recent_monday, parse_headroom_stats_from_json,
+        parse_headroom_stats_history_from_json, parse_ps_cpu_time, tcp_port_accepts_connection,
         total_dir_size_bytes, AppState, ClaudeProjectScan,
         DailySavingsBucket, HeadroomDashboardStats, HeadroomSavingsHistoryPoint,
         PersistedSavingsState, SavingsObservation, SavingsTracker,
@@ -4559,6 +4676,47 @@ mod tests {
         // Shrunk (HF cache pruning during boot — rare, but the function
         // shouldn't lie and call this growth).
         assert!(!hf_cache_grew(Some(200), 100));
+    }
+
+    #[test]
+    fn parse_ps_cpu_time_handles_macos_formats() {
+        // MM:SS.ss (most common — processes under an hour of CPU)
+        assert_eq!(parse_ps_cpu_time("0:00.05"), Some(0));
+        assert_eq!(parse_ps_cpu_time("0:42.13"), Some(42));
+        assert_eq!(parse_ps_cpu_time("12:34.99"), Some(12 * 60 + 34));
+        // HH:MM:SS (longer-lived processes)
+        assert_eq!(parse_ps_cpu_time("1:23:45"), Some(3600 + 23 * 60 + 45));
+        // D-HH:MM:SS (multi-day uptime)
+        assert_eq!(
+            parse_ps_cpu_time("2-01:23:45"),
+            Some(2 * 86400 + 3600 + 23 * 60 + 45)
+        );
+        // Whitespace tolerated (ps emits a trailing newline)
+        assert_eq!(parse_ps_cpu_time("  0:42.13\n"), Some(42));
+        // Bad input returns None rather than panicking.
+        assert_eq!(parse_ps_cpu_time(""), None);
+        assert_eq!(parse_ps_cpu_time("   "), None);
+        assert_eq!(parse_ps_cpu_time("not-a-time"), None);
+        assert_eq!(parse_ps_cpu_time("1:2:3:4"), None);
+    }
+
+    #[test]
+    fn cpu_time_advanced_detects_growth_only() {
+        // Strictly grew → activity.
+        assert!(cpu_time_advanced(Some(3), Some(5)));
+        // First observation with non-zero CPU → activity (process was
+        // already burning cycles before we started polling).
+        assert!(cpu_time_advanced(None, Some(5)));
+        // First observation with zero CPU → not yet doing work.
+        assert!(!cpu_time_advanced(None, Some(0)));
+        // Unchanged (whole-second resolution; sub-second growth is
+        // dropped by the parser, so equal seconds means "no second
+        // elapsed of CPU time").
+        assert!(!cpu_time_advanced(Some(5), Some(5)));
+        // ps stopped reporting (process gone) — not activity.
+        assert!(!cpu_time_advanced(Some(5), None));
+        // Both None — process never tracked or never observed.
+        assert!(!cpu_time_advanced(None, None));
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.3.4",
+  "version": "0.3.5-rc.1",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.3.5-rc.1",
+  "version": "0.3.5-rc.2",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.3.5-rc.2",
+  "version": "0.3.5",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Promotes 0.3.5-rc.2 (staging tip `84cd637`, tag `v0.3.5-rc.2`) to stable.

## Notes
Bugfixes

## Merge instructions
**Use "Create a merge commit"** — squash/rebase will fail the rc-ancestor check in `release-macos.yml`.