### PR TITLE
Release 0.3.9

### DIFF
--- a/.github/release-notes/0.3.9.md
+++ b/.github/release-notes/0.3.9.md
@@ -1,0 +1,1 @@
+Bugfixes

--- a/docs/beta-smoke-test.md
+++ b/docs/beta-smoke-test.md
@@ -48,7 +48,7 @@ In Settings, toggle Pause then Resume. After Pause, `cat ~/.claude/settings.json
 ### 7. Real compression event (not just a heartbeat)
 Capture the compression counter, then trigger a large request (Claude: read a long file like `src-tauri/src/lib.rs` with no offset/limit so the prompt exceeds ~10k tokens), then re-check:
 ```bash
-rtk proxy curl -s http://127.0.0.1:6768/stats | jq '.summary.compression.requests_compressed, .summary.compression.total_tokens_removed'
+rtk proxy curl -s http://127.0.0.1:6767/stats | jq '.summary.compression.requests_compressed, .summary.compression.total_tokens_removed'
 ```
 Expect: `requests_compressed` increased by at least 1 between the two captures, and `total_tokens_removed` is strictly greater. A bumped mtime on `activity-facts.json` is not enough — interception without compression would still touch that file.
 
@@ -60,7 +60,32 @@ The desktop ships its own Python venv and `headroom` CLI; if either is broken, t
 ```
 Expect: a `headroom, version X.Y.Z` line and a path under `.../runtime/venv/lib/python3.12/site-packages/headroom/__init__.py`. No `ModuleNotFoundError`, no `pydantic-core` mismatch traceback (see `extract_required_pydantic_core_version` in `tool_manager.rs` for the exact failure mode).
 
-### 9. Auth / pricing state is intact
+### 9. Backend port fallback when 6768 is held
+The desktop's internal proxy port (default `6768`) can be claimed by other macOS processes — most often `rapportd` at login. The desktop should scan `6769..=6790` and pick a free one instead of failing.
+
+First, confirm the live port and verify the proxy answers there:
+```bash
+lsof -iTCP -sTCP:LISTEN -nP 2>/dev/null | awk '$1 ~ /(headroom|python)/ && $9 ~ /:(67[6-9][0-9]|6790)/ { print $9 }'
+curl -sS -o /dev/null -w '%{http_code}\n' "http://127.0.0.1:6767/livez"
+```
+Expect: at least one `127.0.0.1:67XX` line in the 6768-6790 range, and the curl returns `200`.
+
+Then, force a fallback. Quit Headroom, hold 6768 with `nc`, relaunch, and confirm the proxy comes up on a different port:
+```bash
+osascript -e 'quit app "Headroom"' 2>/dev/null; sleep 2
+nc -l 6768 &
+NC_PID=$!
+open -a Headroom
+sleep 30
+lsof -iTCP -sTCP:LISTEN -nP 2>/dev/null | awk '$1 ~ /(headroom|python)/ && $9 ~ /:(67[6-9][0-9]|6790)/ { print $9 }'
+curl -sS -o /dev/null -w '%{http_code}\n' "http://127.0.0.1:6767/livez"
+kill $NC_PID 2>/dev/null
+```
+Expect: a `127.0.0.1:67XX` line where `XX` is NOT `68` (the fallback worked), and the curl still returns `200`. After the test, quit + relaunch Headroom so the next session goes back to 6768.
+
+If the fallback is missing, check `~/Library/Application Support/Headroom/headroom/logs/` for a `[backend_port]` warning line that names the occupant and the chosen fallback port.
+
+### 10. Auth / pricing state is intact
 The session token lives in the macOS keychain under service `com.extraheadroom.headroom.account`, account `session-token`; the local pricing state lives next to `activity-facts.json`.
 ```bash
 security find-generic-password -s com.extraheadroom.headroom.account -a session-token >/dev/null 2>&1 && echo 'signed in' || echo 'not signed in'
@@ -73,7 +98,7 @@ Expect: if the build is supposed to be signed in, line 1 reports `signed in`; li
 When inspecting the running proxy by hand (e.g. checking `/stats`), wrap `curl` with `rtk proxy` to bypass RTK's output filtering — otherwise large JSON responses get summarized into a type-shape view that looks like a broken endpoint:
 
 ```bash
-rtk proxy curl -s http://127.0.0.1:6768/stats | jq .summary
+rtk proxy curl -s http://127.0.0.1:6767/stats | jq .summary
 ```
 
 ## When something fails

--- a/docs/beta-smoke-test.md
+++ b/docs/beta-smoke-test.md
@@ -70,18 +70,23 @@ curl -sS -o /dev/null -w '%{http_code}\n' "http://127.0.0.1:6767/livez"
 ```
 Expect: at least one `127.0.0.1:67XX` line in the 6768-6790 range, and the curl returns `200`.
 
-Then, force a fallback. Quit Headroom, hold 6768 with `nc`, relaunch, and confirm the proxy comes up on a different port:
+Then, force a fallback. Quit Headroom, hold 6768 with a Python blocker (`nc -l` exits after one connection, so the proxy's first probe frees the port before fallback can trigger), relaunch, and confirm the proxy comes up on a different port. The proxy on a fallback port boots cold (memory tools / model load), so poll `/livez` for up to 90s instead of a fixed sleep:
 ```bash
 osascript -e 'quit app "Headroom"' 2>/dev/null; sleep 2
-nc -l 6768 &
-NC_PID=$!
+python3 -c "import socket,time; s=socket.socket(); s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1); s.bind(('127.0.0.1',6768)); s.listen(16); time.sleep(180)" &
+BLOCK_PID=$!
+sleep 1
 open -a Headroom
-sleep 30
-lsof -iTCP -sTCP:LISTEN -nP 2>/dev/null | awk '$1 ~ /(headroom|python)/ && $9 ~ /:(67[6-9][0-9]|6790)/ { print $9 }'
-curl -sS -o /dev/null -w '%{http_code}\n' "http://127.0.0.1:6767/livez"
-kill $NC_PID 2>/dev/null
+for _ in $(seq 1 90); do
+  code=$(curl -sS -o /dev/null -w '%{http_code}' "http://127.0.0.1:6767/livez" 2>/dev/null)
+  [ "$code" = "200" ] && break
+  sleep 1
+done
+echo "livez=$code"
+lsof -iTCP -sTCP:LISTEN -nP 2>/dev/null | awk -v IGNORECASE=1 '$1 ~ /(headroom|python)/ && $9 ~ /:(67[6-9][0-9]|6790)/ { print $9 }'
+kill $BLOCK_PID 2>/dev/null
 ```
-Expect: a `127.0.0.1:67XX` line where `XX` is NOT `68` (the fallback worked), and the curl still returns `200`. After the test, quit + relaunch Headroom so the next session goes back to 6768.
+Expect: `livez=200`, a `127.0.0.1:67XX` line where `XX` is NOT `68` (the fallback worked). After the test, quit + relaunch Headroom so the next session goes back to 6768.
 
 If the fallback is missing, check `~/Library/Application Support/Headroom/headroom/logs/` for a `[backend_port]` warning line that names the occupant and the chosen fallback port.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.3.8",
+  "version": "0.3.9-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.3.8",
+      "version": "0.3.9-rc.1",
       "dependencies": {
         "@microsoft/clarity": "^1.0.2",
         "@phosphor-icons/react": "^2.1.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.3.9-rc.1",
+  "version": "0.3.9-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.3.9-rc.1",
+      "version": "0.3.9-rc.2",
       "dependencies": {
         "@microsoft/clarity": "^1.0.2",
         "@phosphor-icons/react": "^2.1.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.3.9-rc.2",
+  "version": "0.3.9-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.3.9-rc.2",
+      "version": "0.3.9-rc.3",
       "dependencies": {
         "@microsoft/clarity": "^1.0.2",
         "@phosphor-icons/react": "^2.1.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.3.9-rc.3",
+  "version": "0.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.3.9-rc.3",
+      "version": "0.3.9",
       "dependencies": {
         "@microsoft/clarity": "^1.0.2",
         "@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.3.8",
+  "version": "0.3.9-rc.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.3.9-rc.1",
+  "version": "0.3.9-rc.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.3.9-rc.2",
+  "version": "0.3.9-rc.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.3.9-rc.3",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.3.8"
+version = "0.3.9-rc.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.3.9-rc.1"
+version = "0.3.9-rc.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.3.9-rc.2"
+version = "0.3.9-rc.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.3.9-rc.3"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.3.9-rc.1"
+version = "0.3.9-rc.2"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.3.8"
+version = "0.3.9-rc.1"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.3.9-rc.2"
+version = "0.3.9-rc.3"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.3.9-rc.3"
+version = "0.3.9"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/src/backend_port.rs
+++ b/src-tauri/src/backend_port.rs
@@ -1,0 +1,148 @@
+//! Runtime-selected backend port for the Python proxy.
+//!
+//! `6767` (the intercept port) is fixed because clients are configured to point
+//! at it. `6768` (the internal port between intercept and Python proxy) is
+//! purely internal and can move when something else on the machine has already
+//! grabbed it — most commonly Apple's `rapportd`, which gets a kernel-assigned
+//! port at login and registers it via Bonjour. On affected machines the only
+//! reliable way to free 6768 is a reboot, which is not a fix we can ship.
+//!
+//! At proxy spawn time, [`select_available`] probes 6768 and falls back to
+//! 6769..=6790. The chosen port is stored in [`BACKEND_PORT`]; the intercept
+//! forwarder, spawn args, and health probes all read it through [`get`].
+//!
+//! Default value is [`DEFAULT_BACKEND_PORT`] so anything that reads the atomic
+//! before selection runs gets today's behavior.
+
+use std::sync::atomic::{AtomicU16, Ordering};
+
+pub const DEFAULT_BACKEND_PORT: u16 = 6768;
+pub const FALLBACK_RANGE_START: u16 = 6769;
+pub const FALLBACK_RANGE_END: u16 = 6790;
+
+static BACKEND_PORT: AtomicU16 = AtomicU16::new(DEFAULT_BACKEND_PORT);
+
+pub fn get() -> u16 {
+    BACKEND_PORT.load(Ordering::Acquire)
+}
+
+pub fn set(port: u16) {
+    BACKEND_PORT.store(port, Ordering::Release);
+}
+
+/// Test-only: reset the atomic to [`DEFAULT_BACKEND_PORT`] so test cases that
+/// mutate it don't leak state into other tests in the same binary.
+#[cfg(test)]
+pub fn reset_for_tests() {
+    BACKEND_PORT.store(DEFAULT_BACKEND_PORT, Ordering::Release);
+}
+
+/// Successful selection of a port from the fallback range when the default
+/// port is foreign-held.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelectedFallback {
+    pub port: u16,
+    pub original_occupant: String,
+    pub original_pid: Option<u32>,
+}
+
+/// All probed ports were foreign-held. Vanishingly rare in practice (rapportd
+/// only takes one port) but possible if the user has 23 unrelated daemons in
+/// the 6768-6790 range, so we surface a structured error instead of looping.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AllForeign {
+    pub original_occupant: String,
+    pub original_pid: Option<u32>,
+    pub fallback_range: (u16, u16),
+}
+
+/// Pick a port from `FALLBACK_RANGE_START..=FALLBACK_RANGE_END` for the
+/// Python proxy when the default port is foreign-held. `try_bind` is called
+/// for each candidate; the first that returns true wins. Caller should
+/// have already determined that the default port is unavailable AND that
+/// it isn't a stale headroom proxy of ours.
+pub fn select_fallback(
+    original_occupant: String,
+    original_pid: Option<u32>,
+    try_bind: impl Fn(u16) -> bool,
+) -> Result<SelectedFallback, AllForeign> {
+    for port in FALLBACK_RANGE_START..=FALLBACK_RANGE_END {
+        if try_bind(port) {
+            return Ok(SelectedFallback {
+                port,
+                original_occupant,
+                original_pid,
+            });
+        }
+    }
+    Err(AllForeign {
+        original_occupant,
+        original_pid,
+        fallback_range: (FALLBACK_RANGE_START, FALLBACK_RANGE_END),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_port_is_6768() {
+        reset_for_tests();
+        assert_eq!(get(), DEFAULT_BACKEND_PORT);
+    }
+
+    #[test]
+    fn set_then_get_round_trips() {
+        reset_for_tests();
+        set(6770);
+        assert_eq!(get(), 6770);
+        reset_for_tests();
+    }
+
+    #[test]
+    fn select_fallback_returns_first_bindable_port() {
+        // 6769, 6770 fail; 6771 succeeds.
+        let result = select_fallback(
+            "rapportd pid 594".to_string(),
+            Some(594),
+            |port: u16| port >= 6771,
+        )
+        .expect("ok");
+        assert_eq!(
+            result,
+            SelectedFallback {
+                port: 6771,
+                original_occupant: "rapportd pid 594".to_string(),
+                original_pid: Some(594),
+            }
+        );
+    }
+
+    #[test]
+    fn select_fallback_returns_range_start_when_all_bindable() {
+        let result = select_fallback("x pid 1".to_string(), Some(1), |_| true).expect("ok");
+        assert_eq!(result.port, FALLBACK_RANGE_START);
+    }
+
+    #[test]
+    fn select_fallback_returns_all_foreign_when_no_port_binds() {
+        let result = select_fallback("rapportd pid 594".to_string(), Some(594), |_| false)
+            .expect_err("should be all-foreign");
+        assert_eq!(result.original_occupant, "rapportd pid 594");
+        assert_eq!(result.original_pid, Some(594));
+        assert_eq!(
+            result.fallback_range,
+            (FALLBACK_RANGE_START, FALLBACK_RANGE_END)
+        );
+    }
+
+    #[test]
+    fn select_fallback_preserves_unknown_occupant_pid() {
+        let result = select_fallback("unknown process".to_string(), None, |port| port == 6770)
+            .expect("ok");
+        assert_eq!(result.port, 6770);
+        assert_eq!(result.original_pid, None);
+        assert_eq!(result.original_occupant, "unknown process");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod activity_facts;
 mod analytics;
+mod backend_port;
 mod bearer;
 mod claude_cli;
 mod client_adapters;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2634,6 +2634,25 @@ struct HeadroomLearnRunResult {
     output_tail: Vec<String>,
 }
 
+/// Detect `headroom.learn.analyzer` warnings that mean the LLM never produced
+/// recommendations even though the CLI exited 0. Returns a user-facing message
+/// joining all such warnings, or None if the run was clean.
+fn extract_llm_failure_warnings(stderr: &str) -> Option<String> {
+    const MARKER: &str = "LLM analysis failed:";
+    let messages: Vec<String> = stderr
+        .lines()
+        .filter_map(|line| {
+            line.split_once(MARKER)
+                .map(|(_, rest)| format!("{} {}", MARKER, rest.trim()))
+        })
+        .collect();
+    if messages.is_empty() {
+        None
+    } else {
+        Some(messages.join("\n"))
+    }
+}
+
 fn execute_headroom_learn_run(state: &AppState, project_path: &str) -> HeadroomLearnRunResult {
     let project_name = Path::new(project_path)
         .file_name()
@@ -2695,15 +2714,27 @@ fn execute_headroom_learn_run(state: &AppState, project_path: &str) -> HeadroomL
             };
             let output_tail = crate::state::tail_lines(&merged, 32);
             if output.status.success() {
-                (
-                    format!("headroom learn completed for {project_name}."),
-                    true,
-                    None,
-                    output_tail,
-                    stdout,
-                    stderr,
-                    output.status.to_string(),
-                )
+                if let Some(warnings) = extract_llm_failure_warnings(&stderr) {
+                    (
+                        format!("headroom learn could not produce recommendations for {project_name}."),
+                        false,
+                        Some(warnings),
+                        output_tail,
+                        stdout,
+                        stderr,
+                        output.status.to_string(),
+                    )
+                } else {
+                    (
+                        format!("headroom learn completed for {project_name}."),
+                        true,
+                        None,
+                        output_tail,
+                        stdout,
+                        stderr,
+                        output.status.to_string(),
+                    )
+                }
             } else {
                 let fail_tail = if output_tail.is_empty() {
                     "No output captured.".to_string()
@@ -3700,10 +3731,10 @@ mod tests {
         beta_channel_enabled_from, build_release_updater_config, build_watchdog_give_up_report,
         check_headroom_learn_prereqs, classify_bootstrap_failure, compute_tray_window_position,
         count_memories_created_today, debounced_tray_runtime_visual, delete_applied_pattern,
-        empty_live_learnings_for_projects, fetch_transformations_feed_from, install_pending_update,
-        is_port_conflict_failure, is_prerelease_version, lifetime_token_milestone_kind,
-        parse_live_learnings, parse_request_count_from_stats_body, parse_updater_endpoint_list,
-        pattern_matches_project,
+        empty_live_learnings_for_projects, extract_llm_failure_warnings,
+        fetch_transformations_feed_from, install_pending_update, is_port_conflict_failure,
+        is_prerelease_version, lifetime_token_milestone_kind, parse_live_learnings,
+        parse_request_count_from_stats_body, parse_updater_endpoint_list, pattern_matches_project,
         physical_rect_from_rect, read_applied_patterns_for_project, resolve_release_updater_config,
         select_updater_endpoints, store_checked_update, watchdog_should_be_up,
         AvailableAppUpdate, BootstrapFailureKind, HeadroomLearnPrereqStatus,
@@ -4925,5 +4956,31 @@ Some unrelated content.
         let report =
             build_watchdog_give_up_report(3, false, false, None, None, Some(String::new()));
         assert!(report.last_startup_error.is_none());
+    }
+
+    #[test]
+    fn extract_llm_failure_warnings_returns_none_for_clean_stderr() {
+        let stderr =
+            "2026-05-04 09:00:00,000 - headroom.learn.analyzer - INFO - using claude CLI backend\n";
+        assert!(extract_llm_failure_warnings(stderr).is_none());
+    }
+
+    #[test]
+    fn extract_llm_failure_warnings_extracts_single_timeout() {
+        let stderr = "2026-05-03 22:18:50,070 - headroom.learn.analyzer - WARNING - LLM analysis failed: `claude -p` did not respond within 120s. Check network connectivity or try a different backend with --model <litellm-model-name>.\n";
+        let extracted = extract_llm_failure_warnings(stderr).expect("warning extracted");
+        assert!(extracted.starts_with("LLM analysis failed:"));
+        assert!(extracted.contains("did not respond within 120s"));
+    }
+
+    #[test]
+    fn extract_llm_failure_warnings_joins_multiple_lines() {
+        let stderr = "\
+2026-05-03 22:18:50,070 - headroom.learn.analyzer - WARNING - LLM analysis failed: `claude -p` did not respond within 120s.
+2026-05-03 22:20:50,749 - headroom.learn.analyzer - WARNING - LLM analysis failed: `claude -p` did not respond within 120s.
+";
+        let extracted = extract_llm_failure_warnings(stderr).expect("warnings extracted");
+        assert_eq!(extracted.matches("LLM analysis failed:").count(), 2);
+        assert!(extracted.contains('\n'));
     }
 }

--- a/src-tauri/src/port_conflict.rs
+++ b/src-tauri/src/port_conflict.rs
@@ -277,15 +277,31 @@ mod tests {
         (python3.1 pid 1073); cannot start proxy. \
         Run `lsof -iTCP:6768 -sTCP:LISTEN` to identify it.";
 
+    /// New bail shape emitted by `tool_manager::start_headroom_background`
+    /// when even the fallback range (6769-6790) is exhausted. The marker
+    /// substring `"is occupied by a non-headroom process"` is preserved so
+    /// `is_port_conflict` and `parse_occupant` continue to match.
+    const SAMPLE_BAIL_ALL_FOREIGN: &str = "port 6768 is occupied by a non-headroom process \
+        (rapportd pid 594) and fallback ports 6769-6790 are also unavailable; cannot start proxy. \
+        Reboot to clear stuck listeners, then relaunch Headroom.";
+
     #[test]
     fn is_port_conflict_matches_bail_string() {
         assert!(is_port_conflict(SAMPLE_BAIL));
+        assert!(is_port_conflict(SAMPLE_BAIL_ALL_FOREIGN));
         assert!(!is_port_conflict(
             "headroom proxy already running on port 6768 (likely a stale process)"
         ));
         assert!(!is_port_conflict(
             "exited with status 1 before opening port 6768"
         ));
+    }
+
+    #[test]
+    fn parse_occupant_works_on_all_foreign_bail_shape() {
+        let (cmd, pid) = parse_occupant(SAMPLE_BAIL_ALL_FOREIGN);
+        assert_eq!(cmd.as_deref(), Some("rapportd"));
+        assert_eq!(pid, Some(594));
     }
 
     #[test]

--- a/src-tauri/src/proxy_intercept.rs
+++ b/src-tauri/src/proxy_intercept.rs
@@ -1,7 +1,13 @@
 /// Transparent HTTP proxy intercept layer.
 ///
 /// Binds on 127.0.0.1:6767 (the address clients point at) and forwards every
-/// request unchanged to 127.0.0.1:6768 (where headroom actually listens).
+/// request unchanged to 127.0.0.1:<backend_port>, where headroom actually
+/// listens. The backend port is normally 6768 but is selected at proxy spawn
+/// time and stored in `crate::backend_port`; it can shift to 6769..=6790 if
+/// 6768 is held by a foreign process. We re-read the port per connection so
+/// the intercept (which spawns before proxy startup runs the selection) picks
+/// up the chosen value as soon as it's set.
+///
 /// As each request passes through, any `Authorization: Bearer …` header is
 /// captured into `AppState::claude_bearer_token` so the usage-stats feature
 /// can call the Anthropic OAuth usage endpoint without touching the keychain.
@@ -15,10 +21,10 @@ use parking_lot::Mutex;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
+use crate::backend_port;
 use crate::bearer::BearerToken;
 
 pub const INTERCEPT_PORT: u16 = 6767;
-pub const HEADROOM_BACKEND_PORT: u16 = 6768;
 
 const HEADER_READ_TIMEOUT: Duration = Duration::from_secs(10);
 const MAX_HEADER_BYTES: usize = 64 * 1024;
@@ -51,8 +57,7 @@ pub fn spawn(token_slot: SharedToken, bypass: BypassFlag) {
                 .expect("proxy intercept runtime");
             rt.block_on(async move {
                 let bind_addr: SocketAddr = ([127, 0, 0, 1], INTERCEPT_PORT).into();
-                let backend_addr: SocketAddr = ([127, 0, 0, 1], HEADROOM_BACKEND_PORT).into();
-                match run(bind_addr, backend_addr, token_slot, bypass, upstream_base).await {
+                match run(bind_addr, token_slot, bypass, upstream_base).await {
                     Ok(()) => {}
                     Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
                         // Port is already bound. If /health responds over HTTP, an
@@ -92,7 +97,6 @@ pub fn spawn(token_slot: SharedToken, bypass: BypassFlag) {
 
 async fn run(
     bind_addr: SocketAddr,
-    backend_addr: SocketAddr,
     token_slot: SharedToken,
     bypass: BypassFlag,
     upstream_base: Arc<String>,
@@ -105,7 +109,7 @@ async fn run(
                 let slot = token_slot.clone();
                 let bypass = bypass.clone();
                 let upstream_base = upstream_base.clone();
-                tokio::spawn(handle(client, backend_addr, slot, bypass, upstream_base));
+                tokio::spawn(handle(client, slot, bypass, upstream_base));
             }
             Err(e) => {
                 // EMFILE/ENFILE/ECONNABORTED are transient — log and keep serving
@@ -119,11 +123,15 @@ async fn run(
 
 async fn handle(
     mut client: TcpStream,
-    backend_addr: SocketAddr,
     token_slot: SharedToken,
     bypass: BypassFlag,
     upstream_base: Arc<String>,
 ) {
+    // Re-read the backend port on each connection. `tool_manager` selects the
+    // port (and may switch to a fallback) when the proxy spawn runs, which
+    // happens after this thread is already accepting; reading per-connection
+    // means existing clients pick up the chosen port without restarting.
+    let backend_addr: SocketAddr = ([127, 0, 0, 1], backend_port::get()).into();
     // Read only through the end of the HTTP headers. We only need headers to
     // capture the bearer token, and forwarding early avoids deadlocks with
     // `Expect: 100-continue` request flows.
@@ -535,10 +543,12 @@ mod tests {
         is_hop_by_hop_response_header, parse_request_head, read_http_headers,
         request_is_loopback_safe, run, BypassFlag, SharedToken,
     };
+    use crate::backend_port;
     use std::net::SocketAddr;
     use std::sync::atomic::AtomicBool;
     use std::sync::Arc;
     use parking_lot::Mutex;
+    use serial_test::serial;
     use tokio::io::{duplex, AsyncReadExt, AsyncWriteExt};
     use tokio::net::{TcpListener, TcpStream};
     use tokio::time::{timeout, Duration};
@@ -638,6 +648,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial(backend_port)]
     async fn intercept_captures_bearer_and_forwards_headers_to_backend() {
         // Fake backend: accept one connection, read its header block, hold the
         // connection open long enough for the test to inspect what arrived.
@@ -653,6 +664,11 @@ mod tests {
             received
         });
 
+        // Point the intercept's per-connection backend lookup at our fake
+        // backend's ephemeral port. Serialized via #[serial(backend_port)] so
+        // tests that mutate the global don't race.
+        backend_port::set(backend_addr.port());
+
         // Run the intercept on its own ephemeral port.
         let token_slot: SharedToken = Arc::new(Mutex::new(None));
         let intercept_listener = TcpListener::bind("127.0.0.1:0").await.expect("intercept bind");
@@ -665,7 +681,6 @@ mod tests {
             // run() loops forever; the test cancels it via abort below.
             let _ = run(
                 intercept_addr,
-                backend_addr,
                 slot_for_run,
                 bypass_for_run,
                 upstream_base,
@@ -723,14 +738,17 @@ mod tests {
         );
 
         run_task.abort();
+        backend_port::reset_for_tests();
     }
 
     #[tokio::test]
+    #[serial(backend_port)]
     async fn intercept_returns_502_when_backend_is_unreachable() {
         // Pick a backend port that nothing is listening on. Bind+immediately
         // drop a listener to grab a free port, then connect attempts will fail.
         let (probe, dead_backend_addr) = bind_ephemeral().await;
         drop(probe);
+        backend_port::set(dead_backend_addr.port());
 
         let token_slot: SharedToken = Arc::new(Mutex::new(None));
         let intercept_listener = TcpListener::bind("127.0.0.1:0").await.expect("intercept bind");
@@ -742,7 +760,6 @@ mod tests {
         let run_task = tokio::spawn(async move {
             let _ = run(
                 intercept_addr,
-                dead_backend_addr,
                 slot_for_run,
                 bypass_for_run,
                 upstream_base,
@@ -791,6 +808,7 @@ mod tests {
         );
 
         run_task.abort();
+        backend_port::reset_for_tests();
     }
 
     #[test]
@@ -880,6 +898,7 @@ mod tests {
     /// forwards a request to a fake upstream, then streams the upstream's
     /// response back to the client as HTTP/1.1 chunked transfer.
     #[tokio::test]
+    #[serial(backend_port)]
     async fn bypass_forwards_request_to_upstream_and_streams_response_back() {
         let (upstream_listener, upstream_addr) = bind_ephemeral().await;
         let upstream_base = format!("http://127.0.0.1:{}", upstream_addr.port());
@@ -933,13 +952,14 @@ mod tests {
         let intercept_addr = intercept_listener.local_addr().expect("intercept addr");
         drop(intercept_listener);
         let bypass: BypassFlag = Arc::new(AtomicBool::new(true));
-        let backend_addr: SocketAddr = "127.0.0.1:1".parse().unwrap();
+        // Bypass means we never actually contact the backend; pin to an
+        // unused loopback port so any accidental connect would fail fast.
+        backend_port::set(1);
         let upstream_base_arc = Arc::new(upstream_base);
         let token_for_run = token_slot.clone();
         let run_task = tokio::spawn(async move {
             let _ = run(
                 intercept_addr,
-                backend_addr,
                 token_for_run,
                 bypass,
                 upstream_base_arc,
@@ -1055,9 +1075,11 @@ mod tests {
         );
 
         run_task.abort();
+        backend_port::reset_for_tests();
     }
 
     #[tokio::test]
+    #[serial(backend_port)]
     async fn bypass_returns_502_when_upstream_unreachable() {
         // Bind+drop to grab a free port nothing is listening on.
         let (probe, dead_addr) = bind_ephemeral().await;
@@ -1069,17 +1091,10 @@ mod tests {
         let intercept_addr = intercept_listener.local_addr().expect("intercept addr");
         drop(intercept_listener);
         let bypass: BypassFlag = Arc::new(AtomicBool::new(true));
-        let backend_addr: SocketAddr = "127.0.0.1:1".parse().unwrap();
+        backend_port::set(1);
         let upstream_base_arc = Arc::new(upstream_base);
         let run_task = tokio::spawn(async move {
-            let _ = run(
-                intercept_addr,
-                backend_addr,
-                token_slot,
-                bypass,
-                upstream_base_arc,
-            )
-            .await;
+            let _ = run(intercept_addr, token_slot, bypass, upstream_base_arc).await;
         });
 
         let mut client = None;
@@ -1122,5 +1137,91 @@ mod tests {
         );
 
         run_task.abort();
+        backend_port::reset_for_tests();
+    }
+
+    /// New: the intercept must read the backend port per connection so that
+    /// when `tool_manager` selects a fallback port mid-launch, in-flight
+    /// clients get routed to the new backend without a thread restart.
+    #[tokio::test]
+    #[serial(backend_port)]
+    async fn intercept_picks_up_backend_port_changes_between_connections() {
+        let (first_listener, first_addr) = bind_ephemeral().await;
+        let (second_listener, second_addr) = bind_ephemeral().await;
+
+        let first_task = tokio::spawn(async move {
+            let (mut sock, _) = first_listener.accept().await.expect("first accept");
+            let _ = read_until_header_end(&mut sock).await;
+            let _ = sock
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+                .await;
+            "first"
+        });
+        let second_task = tokio::spawn(async move {
+            let (mut sock, _) = second_listener.accept().await.expect("second accept");
+            let _ = read_until_header_end(&mut sock).await;
+            let _ = sock
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+                .await;
+            "second"
+        });
+
+        backend_port::set(first_addr.port());
+
+        let token_slot: SharedToken = Arc::new(Mutex::new(None));
+        let intercept_listener = TcpListener::bind("127.0.0.1:0").await.expect("intercept bind");
+        let intercept_addr = intercept_listener.local_addr().expect("intercept addr");
+        drop(intercept_listener);
+        let bypass_for_run: BypassFlag = Arc::new(AtomicBool::new(false));
+        let upstream_base = Arc::new("https://api.anthropic.com".to_string());
+        let token_for_run = token_slot.clone();
+        let run_task = tokio::spawn(async move {
+            let _ = run(intercept_addr, token_for_run, bypass_for_run, upstream_base).await;
+        });
+
+        // Wait for the intercept to bind, then send the first request.
+        let mut first_client = None;
+        for _ in 0..50 {
+            if let Ok(c) = TcpStream::connect(intercept_addr).await {
+                first_client = Some(c);
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        let mut first_client = first_client.expect("intercept reachable");
+        let req = format!(
+            "POST / HTTP/1.1\r\nHost: 127.0.0.1:{}\r\nContent-Length: 0\r\n\r\n",
+            intercept_addr.port()
+        );
+        first_client
+            .write_all(req.as_bytes())
+            .await
+            .expect("write first req");
+
+        let routed_first = timeout(Duration::from_secs(2), first_task)
+            .await
+            .expect("first backend received request")
+            .expect("first task ok");
+        assert_eq!(routed_first, "first");
+
+        // Switch the global to the second backend; next connection routes there.
+        backend_port::set(second_addr.port());
+
+        let mut second_client = TcpStream::connect(intercept_addr)
+            .await
+            .expect("connect second");
+        second_client
+            .write_all(req.as_bytes())
+            .await
+            .expect("write second req");
+
+        let routed_second = timeout(Duration::from_secs(2), second_task)
+            .await
+            .expect("second backend received request")
+            .expect("second task ok");
+        assert_eq!(routed_second, "second");
+
+        run_task.abort();
+        backend_port::reset_for_tests();
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -90,20 +90,21 @@ pub fn runtime_upgrade_disabled_by_env() -> bool {
     )
 }
 
-/// One-shot probe of the new proxy. Hits `/livez` on port 6768 directly
-/// first (bypasses the intercept layer on 6767). Falls back to `/health`
-/// for older headroom-ai versions that don't expose `/livez`, then through
-/// the intercept layer on 6767 as a last resort — which also succeeds if
-/// the proxy is alive but too CPU-saturated to answer a direct probe
+/// One-shot probe of the new proxy. Hits `/livez` on the backend port
+/// directly first (bypasses the intercept layer on 6767). Falls back to
+/// `/health` for older headroom-ai versions that don't expose `/livez`, then
+/// through the intercept layer on 6767 as a last resort — which also succeeds
+/// if the proxy is alive but too CPU-saturated to answer a direct probe
 /// quickly, since the intercept has its own retry + longer timeout path.
 fn probe_proxy_livez(client: &reqwest::blocking::Client) -> bool {
+    let backend = crate::backend_port::get();
     let urls = [
-        "http://127.0.0.1:6768/livez",
-        "http://127.0.0.1:6768/health",
-        "http://127.0.0.1:6767/livez",
-        "http://127.0.0.1:6767/health",
+        format!("http://127.0.0.1:{backend}/livez"),
+        format!("http://127.0.0.1:{backend}/health"),
+        "http://127.0.0.1:6767/livez".to_string(),
+        "http://127.0.0.1:6767/health".to_string(),
     ];
-    for url in urls {
+    for url in &urls {
         if client
             .get(url)
             .send()
@@ -216,10 +217,11 @@ fn tcp_port_accepts_connection(addr: std::net::SocketAddr, timeout: std::time::D
     std::net::TcpStream::connect_timeout(&addr, timeout).is_ok()
 }
 
-/// Probe the proxy's loopback port (6768) with a 1s timeout. See
-/// [`tcp_port_accepts_connection`] for semantics.
+/// Probe the proxy's loopback port with a 1s timeout. See
+/// [`tcp_port_accepts_connection`] for semantics. The backend port is
+/// normally 6768 but may have been switched to a fallback by `backend_port`.
 fn proxy_port_accepts_connection() -> bool {
-    let addr: std::net::SocketAddr = ([127, 0, 0, 1], 6768).into();
+    let addr: std::net::SocketAddr = ([127, 0, 0, 1], crate::backend_port::get()).into();
     tcp_port_accepts_connection(addr, std::time::Duration::from_secs(1))
 }
 
@@ -1295,15 +1297,16 @@ impl AppState {
         }
     }
 
-    /// Adaptive boot validation loop. Probes `/livez` on port 6768 until the
-    /// proxy responds, the proxy process exits, the log goes silent past the
+    /// Adaptive boot validation loop. Probes `/livez` on the backend port
+    /// (default 6768; may be a fallback in 6769..=6790) until the proxy
+    /// responds, the proxy process exits, the log goes silent past the
     /// stall threshold, or `RUNTIME_UPGRADE_BOOT_MAX_SECS` elapses. On each
     /// pass through the loop, emits a progress update via `on_progress`.
     ///
     /// "Activity" is the union of four signals: (1) a write to any
     /// ``headroom-proxy*.log`` file, (2) growth in the HuggingFace hub
-    /// cache, (3) a successful TCP connect to ``127.0.0.1:6768``, and
-    /// (4) advancement of the tracked child's accumulated CPU time.
+    /// cache, (3) a successful TCP connect to the backend loopback port,
+    /// and (4) advancement of the tracked child's accumulated CPU time.
     /// Any one resets the silence timer. The HF signal is what keeps
     /// slow-but-progressing first-run downloads from being killed —
     /// when transformers/huggingface_hub is silently pulling multi-GB
@@ -2286,8 +2289,8 @@ impl AppState {
         }
 
         // Serialize lifecycle transitions so launch warm-up, tray open, and the
-        // watchdog cannot race into concurrent proxy spawns before port 6768 is
-        // reachable and `headroom_process` has been recorded.
+        // watchdog cannot race into concurrent proxy spawns before the backend
+        // port is reachable and `headroom_process` has been recorded.
         let _lifecycle_guard = self.lifecycle_lock.lock();
 
         // Another caller may have brought the runtime up while we waited.
@@ -2495,14 +2498,18 @@ impl AppState {
 
         // Also clean up detached/orphaned Headroom-managed headroom proxies
         // so quitting the UI cannot leave the background listener behind.
+        // We deliberately drop the port number from the match pattern: the
+        // proxy may have fallen back to 6769..=6790 if 6768 was foreign-held,
+        // and the python module path / entrypoint subcommand is unique enough
+        // to identify our proxies regardless of port.
         let managed_python = self.tool_manager.managed_python();
         let command_patterns = [
             format!(
-                "{} -m headroom.proxy.server --port 6768 --no-http2",
+                "{} -m headroom.proxy.server",
                 managed_python.display()
             ),
             format!(
-                "{} proxy --port 6768",
+                "{} proxy --port",
                 self.tool_manager.headroom_entrypoint().display()
             ),
         ];
@@ -4603,10 +4610,14 @@ pub(crate) fn headroom_proxy_reachable() -> bool {
 /// case the UI falls back to a generic "open logs" prompt.
 pub(crate) fn classify_startup_error(raw: &str) -> Option<String> {
     if raw.contains("is occupied by a non-headroom process") {
+        // Only reaches here when even the fallback port range was unavailable
+        // (`tool_manager` scans 6768..=6790 before bailing). At that point the
+        // user has 23 unrelated daemons in that range — a reboot is the only
+        // realistic remediation, since common offenders like rapportd reset
+        // their port at login.
         return Some(
-            "Port 6768 is in use by another app on your machine. \
-             Run `lsof -iTCP:6768 -sTCP:LISTEN` in a terminal to find it, \
-             quit that process, then click Retry."
+            "A port Headroom needs is held by another app on your machine. \
+             Reboot to clear stuck listeners, then relaunch Headroom."
                 .into(),
         );
     }
@@ -5122,7 +5133,53 @@ mod tests {
         let raw =
             "port 6768 is occupied by a non-headroom process (pid 1234 node); cannot start proxy.";
         let hint = classify_startup_error(raw).expect("foreign port should classify");
-        assert!(hint.contains("lsof -iTCP:6768"), "got: {hint}");
+        assert!(hint.contains("Reboot"), "got: {hint}");
+    }
+
+    #[test]
+    fn classify_startup_error_foreign_port_with_fallback_exhausted() {
+        let raw =
+            "port 6768 is occupied by a non-headroom process (rapportd pid 594) and fallback ports 6769-6790 are also unavailable; cannot start proxy. Reboot to clear stuck listeners, then relaunch Headroom.";
+        let hint = classify_startup_error(raw).expect("all-foreign should classify");
+        assert!(hint.contains("Reboot"), "got: {hint}");
+    }
+
+    /// Defensive: classify_startup_error must NOT regress on any of the
+    /// bail strings that tool_manager actually produces. If the message
+    /// shape drifts (e.g. someone tweaks the bail wording), this test
+    /// fails and forces the classifier to be updated alongside.
+    #[test]
+    fn classify_startup_error_handles_every_tool_manager_bail_format() {
+        // 1. all-foreign exhaustion
+        let raw = "port 6768 is occupied by a non-headroom process (rapportd pid 594) and fallback ports 6769-6790 are also unavailable; cannot start proxy. \
+                   Reboot to clear stuck listeners, then relaunch Headroom.";
+        assert!(
+            classify_startup_error(raw).is_some(),
+            "all-foreign bail must classify"
+        );
+
+        // 2. stale headroom proxy
+        let raw = "headroom proxy already running on port 6768 (likely a stale process from a prior session). \
+                   Run `lsof -iTCP:6768 -sTCP:LISTEN` to find and kill it, then retry.";
+        assert!(
+            classify_startup_error(raw).is_some(),
+            "stale proxy bail must classify"
+        );
+
+        // 3. spawn timeout (port never opened) — phrased generically over
+        //    whatever port the proxy ended up on, so test with a fallback port.
+        let raw = "never opened port 6770 within 60000ms";
+        assert!(
+            classify_startup_error(raw).is_some(),
+            "spawn timeout must classify on any port"
+        );
+
+        // 4. python crash
+        let raw = "exited with status 1 before opening port 6770";
+        assert!(
+            classify_startup_error(raw).is_some(),
+            "python crash must classify on any port"
+        );
     }
 
     #[test]

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -443,17 +443,7 @@ impl ToolManager {
                 bail!("headroom managed python not found at {}", python.display());
             }
 
-            // Use the console_scripts entrypoint when available to avoid the Python
-            // -m double-import RuntimeWarning. Fall back to -m if missing.
             let entrypoint = self.headroom_entrypoint();
-            let startup_variants: Vec<(PathBuf, Vec<String>)> = if entrypoint.exists() {
-                vec![
-                    (entrypoint, headroom_entrypoint_startup_args()),
-                    (python.clone(), headroom_python_startup_args()),
-                ]
-            } else {
-                vec![(python.clone(), headroom_python_startup_args())]
-            };
 
             let mut failures: Vec<HeadroomStartupFailure> = Vec::new();
             let logs_dir = self.runtime.logs_dir();
@@ -546,6 +536,21 @@ impl ToolManager {
                     }
                 }
             }
+
+            // Construct spawn variants AFTER pre-flight so `--port` reflects any
+            // fallback chosen above. The arg helpers read `backend_port::get()`
+            // eagerly; building them earlier bakes in the stale default and the
+            // proxy ends up trying to bind the foreign-held port.
+            // Use the console_scripts entrypoint when available to avoid the Python
+            // -m double-import RuntimeWarning. Fall back to -m if missing.
+            let startup_variants: Vec<(PathBuf, Vec<String>)> = if entrypoint.exists() {
+                vec![
+                    (entrypoint, headroom_entrypoint_startup_args()),
+                    (python.clone(), headroom_python_startup_args()),
+                ]
+            } else {
+                vec![(python.clone(), headroom_python_startup_args())]
+            };
 
             for (executable, args) in &startup_variants {
                 let variant = if args.is_empty() {
@@ -4780,6 +4785,36 @@ mod tests {
         assert!(!python_args.contains(&"--no-memory-tools".to_string()));
         assert!(!python_args.contains(&"--no-memory-context".to_string()));
         assert!(!python_args.contains(&"--memory-db-path".to_string()));
+
+        backend_port::reset_for_tests();
+    }
+
+    /// Regression: `start_headroom_background` previously built `startup_variants`
+    /// before pre-flight ran, so when fallback called `backend_port::set(6769)`
+    /// the variants still spawned with `--port 6768` and both failed with
+    /// EADDRINUSE. The arg helpers read the atomic at call time, so as long as
+    /// the helpers are invoked AFTER fallback has updated the atomic, the
+    /// chosen fallback port flows through.
+    #[test]
+    fn startup_args_reflect_fallback_port_set_after_default() {
+        backend_port::reset_for_tests();
+        backend_port::set(6770);
+
+        let entrypoint_args = headroom_entrypoint_startup_args();
+        let port_idx = entrypoint_args
+            .iter()
+            .position(|a| a == "--port")
+            .expect("entrypoint args contain --port");
+        assert_eq!(entrypoint_args[port_idx + 1], "6770");
+
+        let python_args = headroom_python_startup_args();
+        let port_idx = python_args
+            .iter()
+            .position(|a| a == "--port")
+            .expect("python args contain --port");
+        assert_eq!(python_args[port_idx + 1], "6770");
+
+        backend_port::reset_for_tests();
     }
 
     #[test]

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -18,6 +18,7 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use tar::Archive;
 
+use crate::backend_port::{self, AllForeign, SelectedFallback};
 use crate::models::{ManagedTool, RtkTodayStats, ToolStatus};
 
 /// Pinned headroom-ai version. Upgrade logic is disabled; this exact version
@@ -31,8 +32,13 @@ const HEADROOM_SMOKE_TEST_TIMEOUT: Duration = Duration::from_secs(15);
 /// GitHub's expanded_assets endpoint serves HTML anchors pip can consume via --find-links.
 const VENDOR_WHEELS_INDEX_URL: &str =
     "https://github.com/gglucass/headroom-desktop/releases/expanded_assets/vendor-wheels-v1";
-// headroom binds on 6768; the intercept layer on 6767 forwards to it.
-const HEADROOM_PROXY_PORT: &str = "6768";
+// headroom binds on the backend port chosen at spawn time (default 6768);
+// the intercept layer on 6767 forwards to it. The backend port is dynamic
+// because something else on the machine (e.g. rapportd) can claim 6768 at
+// login — see `backend_port` for the selection logic.
+fn headroom_proxy_port() -> String {
+    backend_port::get().to_string()
+}
 const HEADROOM_PROXY_URL: &str = "http://127.0.0.1:6767";
 const MCP_METHOD_CLAUDE_CLI: &str = "claude_cli";
 const MCP_METHOD_FALLBACK_JSON: &str = "fallback_json";
@@ -454,28 +460,90 @@ impl ToolManager {
             std::fs::create_dir_all(&logs_dir)
                 .with_context(|| format!("creating {}", logs_dir.display()))?;
 
-            // Pre-flight: if port 6768 is already bound, the subprocess will
-            // immediately exit with status 1 when it fails to bind. Distinguish
-            // "ours" (a prior headroom proxy still running, which we can reuse) from
-            // "foreign" (something else is holding the port).
-            match diagnose_proxy_port() {
-                PortState::Free => {}
+            // Pre-flight: 6768 may already be held. Three cases:
+            //   * Free → spawn on 6768.
+            //   * HeadroomRunning → bail (a previous headroom proxy is alive;
+            //     we want a fresh one).
+            //   * ForeignOccupant → try to fall back to a port in
+            //     6769..=6790. Only bail if every fallback is also taken.
+            // The chosen port is stored in `backend_port` so the intercept,
+            // health probes, and spawn args all pick it up.
+            let initial_state = diagnose_proxy_port(backend_port::DEFAULT_BACKEND_PORT);
+            match initial_state {
+                PortState::Free => {
+                    backend_port::set(backend_port::DEFAULT_BACKEND_PORT);
+                }
                 PortState::HeadroomRunning => {
                     bail!(
-                    "headroom proxy already running on port {} (likely a stale process from a prior session). \
-                     Run `lsof -iTCP:{} -sTCP:LISTEN` to find and kill it, then retry.",
-                    HEADROOM_PROXY_PORT,
-                    HEADROOM_PROXY_PORT
-                );
+                        "{}",
+                        format_already_running_bail(backend_port::DEFAULT_BACKEND_PORT)
+                    );
                 }
                 PortState::ForeignOccupant(detail) => {
-                    bail!(
-                        "port {} is occupied by a non-headroom process ({}); cannot start proxy. \
-                     Run `lsof -iTCP:{} -sTCP:LISTEN` to identify it.",
-                        HEADROOM_PROXY_PORT,
-                        detail,
-                        HEADROOM_PROXY_PORT
-                    );
+                    let pid = parse_pid_from_lsof_detail(&detail);
+                    let try_bind = |port: u16| {
+                        TcpListener::bind(("127.0.0.1", port)).is_ok()
+                    };
+                    match backend_port::select_fallback(detail.clone(), pid, try_bind) {
+                        Ok(SelectedFallback {
+                            port,
+                            original_occupant,
+                            original_pid,
+                        }) => {
+                            backend_port::set(port);
+                            log::warn!(
+                                "[backend_port] {} held by {}; falling back to {}",
+                                backend_port::DEFAULT_BACKEND_PORT,
+                                original_occupant,
+                                port,
+                            );
+                            sentry::with_scope(
+                                |scope| {
+                                    scope.set_tag("flow", "backend_port_fallback");
+                                    scope.set_tag(
+                                        "occupant_cmd",
+                                        original_occupant
+                                            .split(" pid ")
+                                            .next()
+                                            .unwrap_or("unknown"),
+                                    );
+                                    scope.set_extra(
+                                        "original_port",
+                                        backend_port::DEFAULT_BACKEND_PORT.into(),
+                                    );
+                                    scope.set_extra("chosen_port", port.into());
+                                    if let Some(p) = original_pid {
+                                        scope.set_extra("occupant_pid", p.into());
+                                    }
+                                },
+                                || {
+                                    sentry::capture_message(
+                                        &format!(
+                                            "backend_port_fallback: {} held by {}, using {}",
+                                            backend_port::DEFAULT_BACKEND_PORT,
+                                            original_occupant,
+                                            port,
+                                        ),
+                                        sentry::Level::Info,
+                                    );
+                                },
+                            );
+                        }
+                        Err(AllForeign {
+                            original_occupant,
+                            fallback_range,
+                            ..
+                        }) => {
+                            bail!(
+                                "{}",
+                                format_all_foreign_bail(
+                                    backend_port::DEFAULT_BACKEND_PORT,
+                                    &original_occupant,
+                                    fallback_range,
+                                )
+                            );
+                        }
+                    }
                 }
             }
 
@@ -540,7 +608,7 @@ impl ToolManager {
                         Ok(Some(status)) => {
                             reason = Some(format!(
                                 "exited with status {} before opening port {}",
-                                status, HEADROOM_PROXY_PORT
+                                status, headroom_proxy_port()
                             ));
                             break;
                         }
@@ -573,7 +641,8 @@ impl ToolManager {
                 let reason = reason.unwrap_or_else(|| {
                     format!(
                         "never opened port {} within {}ms",
-                        HEADROOM_PROXY_PORT, HEADROOM_STARTUP_TIMEOUT_MS
+                        headroom_proxy_port(),
+                        HEADROOM_STARTUP_TIMEOUT_MS
                     )
                 });
                 failures.push(HeadroomStartupFailure {
@@ -2849,13 +2918,9 @@ fn write_headroom_to_claude_json(entrypoint: &Path, proxy_url: &str) -> Result<(
 }
 
 fn is_local_proxy_reachable() -> bool {
-    // Check headroom's actual backend port (6768), not the intercept port (6767),
+    // Check headroom's actual backend port, not the intercept port (6767),
     // because the intercept starts before headroom and would always be reachable.
-    let address: SocketAddr = match "127.0.0.1:6768".parse() {
-        Ok(address) => address,
-        Err(_) => return false,
-    };
-
+    let address: SocketAddr = ([127, 0, 0, 1], backend_port::get()).into();
     TcpStream::connect_timeout(&address, Duration::from_millis(180)).is_ok()
 }
 
@@ -2865,29 +2930,26 @@ enum PortState {
     ForeignOccupant(String),
 }
 
-fn diagnose_proxy_port() -> PortState {
+fn diagnose_proxy_port(port: u16) -> PortState {
     // If we can bind the port, nothing is there.
-    if TcpListener::bind(("127.0.0.1", 6768)).is_ok() {
+    if TcpListener::bind(("127.0.0.1", port)).is_ok() {
         return PortState::Free;
     }
 
     // Port is held. Probe it: headroom's proxy speaks HTTP and, for an
     // unrecognized path, responds with an HTTP status line. A foreign
     // non-HTTP service (SSH, Redis, etc.) will not.
-    let headroom_like = probe_headroom_http(Duration::from_millis(400));
+    let headroom_like = probe_headroom_http(port, Duration::from_millis(400));
     if headroom_like {
         PortState::HeadroomRunning
     } else {
-        PortState::ForeignOccupant(lsof_listener(6768).unwrap_or_else(|| "unknown process".into()))
+        PortState::ForeignOccupant(lsof_listener(port).unwrap_or_else(|| "unknown process".into()))
     }
 }
 
-fn probe_headroom_http(timeout: Duration) -> bool {
+fn probe_headroom_http(port: u16, timeout: Duration) -> bool {
     use std::io::{Read, Write};
-    let addr: SocketAddr = match "127.0.0.1:6768".parse() {
-        Ok(a) => a,
-        Err(_) => return false,
-    };
+    let addr: SocketAddr = ([127, 0, 0, 1], port).into();
     let Ok(mut stream) = TcpStream::connect_timeout(&addr, timeout) else {
         return false;
     };
@@ -2920,6 +2982,38 @@ fn lsof_listener(port: u16) -> Option<String> {
     let cmd = fields.next()?;
     let pid = fields.next()?;
     Some(format!("{cmd} pid {pid}"))
+}
+
+/// Extract the numeric pid from a `"cmd pid 1234"` string returned by
+/// [`lsof_listener`]. Returns None for the `"unknown process"` placeholder
+/// or any unparseable shape. Companion to `port_conflict::parse_occupant`,
+/// which works on the full bail string instead of the lsof detail.
+fn parse_pid_from_lsof_detail(detail: &str) -> Option<u32> {
+    let idx = detail.rfind(" pid ")?;
+    detail[idx + " pid ".len()..].trim().parse().ok()
+}
+
+/// Bail message when a previous (still-alive) headroom proxy holds the port.
+/// Extracted as a function so the exact format is testable against
+/// `port_conflict::is_port_conflict` and `state::classify_startup_error`.
+fn format_already_running_bail(port: u16) -> String {
+    format!(
+        "headroom proxy already running on port {port} (likely a stale process from a prior session). \
+         Run `lsof -iTCP:{port} -sTCP:LISTEN` to find and kill it, then retry."
+    )
+}
+
+/// Bail message when 6768 is foreign-held AND every port in the fallback
+/// range is also taken. Must contain `"is occupied by a non-headroom process"`
+/// so `port_conflict::is_port_conflict` continues to match, and the
+/// `(occupant)` parenthetical so `port_conflict::parse_occupant` can extract
+/// the cmd/pid for the persistent-conflict marker.
+fn format_all_foreign_bail(default_port: u16, occupant: &str, range: (u16, u16)) -> String {
+    let (start, end) = range;
+    format!(
+        "port {default_port} is occupied by a non-headroom process ({occupant}) and fallback ports {start}-{end} are also unavailable; cannot start proxy. \
+         Reboot to clear stuck listeners, then relaunch Headroom."
+    )
 }
 
 pub(crate) fn tail_log_file(path: &Path, max_lines: usize) -> String {
@@ -3019,7 +3113,7 @@ fn headroom_python_startup_args() -> Vec<String> {
         "-m".to_string(),
         "headroom.proxy.server".to_string(),
         "--port".to_string(),
-        HEADROOM_PROXY_PORT.to_string(),
+        headroom_proxy_port(),
         "--no-http2".to_string(),
         "--log-messages".to_string(),
     ]
@@ -3033,7 +3127,7 @@ fn headroom_entrypoint_startup_args() -> Vec<String> {
     let mut args = vec![
         "proxy".to_string(),
         "--port".to_string(),
-        HEADROOM_PROXY_PORT.to_string(),
+        headroom_proxy_port(),
         "--log-messages".to_string(),
     ];
     args.extend(headroom_learn_startup_args());
@@ -3057,7 +3151,7 @@ fn expected_proxy_arg_signature() -> Vec<&'static str> {
 /// Returns the full command line of whatever process is currently listening on
 /// the proxy port, or `None` if we couldn't determine it.
 pub fn running_proxy_argv() -> Option<String> {
-    let pid = lsof_listener_pid(HEADROOM_PROXY_PORT.parse().ok()?)?;
+    let pid = lsof_listener_pid(backend_port::get())?;
     ps_command(pid)
 }
 
@@ -4140,15 +4234,18 @@ mod tests {
 
     use super::{
         bootstrap_requirements_lock_for_target, extract_required_pydantic_core_version,
+        format_all_foreign_bail, format_already_running_bail,
         headroom_entrypoint_startup_args, headroom_python_startup_args,
-        looks_like_corrupt_venv_error, parse_major_minor_patch,
+        looks_like_corrupt_venv_error, parse_major_minor_patch, parse_pid_from_lsof_detail,
         proxy_argv_contains_expected_flags, read_headroom_learn_metadata_from_path,
         receipt_requires_atomic_rebuild, redact_sensitive, requirements_lock_sha,
         rtk_distribution_artifact, run_command, sanitize_log_variant, sha256_bytes,
         verify_sha256_file, CommandFailure, HeadroomRelease, ManagedRuntime,
         PipOutputCapture, ToolManager, UpgradeOutcome, ATOMIC_REBUILD_FLOOR_VERSION,
-        HEADROOM_PROXY_PORT, RTK_VERSION,
+        RTK_VERSION,
     };
+    use crate::backend_port;
+    use crate::port_conflict;
 
     #[test]
     fn redact_sensitive_strips_anthropic_keys() {
@@ -4564,6 +4661,69 @@ mod tests {
     }
 
     #[test]
+    fn parse_pid_from_lsof_detail_extracts_numeric_pid() {
+        assert_eq!(parse_pid_from_lsof_detail("rapportd pid 594"), Some(594));
+        assert_eq!(parse_pid_from_lsof_detail("python3.12 pid 1073"), Some(1073));
+        assert_eq!(
+            parse_pid_from_lsof_detail("Google Chrome Helper pid 4242"),
+            Some(4242)
+        );
+    }
+
+    #[test]
+    fn parse_pid_from_lsof_detail_returns_none_for_unknown_or_malformed() {
+        assert_eq!(parse_pid_from_lsof_detail("unknown process"), None);
+        assert_eq!(parse_pid_from_lsof_detail(""), None);
+        assert_eq!(parse_pid_from_lsof_detail("rapportd pid not-a-number"), None);
+        // Missing the " pid " separator entirely.
+        assert_eq!(parse_pid_from_lsof_detail("rapportd 594"), None);
+    }
+
+    /// Round-trip: the bail string produced by `format_all_foreign_bail` must
+    /// be matched by `port_conflict::is_port_conflict` (so the persistent-
+    /// conflict marker keeps tracking it) AND the occupant must be parseable
+    /// by `port_conflict::parse_occupant` (so analytics/Sentry get the
+    /// process name and pid).
+    #[test]
+    fn all_foreign_bail_round_trips_through_port_conflict_helpers() {
+        let bail = format_all_foreign_bail(6768, "rapportd pid 594", (6769, 6790));
+        assert!(
+            port_conflict::is_port_conflict(&bail),
+            "bail must match is_port_conflict so the marker keeps tracking; got: {bail}"
+        );
+        let (cmd, pid) = port_conflict::parse_occupant(&bail);
+        assert_eq!(cmd.as_deref(), Some("rapportd"), "bail: {bail}");
+        assert_eq!(pid, Some(594), "bail: {bail}");
+    }
+
+    /// Mirror round-trip for the unknown-occupant path (lsof returned nothing
+    /// useful). `parse_occupant` should return None/None instead of inventing
+    /// a fake cmd from "unknown process".
+    #[test]
+    fn all_foreign_bail_with_unknown_occupant_round_trips() {
+        let bail = format_all_foreign_bail(6768, "unknown process", (6769, 6790));
+        assert!(port_conflict::is_port_conflict(&bail));
+        let (cmd, pid) = port_conflict::parse_occupant(&bail);
+        assert!(cmd.is_none(), "got cmd: {cmd:?} from bail: {bail}");
+        assert!(pid.is_none(), "got pid: {pid:?} from bail: {bail}");
+    }
+
+    /// The "stale headroom proxy holding the port" bail must NOT trigger
+    /// the foreign-process port-conflict path — those are separate
+    /// fingerprints in Sentry. Verifies the boundary stays intact.
+    #[test]
+    fn already_running_bail_is_not_classified_as_foreign_conflict() {
+        let bail = format_already_running_bail(6768);
+        assert!(
+            !port_conflict::is_port_conflict(&bail),
+            "stale-proxy bail must not match foreign-port classifier; got: {bail}"
+        );
+        // But the lib.rs port-conflict-failure classifier (which fingerprints
+        // both shapes the same way) still catches it via its second condition.
+        assert!(crate::is_port_conflict_failure(&bail));
+    }
+
+    #[test]
     fn extract_required_pydantic_core_version_pulls_pin_from_systemerror() {
         let log = "Traceback (most recent call last):\n  File \"<frozen runpy>\", line 189, in _run_module_as_main\n  ...\nSystemError: The installed pydantic-core version (2.46.3) is incompatible with the current pydantic version, which requires 2.41.5. If you encounter this error, make sure that you haven't upgraded pydantic-core manually.\n";
         assert_eq!(
@@ -4588,11 +4748,13 @@ mod tests {
 
     #[test]
     fn managed_headroom_startup_uses_supported_proxy_args() {
+        backend_port::reset_for_tests();
+        let default_port = backend_port::DEFAULT_BACKEND_PORT.to_string();
         let entrypoint_args = headroom_entrypoint_startup_args();
         assert!(entrypoint_args.starts_with(&[
             "proxy".to_string(),
             "--port".to_string(),
-            HEADROOM_PROXY_PORT.to_string(),
+            default_port.clone(),
             "--log-messages".to_string(),
         ]));
         assert!(entrypoint_args.contains(&"--learn".to_string()));
@@ -4607,7 +4769,7 @@ mod tests {
                 "-m".to_string(),
                 "headroom.proxy.server".to_string(),
                 "--port".to_string(),
-                HEADROOM_PROXY_PORT.to_string(),
+                default_port,
                 "--no-http2".to_string(),
                 "--log-messages".to_string(),
             ]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.3.9-rc.1",
+  "version": "0.3.9-rc.2",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.3.8",
+  "version": "0.3.9-rc.1",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.3.9-rc.2",
+  "version": "0.3.9-rc.3",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.3.9-rc.3",
+  "version": "0.3.9",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Promote 0.3.9 from staging to stable.
- Strips `-rc.N` suffix from `package.json`, `package-lock.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`.
- Adds `.github/release-notes/0.3.9.md` ("Bugfixes") for the in-app update dialog.

Cut from `staging` tip (0d8c8a7, 0.3.9-rc.3). RC trail since 0.3.8: rc.1 → rc.2 → rc.3.

Notable changes since 0.3.8: backend port handling (new `backend_port.rs`), proxy intercept rework, port conflict handling, tool_manager work.

## Merge instructions
- **Use "Create a merge commit"** (not squash, not rebase) so the rc commits stay in `main`'s history and the rc-ancestor check passes.
- Do not merge until v0.3.9-rc.3 has built and been verified on the staging tester. The main release workflow enforces that a `vX.Y.Z-rc.N` prerelease exists whose commit is an ancestor of the merge commit.

## Test plan
- [ ] v0.3.9-rc.3 staging build completes successfully
- [ ] Staging tester auto-updates to rc.3 and is verified working
- [ ] Merge commit triggers `release-macos.yml` and publishes stable v0.3.9 DMG
- [ ] Staging rolling release re-points to stable; staging tester switches back to stable channel