### PR TITLE
Release 0.3.11

### DIFF
--- a/.github/release-notes/0.3.11.md
+++ b/.github/release-notes/0.3.11.md
@@ -1,0 +1,1 @@
+Improved logging and tooling reliability

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.3.10-rc.1",
+  "version": "0.3.11-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.3.10-rc.1",
+      "version": "0.3.11-rc.1",
       "dependencies": {
         "@microsoft/clarity": "^1.0.2",
         "@phosphor-icons/react": "^2.1.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.3.11-rc.1",
+  "version": "0.3.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.3.11-rc.1",
+      "version": "0.3.11",
       "dependencies": {
         "@microsoft/clarity": "^1.0.2",
         "@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.3.10-rc.1",
+  "version": "0.3.11-rc.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.3.11-rc.1",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.3.10-rc.1"
+version = "0.3.11-rc.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.3.11-rc.1"
+version = "0.3.11"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.3.10-rc.1"
+version = "0.3.11-rc.1"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.3.11-rc.1"
+version = "0.3.11"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -640,6 +640,13 @@ fn capture_bootstrap_failure(err: &anyhow::Error, kind: BootstrapFailureKind) {
                         .unwrap_or_else(|| "signal".into())
                         .into(),
                 );
+                scope.set_extra(
+                    "signal",
+                    failure
+                        .signal
+                        .map(|s| s.to_string().into())
+                        .unwrap_or(serde_json::Value::Null),
+                );
                 scope.set_extra("stdout", failure.stdout.clone().into());
                 scope.set_extra("stderr", failure.stderr.clone().into());
                 scope.set_extra("error_chain", technical_err.clone().into());
@@ -757,8 +764,34 @@ pub(crate) struct WatchdogGiveUpReport {
     /// "spawn returned Ok but `/readyz` never came back" (None) — the two
     /// failure modes look identical without this field.
     pub last_startup_error: Option<String>,
+    /// PID of the tracked Python child at give-up time, if we own a Child
+    /// handle. Useful for ad-hoc correlation with external `ps`/Activity
+    /// Monitor snapshots the user can attach to a bug report.
+    pub tracked_pid: Option<u32>,
+    /// Whether the backend loopback port still accepts a TCP connection.
+    /// Distinguishes "process gone, port closed" (false) from "process
+    /// alive but event loop wedged" (true) — the kernel completes
+    /// `accept()` even when uvicorn can't service HTTP. See
+    /// `state::tcp_port_accepts_connection` for full semantics.
+    pub port_accepts_tcp: bool,
+    /// Accumulated CPU seconds for the tracked PID at give-up time.
+    /// None when no tracked child or `ps` failed. Combined with
+    /// `log_silent_secs`, lets us see whether the child was burning CPU
+    /// silently (sync compute) vs idle/blocked (deadlock, await never
+    /// resolving).
+    pub process_cpu_secs: Option<u64>,
+    /// Seconds since the newest `headroom-proxy*.log` file was last
+    /// modified. None when there is no proxy log on disk yet, or the
+    /// mtime is in the future (clock skew).
+    pub log_silent_secs: Option<u64>,
+    /// Outcome of probing `/readyz` directly on the backend port at
+    /// give-up time. Disambiguates intercept-layer failures (intercept
+    /// fails, backend `ok`) from Python-layer failures (both fail).
+    /// One of: `ok`, `timeout`, `refused`, `http_<status>`, `error: <msg>`.
+    pub backend_readyz_outcome: String,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn build_watchdog_give_up_report(
     consecutive_failures: u32,
     bypass_active: bool,
@@ -766,6 +799,11 @@ pub(crate) fn build_watchdog_give_up_report(
     exit_status: Option<String>,
     log_tail: Option<String>,
     last_startup_error: Option<String>,
+    tracked_pid: Option<u32>,
+    port_accepts_tcp: bool,
+    process_cpu_secs: Option<u64>,
+    log_silent_secs: Option<u64>,
+    backend_readyz_outcome: String,
 ) -> WatchdogGiveUpReport {
     WatchdogGiveUpReport {
         message: format!(
@@ -778,6 +816,47 @@ pub(crate) fn build_watchdog_give_up_report(
         consecutive_failures,
         log_tail: log_tail.filter(|s| !s.is_empty()),
         last_startup_error: last_startup_error.filter(|s| !s.is_empty()),
+        tracked_pid,
+        port_accepts_tcp,
+        process_cpu_secs,
+        log_silent_secs,
+        backend_readyz_outcome,
+    }
+}
+
+/// Probe `/readyz` on the backend port directly (bypassing the Rust
+/// intercept on 6767) and classify the outcome for inclusion in a
+/// give-up Sentry event. 1.5s timeout matches `is_headroom_proxy_reachable`
+/// so a `timeout` here corresponds to the same wait the watchdog already
+/// experienced.
+fn probe_backend_readyz_outcome() -> String {
+    let port = crate::backend_port::get();
+    let client = match reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_millis(1500))
+        .build()
+    {
+        Ok(c) => c,
+        Err(err) => return format!("error: {err}"),
+    };
+    let url = format!("http://127.0.0.1:{port}/readyz");
+    match client.get(&url).send() {
+        Ok(response) => {
+            let status = response.status();
+            if status.is_success() {
+                "ok".to_string()
+            } else {
+                format!("http_{}", status.as_u16())
+            }
+        }
+        Err(err) => {
+            if err.is_timeout() {
+                "timeout".to_string()
+            } else if err.is_connect() {
+                "refused".to_string()
+            } else {
+                format!("error: {err}")
+            }
+        }
     }
 }
 
@@ -797,9 +876,26 @@ fn capture_watchdog_give_up(
     }
     let exit_status = state.headroom_process_exited();
     let upgrade_in_progress = state.runtime_upgrade_in_progress();
-    let log_tail = tool_manager::newest_proxy_log_path(&state.tool_manager.logs_dir())
-        .map(|path| tool_manager::tail_log_file(&path, 30));
+    let logs_dir = state.tool_manager.logs_dir();
+    let log_tail = tool_manager::newest_proxy_log_path(&logs_dir)
+        .map(|path| tool_manager::tail_log_file(&path, 100));
     let last_startup_error = state.last_startup_error.lock().clone();
+
+    let tracked_pid: Option<u32> = state
+        .headroom_process
+        .lock()
+        .as_ref()
+        .map(|child| child.id());
+    let port_accepts_tcp = crate::state::proxy_port_accepts_connection();
+    let process_cpu_secs =
+        tracked_pid.and_then(crate::state::tracked_process_cpu_time_secs);
+    let log_silent_secs = crate::state::newest_proxy_log_mtime(&logs_dir).and_then(|mtime| {
+        std::time::SystemTime::now()
+            .duration_since(mtime)
+            .ok()
+            .map(|d| d.as_secs())
+    });
+    let backend_readyz_outcome = probe_backend_readyz_outcome();
 
     let report = build_watchdog_give_up_report(
         consecutive_failures,
@@ -808,6 +904,11 @@ fn capture_watchdog_give_up(
         exit_status,
         log_tail,
         last_startup_error,
+        tracked_pid,
+        port_accepts_tcp,
+        process_cpu_secs,
+        log_silent_secs,
+        backend_readyz_outcome,
     );
 
     sentry::with_scope(
@@ -833,6 +934,20 @@ fn capture_watchdog_give_up(
             if let Some(err) = &report.last_startup_error {
                 scope.set_extra("last_startup_error", err.clone().into());
             }
+            if let Some(pid) = report.tracked_pid {
+                scope.set_extra("tracked_pid", (pid as i64).into());
+            }
+            scope.set_extra("port_accepts_tcp", report.port_accepts_tcp.into());
+            if let Some(cpu) = report.process_cpu_secs {
+                scope.set_extra("process_cpu_secs", (cpu as i64).into());
+            }
+            if let Some(silent) = report.log_silent_secs {
+                scope.set_extra("log_silent_secs", (silent as i64).into());
+            }
+            scope.set_extra(
+                "backend_readyz_outcome",
+                report.backend_readyz_outcome.clone().into(),
+            );
         },
         || {
             sentry::capture_message(&report.message, sentry::Level::Error);
@@ -984,6 +1099,13 @@ pub(crate) fn capture_upgrade_failure(
                         .map(|c| c.to_string())
                         .unwrap_or_else(|| "signal".into())
                         .into(),
+                );
+                scope.set_extra(
+                    "signal",
+                    failure
+                        .signal
+                        .map(|s| s.to_string().into())
+                        .unwrap_or(serde_json::Value::Null),
                 );
                 scope.set_extra("stdout", failure.stdout.clone().into());
                 scope.set_extra("stderr", failure.stderr.clone().into());
@@ -2758,6 +2880,17 @@ fn execute_headroom_learn_run(state: &AppState, project_path: &str) -> HeadroomL
                     .code()
                     .map(|c| c.to_string())
                     .unwrap_or_else(|| "signal".into());
+                let signal_num: Option<i32> = {
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::process::ExitStatusExt;
+                        output.status.signal()
+                    }
+                    #[cfg(not(unix))]
+                    {
+                        None
+                    }
+                };
                 // First non-empty line of stderr (or stdout if stderr empty),
                 // truncated, used both in the message and the fingerprint so
                 // events group by failure mode instead of the capture-site stack.
@@ -2789,6 +2922,12 @@ fn execute_headroom_learn_run(state: &AppState, project_path: &str) -> HeadroomL
                         scope.set_tag("flow", "headroom_learn");
                         scope.set_tag("exit_code", &exit_code_str);
                         scope.set_extra("exit_status", output.status.to_string().into());
+                        scope.set_extra(
+                            "signal",
+                            signal_num
+                                .map(|s| s.to_string().into())
+                                .unwrap_or(serde_json::Value::Null),
+                        );
                         scope.set_extra("output_tail", fail_tail.clone().into());
                         scope.set_extra("stderr_head", stderr_head.into());
                         scope.set_extra("stdout_head", stdout_head.into());
@@ -4572,6 +4711,7 @@ mod tests {
             stdout: String::new(),
             stderr: stderr.into(),
             exit_code: Some(1),
+            signal: None,
         }
     }
 
@@ -4909,6 +5049,11 @@ Some unrelated content.
             Some("exit status: 1".to_string()),
             Some("Traceback (most recent call last):\n  ...".to_string()),
             None,
+            None,
+            false,
+            None,
+            None,
+            "ok".to_string(),
         );
         assert_eq!(report.tracked_child_exit_status, "exit status: 1");
         assert_eq!(report.consecutive_failures, 3);
@@ -4926,7 +5071,19 @@ Some unrelated content.
     fn build_watchdog_give_up_report_falls_back_when_child_untracked() {
         // headroom_process_exited returns None when no Child handle is held
         // or the OS hasn't reaped the child. Payload must still be useful.
-        let report = build_watchdog_give_up_report(5, true, false, None, None, None);
+        let report = build_watchdog_give_up_report(
+            5,
+            true,
+            false,
+            None,
+            None,
+            None,
+            None,
+            false,
+            None,
+            None,
+            "refused".to_string(),
+        );
         assert_eq!(report.tracked_child_exit_status, "still_alive_or_untracked");
         assert!(report.bypass_active);
         assert!(report.log_tail.is_none());
@@ -4936,14 +5093,37 @@ Some unrelated content.
     fn build_watchdog_give_up_report_drops_empty_log_tail() {
         // tail_log_file returns "" when the log file is missing or unreadable.
         // Empty tails must not become an empty `proxy_log_tail` Sentry extra.
-        let report =
-            build_watchdog_give_up_report(3, false, false, None, Some(String::new()), None);
+        let report = build_watchdog_give_up_report(
+            3,
+            false,
+            false,
+            None,
+            Some(String::new()),
+            None,
+            None,
+            false,
+            None,
+            None,
+            "timeout".to_string(),
+        );
         assert!(report.log_tail.is_none());
     }
 
     #[test]
     fn build_watchdog_give_up_report_propagates_upgrade_flag() {
-        let report = build_watchdog_give_up_report(3, false, true, None, None, None);
+        let report = build_watchdog_give_up_report(
+            3,
+            false,
+            true,
+            None,
+            None,
+            None,
+            None,
+            false,
+            None,
+            None,
+            "timeout".to_string(),
+        );
         assert!(report.runtime_upgrade_in_progress);
     }
 
@@ -4956,6 +5136,11 @@ Some unrelated content.
             None,
             None,
             Some("Address already in use (os error 48)".to_string()),
+            None,
+            false,
+            None,
+            None,
+            "refused".to_string(),
         );
         assert_eq!(
             report.last_startup_error.as_deref(),
@@ -4965,9 +5150,44 @@ Some unrelated content.
 
     #[test]
     fn build_watchdog_give_up_report_drops_empty_last_startup_error() {
-        let report =
-            build_watchdog_give_up_report(3, false, false, None, None, Some(String::new()));
+        let report = build_watchdog_give_up_report(
+            3,
+            false,
+            false,
+            None,
+            None,
+            Some(String::new()),
+            None,
+            false,
+            None,
+            None,
+            "ok".to_string(),
+        );
         assert!(report.last_startup_error.is_none());
+    }
+
+    #[test]
+    fn build_watchdog_give_up_report_carries_diagnostic_fields() {
+        // Busy-event-loop signature: process alive, port still binds,
+        // backend /readyz times out, log silent for ~30s.
+        let report = build_watchdog_give_up_report(
+            3,
+            false,
+            false,
+            None,
+            None,
+            None,
+            Some(54321),
+            true,
+            Some(120),
+            Some(30),
+            "timeout".to_string(),
+        );
+        assert_eq!(report.tracked_pid, Some(54321));
+        assert!(report.port_accepts_tcp);
+        assert_eq!(report.process_cpu_secs, Some(120));
+        assert_eq!(report.log_silent_secs, Some(30));
+        assert_eq!(report.backend_readyz_outcome, "timeout");
     }
 
     #[test]

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -71,12 +71,7 @@ impl FileLogger {
     }
 }
 
-// Drop transient updater transport errors (offline laptop, flaky wifi, GitHub
-// blip) from Sentry. They still hit the local log file via write_record.
-fn skip_sentry(target: &str, msg: &str) -> bool {
-    if !target.starts_with("tauri_plugin_updater") {
-        return false;
-    }
+fn is_transient_transport_error(msg: &str) -> bool {
     msg.contains("error sending request")
         || msg.contains("dns error")
         || msg.contains("connection refused")
@@ -86,6 +81,23 @@ fn skip_sentry(target: &str, msg: &str) -> bool {
         || msg.contains("os error 50") // macOS: Network is down
         || msg.contains("os error 51") // macOS: Network is unreachable
         || msg.contains("os error 65") // macOS: No route to host
+}
+
+// Drop transient transport errors (offline laptop, flaky wifi, upstream blip)
+// from Sentry. They still hit the local log file via write_record.
+fn skip_sentry(target: &str, msg: &str) -> bool {
+    if target.starts_with("tauri_plugin_updater") {
+        return is_transient_transport_error(msg);
+    }
+    // proxy_intercept bypass forwarder: when CC is bypassing the local Python
+    // proxy and we re-issue directly to api.anthropic.com, transient network
+    // failures aren't actionable — client already gets a 502 and CC retries.
+    if target.starts_with("headroom_desktop_lib::proxy_intercept")
+        && msg.starts_with("proxy_intercept bypass forward failed")
+    {
+        return is_transient_transport_error(msg);
+    }
+    false
 }
 
 impl Log for FileLogger {
@@ -196,5 +208,29 @@ mod tests {
             "error sending request: timeout"
         ));
         assert!(!skip_sentry("reqwest", "error sending request"));
+    }
+
+    #[test]
+    fn skips_proxy_intercept_bypass_transport_errors() {
+        assert!(skip_sentry(
+            "headroom_desktop_lib::proxy_intercept",
+            "proxy_intercept bypass forward failed: error sending request for url (https://api.anthropic.com/v1/messages?beta=true)"
+        ));
+        assert!(skip_sentry(
+            "headroom_desktop_lib::proxy_intercept",
+            "proxy_intercept bypass forward failed: dns error: failed to lookup address"
+        ));
+    }
+
+    #[test]
+    fn keeps_proxy_intercept_non_transport_errors() {
+        assert!(!skip_sentry(
+            "headroom_desktop_lib::proxy_intercept",
+            "proxy_intercept bypass forward failed: invalid header value"
+        ));
+        assert!(!skip_sentry(
+            "headroom_desktop_lib::proxy_intercept",
+            "some other proxy_intercept warning"
+        ));
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -220,7 +220,7 @@ fn tcp_port_accepts_connection(addr: std::net::SocketAddr, timeout: std::time::D
 /// Probe the proxy's loopback port with a 1s timeout. See
 /// [`tcp_port_accepts_connection`] for semantics. The backend port is
 /// normally 6768 but may have been switched to a fallback by `backend_port`.
-fn proxy_port_accepts_connection() -> bool {
+pub(crate) fn proxy_port_accepts_connection() -> bool {
     let addr: std::net::SocketAddr = ([127, 0, 0, 1], crate::backend_port::get()).into();
     tcp_port_accepts_connection(addr, std::time::Duration::from_secs(1))
 }
@@ -254,7 +254,7 @@ fn parse_ps_cpu_time(raw: &str) -> Option<u64> {
 /// Returns None if the process is gone or `ps` fails. Cheap enough
 /// to call on a 500ms boot-validation tick — fork+exec of a tiny
 /// system binary, no I/O beyond the kernel proc table.
-fn tracked_process_cpu_time_secs(pid: u32) -> Option<u64> {
+pub(crate) fn tracked_process_cpu_time_secs(pid: u32) -> Option<u64> {
     let output = Command::new("ps")
         .args(["-p", &pid.to_string(), "-o", "time="])
         .output()
@@ -301,7 +301,7 @@ fn boot_validation_stalled(
 
 /// Newest mtime of any `headroom-proxy*.log` file in the logs directory, as
 /// a "is the proxy doing anything" signal. Returns None if no logs yet.
-fn newest_proxy_log_mtime(logs_dir: &std::path::Path) -> Option<std::time::SystemTime> {
+pub(crate) fn newest_proxy_log_mtime(logs_dir: &std::path::Path) -> Option<std::time::SystemTime> {
     let entries = std::fs::read_dir(logs_dir).ok()?;
     let mut newest: Option<std::time::SystemTime> = None;
     for entry in entries.flatten() {

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -1612,6 +1612,10 @@ impl ToolManager {
                     .chain()
                     .find_map(|cause| cause.downcast_ref::<CommandFailure>())
                     .and_then(|failure| failure.exit_code),
+                signal: err
+                    .chain()
+                    .find_map(|cause| cause.downcast_ref::<CommandFailure>())
+                    .and_then(|failure| failure.signal),
             }))
             .context("Headroom smoke test failed — the new version cannot be imported");
         }
@@ -2646,6 +2650,7 @@ impl ToolManager {
             let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
             let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
             let exit_code = output.status.code();
+            let signal = exit_status_signal(&output.status);
             let detected = detected_claude
                 .as_ref()
                 .map(|p| p.display().to_string())
@@ -2654,6 +2659,7 @@ impl ToolManager {
                 |scope| {
                     scope.set_extra("claude_cli_detected", detected.clone().into());
                     scope.set_extra("exit_code", exit_code.map(|c| c.into()).unwrap_or(serde_json::Value::Null));
+                    scope.set_extra("signal", signal.map(|s| s.into()).unwrap_or(serde_json::Value::Null));
                     scope.set_extra(
                         "stdout_tail",
                         stdout[stdout.char_indices().rev().nth(2047).map_or(0, |(i, _)| i)..].into(),
@@ -2676,6 +2682,7 @@ impl ToolManager {
                 stdout,
                 stderr,
                 exit_code,
+                signal,
             }))
             .context("configuring Headroom MCP integration");
         }
@@ -3927,6 +3934,39 @@ fn pip_line_to_progress(
     })
 }
 
+// Compact representation of a pip-install failure for log/Sentry. The full
+// CommandFailure Display dumps program + args + stdout + stderr, which the
+// 400-char Sentry cap eats before any stderr lines appear. Pip's actual
+// reason lives on stderr, so prefer the tail of stderr (or stdout if stderr
+// is empty) plus exit code.
+fn compact_pip_failure(err: &anyhow::Error) -> String {
+    const TAIL_BUDGET: usize = 300;
+    let Some(failure) = err.chain().find_map(|c| c.downcast_ref::<CommandFailure>()) else {
+        return err.to_string();
+    };
+    let source = if !failure.stderr.trim().is_empty() {
+        failure.stderr.as_str()
+    } else {
+        failure.stdout.as_str()
+    };
+    let trimmed = source.trim_end();
+    let tail = if trimmed.len() > TAIL_BUDGET {
+        let start = trimmed.len() - TAIL_BUDGET;
+        let aligned = trimmed[start..]
+            .find('\n')
+            .map(|i| start + i + 1)
+            .unwrap_or(start);
+        &trimmed[aligned..]
+    } else {
+        trimmed
+    };
+    let exit = failure
+        .exit_code
+        .map(|c| c.to_string())
+        .unwrap_or_else(|| "signal".into());
+    format!("exit={exit}; stderr tail: {tail}")
+}
+
 /// Streaming variant of `run_pip_install_with_retries`. Each line emitted by
 /// pip on stdout/stderr is piped through `on_line` as it arrives, so callers
 /// can translate noteworthy pip events ("Collecting X", "Downloading Y",
@@ -3957,7 +3997,7 @@ where
                 } else {
                     log::warn!(
                         "pip install attempt {}/{} failed (final): {}",
-                        attempt, MAX_ATTEMPTS, err
+                        attempt, MAX_ATTEMPTS, compact_pip_failure(&err)
                     );
                 }
                 last_err = Some(err);
@@ -4041,6 +4081,7 @@ where
             stdout: stdout_buf,
             stderr: stderr_buf,
             exit_code: status.code(),
+            signal: exit_status_signal(&status),
         }));
     }
 
@@ -4129,6 +4170,7 @@ fn run_command_with_timeout(
             stdout,
             stderr,
             exit_code: None,
+            signal: exit_status_signal(&status),
         }));
     }
 
@@ -4139,6 +4181,7 @@ fn run_command_with_timeout(
             stdout,
             stderr,
             exit_code: status.code(),
+            signal: exit_status_signal(&status),
         }));
     }
 
@@ -4157,6 +4200,7 @@ fn run_command(binary: &Path, args: &[&str], cwd: &Path) -> Result<()> {
             stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
             stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
             exit_code: output.status.code(),
+            signal: exit_status_signal(&output.status),
         }));
     }
 
@@ -4173,13 +4217,23 @@ pub struct CommandFailure {
     pub stdout: String,
     pub stderr: String,
     pub exit_code: Option<i32>,
+    /// Unix signal number when the child was killed by a signal (`exit_code` is
+    /// `None` in that case). Lets us tell SIGKILL (9 — likely parent shutdown,
+    /// OOM, or launchd) from SIGTERM (15 — graceful kill) in failure reports.
+    pub signal: Option<i32>,
 }
 
 impl std::fmt::Display for CommandFailure {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let status = match (self.exit_code, self.signal) {
+            (Some(code), _) => format!("exit {}", code),
+            (None, Some(sig)) => format!("killed by signal {}", sig),
+            (None, None) => "killed by signal".to_string(),
+        };
         write!(
             f,
-            "command failed: {} {}\nstdout:\n{}\nstderr:\n{}",
+            "command failed ({}): {} {}\nstdout:\n{}\nstderr:\n{}",
+            status,
             self.program,
             self.args.join(" "),
             self.stdout,
@@ -4189,6 +4243,22 @@ impl std::fmt::Display for CommandFailure {
 }
 
 impl std::error::Error for CommandFailure {}
+
+/// Extract the Unix signal number that killed a child, or `None` on non-Unix
+/// or when the process exited normally. Used to populate `CommandFailure.signal`
+/// so failure reports distinguish SIGKILL from SIGTERM.
+fn exit_status_signal(status: &std::process::ExitStatus) -> Option<i32> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        status.signal()
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = status;
+        None
+    }
+}
 
 /// Returns true when an `anyhow::Error` from a `headroom <subcommand>` shell-out
 /// looks like the venv is missing pinned dependencies — i.e. Python died with
@@ -4298,6 +4368,7 @@ mod tests {
             stdout: String::new(),
             stderr: stderr.into(),
             exit_code: Some(1),
+            signal: None,
         })
     }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.3.10-rc.1",
+  "version": "0.3.11-rc.1",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.3.11-rc.1",
+  "version": "0.3.11",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Promote 0.3.11 from staging to stable.
- Strips `-rc.N` suffix from `package.json`, `package-lock.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`.
- Adds `.github/release-notes/0.3.11.md` ("Improved logging and tooling reliability") for the in-app update dialog.

Cut from `staging` tip (2ed83a5, 0.3.11-rc.1). v0.3.11-rc.1 staging build has already completed successfully.

## Merge instructions
- **Use "Create a merge commit"** (not squash, not rebase) so the rc commits stay in `main`'s history and the rc-ancestor check passes.
- Verify rc.1 on the staging tester before merging.

## Test plan
- [ ] v0.3.11-rc.1 verified on the staging tester
- [ ] Merge commit triggers `release-macos.yml` and publishes stable v0.3.11 DMG
- [ ] Staging rolling release re-points to stable; staging tester switches back to stable channel