### PR TITLE
Add external Headroom host/port config & detection

### DIFF
--- a/src-tauri/src/backend_port.rs
+++ b/src-tauri/src/backend_port.rs
@@ -16,11 +16,13 @@
 
 use std::sync::atomic::{AtomicU16, Ordering};
 
+pub const DEFAULT_BACKEND_HOST: &str = "127.0.0.1";
 pub const DEFAULT_BACKEND_PORT: u16 = 6768;
 pub const FALLBACK_RANGE_START: u16 = 6769;
 pub const FALLBACK_RANGE_END: u16 = 6790;
 
 static BACKEND_PORT: AtomicU16 = AtomicU16::new(DEFAULT_BACKEND_PORT);
+static BACKEND_HOST: parking_lot::RwLock<String> = parking_lot::RwLock::new(String::new());
 
 pub fn get() -> u16 {
     BACKEND_PORT.load(Ordering::Acquire)
@@ -30,11 +32,25 @@ pub fn set(port: u16) {
     BACKEND_PORT.store(port, Ordering::Release);
 }
 
-/// Test-only: reset the atomic to [`DEFAULT_BACKEND_PORT`] so test cases that
-/// mutate it don't leak state into other tests in the same binary.
-#[cfg(test)]
+pub fn get_host() -> String {
+    let host = BACKEND_HOST.read();
+    if host.is_empty() {
+        DEFAULT_BACKEND_HOST.to_string()
+    } else {
+        host.clone()
+    }
+}
+
+pub fn set_host(host: String) {
+    *BACKEND_HOST.write() = host;
+}
+
+/// Test-only: reset the static variables so test cases that
+/// mutate them don't leak state into other tests in the same binary.
+#[allow(dead_code)]
 pub fn reset_for_tests() {
     BACKEND_PORT.store(DEFAULT_BACKEND_PORT, Ordering::Release);
+    *BACKEND_HOST.write() = String::new();
 }
 
 /// Successful selection of a port from the fallback range when the default

--- a/src-tauri/src/client_adapters.rs
+++ b/src-tauri/src/client_adapters.rs
@@ -90,11 +90,12 @@ fn ensure_rtk_integrations_for_targets(
 }
 
 pub fn rtk_integration_status() -> Result<(bool, bool)> {
-    let path_configured = shell_block_contains_text_in_files(
-        &resolve_default_shell_targets(),
-        "managed_rtk",
-        "export PATH=",
-    )?;
+    let path_configured = crate::tool_manager::find_rtk_on_path().is_some()
+        || shell_block_contains_text_in_files(
+            &resolve_default_shell_targets(),
+            "managed_rtk",
+            "export PATH=",
+        )?;
     let hook_configured = claude_settings_hook_matches("headroom-rtk-rewrite.sh")?
         && headroom_rtk_hook_path().exists();
     Ok((path_configured, hook_configured))
@@ -1748,9 +1749,25 @@ fn shell_double_quote(value: &str) -> String {
         .replace('`', "\\`")
 }
 
+fn which_python() -> Option<PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join("python3");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
 fn build_headroom_rtk_hook(managed_rtk_path: &Path, managed_python_path: &Path) -> String {
     let rtk = shell_double_quote(&managed_rtk_path.to_string_lossy());
-    let python = shell_double_quote(&managed_python_path.to_string_lossy());
+    let python_path = if cfg!(test) || managed_python_path.exists() {
+        managed_python_path.to_path_buf()
+    } else {
+        which_python().unwrap_or_else(|| PathBuf::from("/usr/bin/python3"))
+    };
+    let python = shell_double_quote(&python_path.to_string_lossy());
 
     format!(
         r#"#!/usr/bin/env bash

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1536,9 +1536,23 @@ fn detect_installed_headroom(
     }
 
     if binary_path.is_none() {
+        if let Ok(output) = std::process::Command::new("rtk")
+            .arg("--version")
+            .output()
+        {
+            if output.status.success() {
+                in_path = true;
+                binary_path = Some("rtk".to_string());
+            }
+        }
+    }
+
+    if binary_path.is_none() {
         let common_paths = [
             "/opt/homebrew/bin/headroom",
             "/usr/local/bin/headroom",
+            "/opt/homebrew/bin/rtk",
+            "/usr/local/bin/rtk",
         ];
         for path in &common_paths {
             if std::path::Path::new(path).exists() {
@@ -1550,9 +1564,12 @@ fn detect_installed_headroom(
 
     if binary_path.is_none() {
         if let Some(home) = dirs::home_dir() {
-            let user_local_path = home.join(".local").join("bin").join("headroom");
-            if user_local_path.exists() {
-                binary_path = Some(user_local_path.to_string_lossy().to_string());
+            for name in &["headroom", "rtk"] {
+                let user_local_path = home.join(".local").join("bin").join(name);
+                if user_local_path.exists() {
+                    binary_path = Some(user_local_path.to_string_lossy().to_string());
+                    break;
+                }
             }
         }
     }
@@ -2962,6 +2979,7 @@ pub fn run() {
             submit_contact_request,
             hide_launcher_animated,
             complete_setup_wizard,
+            reset_setup_wizard,
             get_autostart_enabled,
             set_autostart_enabled,
             uninstall_and_quit,
@@ -3500,9 +3518,10 @@ fn execute_headroom_learn_run(state: &AppState, project_path: &str) -> HeadroomL
 
 fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
     let show = tauri::menu::MenuItem::with_id(app, "show", "Show Headroom", true, None::<&str>)?;
+    let settings = tauri::menu::MenuItem::with_id(app, "settings", "Settings...", true, None::<&str>)?;
     let quit = tauri::menu::MenuItem::with_id(app, "quit", "Quit Headroom", true, None::<&str>)?;
     let separator = tauri::menu::PredefinedMenuItem::separator(app)?;
-    let menu = tauri::menu::Menu::with_items(app, &[&show, &separator, &quit])?;
+    let menu = tauri::menu::Menu::with_items(app, &[&show, &settings, &separator, &quit])?;
     let popup_menu = menu.clone();
     let mut tray_builder = tauri::tray::TrayIconBuilder::with_id("headroom-tray")
         .menu(&menu)
@@ -3546,6 +3565,11 @@ fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
                 } else {
                     let _ = show_launcher_window(app);
                 }
+            }
+            "settings" => {
+                let _ = hide_launcher_window(app);
+                let _ = show_main_window(app, None);
+                let _ = app.emit("open-settings", &());
             }
             "quit" => {
                 exit_headroom(app, QuitSource::TrayMenu);
@@ -4275,7 +4299,11 @@ fn ensure_runtime_ready_for_tray(app: &AppHandle) {
 
 fn onboarding_complete(app: &AppHandle) -> bool {
     let state: tauri::State<'_, AppState> = app.state();
-    if !state.tool_manager.python_runtime_installed() {
+    let is_external = {
+        let config = state.external_headroom_config();
+        config.enabled
+    };
+    if !is_external && !state.tool_manager.python_runtime_installed() {
         return false;
     }
     // Only require wizard completion on the very first launch. Existing users
@@ -4286,6 +4314,19 @@ fn onboarding_complete(app: &AppHandle) -> bool {
 #[tauri::command]
 fn complete_setup_wizard(state: tauri::State<'_, AppState>) {
     state.mark_setup_wizard_complete();
+}
+
+#[tauri::command]
+fn reset_setup_wizard(state: tauri::State<'_, AppState>, app: AppHandle) -> Result<(), String> {
+    state.reset_setup_wizard();
+    if let Some(main) = app.get_webview_window("main") {
+        let _ = main.hide();
+    }
+    if let Some(launcher) = app.get_webview_window("launcher") {
+        let _ = show_launcher_window(&app);
+        let _ = launcher.eval("window.location.reload()");
+    }
+    Ok(())
 }
 
 fn show_main_window(app: &AppHandle, anchor_rect: Option<Rect>) -> tauri::Result<()> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1502,10 +1502,140 @@ fn debug_force_proxy_bypass(state: State<'_, AppState>, on: bool) -> Result<bool
 }
 
 #[tauri::command]
+fn get_external_headroom_config(
+    state: State<'_, AppState>,
+) -> crate::models::ExternalHeadroomConfig {
+    state.external_headroom_config()
+}
+
+#[tauri::command]
+fn set_external_headroom_config(
+    state: State<'_, AppState>,
+    config: crate::models::ExternalHeadroomConfig,
+) -> Result<(), String> {
+    state
+        .set_external_headroom_config(config)
+        .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+fn detect_installed_headroom(
+    state: State<'_, AppState>,
+) -> Result<Option<crate::models::DetectedHeadroom>, String> {
+    let mut in_path = false;
+    let mut binary_path = None;
+
+    if let Ok(output) = std::process::Command::new("headroom")
+        .arg("--version")
+        .output()
+    {
+        if output.status.success() {
+            in_path = true;
+            binary_path = Some("headroom".to_string());
+        }
+    }
+
+    if binary_path.is_none() {
+        let common_paths = [
+            "/opt/homebrew/bin/headroom",
+            "/usr/local/bin/headroom",
+        ];
+        for path in &common_paths {
+            if std::path::Path::new(path).exists() {
+                binary_path = Some(path.to_string());
+                break;
+            }
+        }
+    }
+
+    if binary_path.is_none() {
+        if let Some(home) = dirs::home_dir() {
+            let user_local_path = home.join(".local").join("bin").join("headroom");
+            if user_local_path.exists() {
+                binary_path = Some(user_local_path.to_string_lossy().to_string());
+            }
+        }
+    }
+
+    let mut running_locally = false;
+    let mut running_port = None;
+    let ports_to_check = [8787, 6768];
+
+    let current_port = crate::backend_port::get();
+    let check_ports = if ports_to_check.contains(&current_port) {
+        vec![8787, 6768]
+    } else {
+        vec![8787, 6768, current_port]
+    };
+
+    for port in check_ports {
+        if probe_headroom_on_port("127.0.0.1", port) {
+            running_locally = true;
+            running_port = Some(port);
+            break;
+        }
+    }
+
+    if !running_locally {
+        let config = state.external_headroom_config();
+        if config.enabled && probe_headroom_on_port(&config.host, config.port) {
+            running_locally = true;
+            running_port = Some(config.port);
+        }
+    }
+
+    if binary_path.is_none() && !running_locally {
+        Ok(None)
+    } else {
+        Ok(Some(crate::models::DetectedHeadroom {
+            binary_path,
+            in_path,
+            running_locally,
+            running_port,
+        }))
+    }
+}
+
+fn probe_headroom_on_port(host: &str, port: u16) -> bool {
+    let client = match reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_millis(300))
+        .build()
+    {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    
+    let url = format!("http://{host}:{port}/stats");
+    if let Ok(res) = client.get(&url).send() {
+        if res.status().is_success() {
+            return true;
+        }
+    }
+    
+    for path in &["/readyz", "/livez", "/health"] {
+        let url = format!("http://{host}:{port}{path}");
+        if let Ok(res) = client.get(&url).send() {
+            if res.status().is_success() {
+                return true;
+            }
+        }
+    }
+    
+    false
+}
+
+#[tauri::command]
 fn get_headroom_logs(
     state: State<'_, AppState>,
     max_lines: Option<usize>,
 ) -> Result<Vec<String>, String> {
+    if state.external_headroom_config().enabled {
+        let config = state.external_headroom_config();
+        return Ok(vec![format!(
+            "Connected to external headroom at {}:{}. Local logs are not written.",
+            config.host, config.port
+        )]);
+    }
     let limit = max_lines.unwrap_or(120).clamp(20, 500);
     state
         .tool_manager
@@ -1955,11 +2085,39 @@ fn aggregate_live_learnings(
     Ok(out)
 }
 
+fn resolve_headroom_binary(state: &AppState) -> std::path::PathBuf {
+    if state.external_headroom_config().enabled {
+        if let Ok(output) = std::process::Command::new("headroom").arg("--version").output() {
+            if output.status.success() {
+                return std::path::PathBuf::from("headroom");
+            }
+        }
+        
+        for path in &["/opt/homebrew/bin/headroom", "/usr/local/bin/headroom"] {
+            let p = std::path::PathBuf::from(path);
+            if p.exists() {
+                return p;
+            }
+        }
+        
+        if let Some(home) = dirs::home_dir() {
+            let p = home.join(".local").join("bin").join("headroom");
+            if p.exists() {
+                return p;
+            }
+        }
+    }
+    state.tool_manager.headroom_entrypoint()
+}
+
 fn memory_export_cached(state: &State<'_, AppState>, memory_path: &Path) -> Result<String, String> {
     if let Some(cached) = state.cached_memory_export() {
         return Ok(cached);
     }
-    let entrypoint = state.tool_manager.headroom_entrypoint();
+    let entrypoint = resolve_headroom_binary(state);
+    if !entrypoint.exists() && entrypoint.to_string_lossy() != "headroom" {
+        return Err("Headroom binary not found. Please make sure headroom is installed on your system.".into());
+    }
     let stdout = run_memory_export(&entrypoint, memory_path)?;
     state.store_memory_export(stdout.clone());
     Ok(stdout)
@@ -1971,7 +2129,10 @@ fn delete_live_learning(state: State<'_, AppState>, memory_id: String) -> Result
     if !memory_path.exists() {
         return Err("Memory database does not exist.".into());
     }
-    let entrypoint = state.tool_manager.headroom_entrypoint();
+    let entrypoint = resolve_headroom_binary(&state);
+    if !entrypoint.exists() && entrypoint.to_string_lossy() != "headroom" {
+        return Err("Headroom binary not found. Please make sure headroom is installed on your system.".into());
+    }
     let output = Command::new(&entrypoint)
         .arg("memory")
         .arg("delete")
@@ -2805,6 +2966,9 @@ pub fn run() {
             set_autostart_enabled,
             uninstall_and_quit,
             quit_headroom,
+            get_external_headroom_config,
+            set_external_headroom_config,
+            detect_installed_headroom,
             #[cfg(debug_assertions)]
             debug_force_proxy_bypass
         ])

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -221,6 +221,7 @@ pub struct RuntimeStatus {
     pub platform: String,
     pub support_tier: String,
     pub installed: bool,
+    pub local_runtime_installed: bool,
     pub running: bool,
     pub starting: bool,
     pub paused: bool,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -723,3 +723,20 @@ pub struct HeadroomAuthCodeRequest {
     pub email: String,
     pub expires_in_seconds: u64,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalHeadroomConfig {
+    pub enabled: bool,
+    pub host: String,
+    pub port: u16,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DetectedHeadroom {
+    pub binary_path: Option<String>,
+    pub in_path: bool,
+    pub running_locally: bool,
+    pub running_port: Option<u16>,
+}

--- a/src-tauri/src/proxy_intercept.rs
+++ b/src-tauri/src/proxy_intercept.rs
@@ -149,11 +149,12 @@ async fn handle(
     fresh_bearer_tx: FreshBearerNotifier,
     upstream_base: Arc<String>,
 ) {
-    // Re-read the backend port on each connection. `tool_manager` selects the
+    // Re-read the backend host and port on each connection. `tool_manager` selects the
     // port (and may switch to a fallback) when the proxy spawn runs, which
     // happens after this thread is already accepting; reading per-connection
     // means existing clients pick up the chosen port without restarting.
-    let backend_addr: SocketAddr = ([127, 0, 0, 1], backend_port::get()).into();
+    let backend_host = backend_port::get_host();
+    let backend_port_val = backend_port::get();
     // Read only through the end of the HTTP headers. We only need headers to
     // capture the bearer token, and forwarding early avoids deadlocks with
     // `Expect: 100-continue` request flows.
@@ -203,7 +204,7 @@ async fn handle(
     }
 
     // Forward to the headroom backend.
-    let Ok(mut backend) = TcpStream::connect(backend_addr).await else {
+    let Ok(mut backend) = TcpStream::connect((backend_host.as_str(), backend_port_val)).await else {
         // headroom not up yet — send a 502 so the client gets a clean error.
         let _ = client
             .write_all(b"HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n\r\n")

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1657,6 +1657,13 @@ impl AppState {
         persist_launch_profile(&self.launch_profile_path, &profile);
     }
 
+    pub fn reset_setup_wizard(&self) {
+        let mut profile = self.launch_profile.lock();
+        profile.setup_wizard_complete = false;
+        profile.launch_experience = crate::models::LaunchExperience::FirstRun;
+        persist_launch_profile(&self.launch_profile_path, &profile);
+    }
+
     pub fn external_headroom_config(&self) -> crate::models::ExternalHeadroomConfig {
         let profile = self.launch_profile.lock();
         crate::models::ExternalHeadroomConfig {
@@ -2092,8 +2099,16 @@ impl AppState {
             DashboardState {
                 app_version: env!("CARGO_PKG_VERSION").into(),
                 launch_experience: self.launch_profile.lock().launch_experience.clone(),
-                bootstrap_complete: self.tool_manager.python_runtime_installed(),
-                python_runtime_installed: self.tool_manager.python_runtime_installed(),
+                bootstrap_complete: if self.launch_profile.lock().external_headroom_enabled {
+                    true
+                } else {
+                    self.tool_manager.python_runtime_installed()
+                },
+                python_runtime_installed: if self.launch_profile.lock().external_headroom_enabled {
+                    true
+                } else {
+                    self.tool_manager.python_runtime_installed()
+                },
                 lifetime_requests: snapshot.lifetime_requests,
                 lifetime_estimated_savings_usd: snapshot.lifetime_estimated_savings_usd,
                 lifetime_estimated_tokens_saved: snapshot.lifetime_estimated_tokens_saved,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -2649,6 +2649,8 @@ impl AppState {
             }
         };
 
+        let local_runtime_installed = self.tool_manager.python_runtime_installed();
+
         let effective_running = installed && !paused && proxy_reachable;
 
         let startup_error = self.last_startup_error.lock().clone();
@@ -2658,6 +2660,7 @@ impl AppState {
             platform: platform.into(),
             support_tier: support_tier.into(),
             installed,
+            local_runtime_installed,
             running: effective_running,
             starting: self.runtime_is_starting() && !effective_running,
             paused,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -97,10 +97,11 @@ pub fn runtime_upgrade_disabled_by_env() -> bool {
 /// if the proxy is alive but too CPU-saturated to answer a direct probe
 /// quickly, since the intercept has its own retry + longer timeout path.
 fn probe_proxy_livez(client: &reqwest::blocking::Client) -> bool {
+    let backend_host = crate::backend_port::get_host();
     let backend = crate::backend_port::get();
     let urls = [
-        format!("http://127.0.0.1:{backend}/livez"),
-        format!("http://127.0.0.1:{backend}/health"),
+        format!("http://{backend_host}:{backend}/livez"),
+        format!("http://{backend_host}:{backend}/health"),
         "http://127.0.0.1:6767/livez".to_string(),
         "http://127.0.0.1:6767/health".to_string(),
     ];
@@ -221,8 +222,15 @@ fn tcp_port_accepts_connection(addr: std::net::SocketAddr, timeout: std::time::D
 /// [`tcp_port_accepts_connection`] for semantics. The backend port is
 /// normally 6768 but may have been switched to a fallback by `backend_port`.
 pub(crate) fn proxy_port_accepts_connection() -> bool {
-    let addr: std::net::SocketAddr = ([127, 0, 0, 1], crate::backend_port::get()).into();
-    tcp_port_accepts_connection(addr, std::time::Duration::from_secs(1))
+    use std::net::ToSocketAddrs;
+    let host = crate::backend_port::get_host();
+    let port = crate::backend_port::get();
+    if let Ok(mut addrs) = format!("{host}:{port}").to_socket_addrs() {
+        if let Some(addr) = addrs.next() {
+            return tcp_port_accepts_connection(addr, std::time::Duration::from_secs(1));
+        }
+    }
+    false
 }
 
 /// Parse the `ps -p PID -o time=` accumulated CPU time format.
@@ -517,6 +525,10 @@ impl AppState {
         let runtime = ManagedRuntime::bootstrap_root(&base_dir);
         let tool_manager = ToolManager::new(runtime);
         let (launch_profile, launch_profile_path) = LaunchProfile::load_or_create(&base_dir)?;
+        if launch_profile.external_headroom_enabled {
+            crate::backend_port::set_host(launch_profile.external_headroom_host.clone());
+            crate::backend_port::set(launch_profile.external_headroom_port);
+        }
         let (last_known_good_plan, last_known_good_plan_path) = LastKnownGoodPlan::load(&base_dir);
         let savings_tracker = SavingsTracker::load_or_create(&base_dir)?;
         let activity_facts = ActivityFacts::load_or_create(&base_dir)?;
@@ -592,6 +604,34 @@ impl AppState {
         // dir holds the real working environment and the live venv is a
         // partial install. Restore before doing anything else.
         let _ = self.tool_manager.recover_from_interrupted_upgrade();
+
+        let is_external = {
+            let profile = self.launch_profile.lock();
+            profile.external_headroom_enabled
+        };
+
+        if is_external {
+            let (host, port) = {
+                let profile = self.launch_profile.lock();
+                (profile.external_headroom_host.clone(), profile.external_headroom_port)
+            };
+            crate::backend_port::set_host(host);
+            crate::backend_port::set(port);
+
+            self.set_runtime_starting(true);
+            let _ = self.ensure_headroom_running();
+
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            while std::time::Instant::now() < deadline {
+                if is_headroom_proxy_reachable() {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(200));
+            }
+
+            self.set_runtime_starting(false);
+            return;
+        }
 
         if !self.tool_manager.python_runtime_installed() {
             // First-run; start_bootstrap (wizard) handles install.
@@ -1617,6 +1657,46 @@ impl AppState {
         persist_launch_profile(&self.launch_profile_path, &profile);
     }
 
+    pub fn external_headroom_config(&self) -> crate::models::ExternalHeadroomConfig {
+        let profile = self.launch_profile.lock();
+        crate::models::ExternalHeadroomConfig {
+            enabled: profile.external_headroom_enabled,
+            host: profile.external_headroom_host.clone(),
+            port: profile.external_headroom_port,
+        }
+    }
+
+    pub fn set_external_headroom_config(&self, config: crate::models::ExternalHeadroomConfig) -> Result<()> {
+        let was_enabled = self.launch_profile.lock().external_headroom_enabled;
+
+        {
+            let mut profile = self.launch_profile.lock();
+            profile.external_headroom_enabled = config.enabled;
+            profile.external_headroom_host = config.host.clone();
+            profile.external_headroom_port = config.port;
+            persist_launch_profile(&self.launch_profile_path, &profile);
+        }
+
+        if config.enabled {
+            crate::backend_port::set_host(config.host);
+            crate::backend_port::set(config.port);
+
+            if !was_enabled {
+                self.stop_headroom();
+            }
+        } else {
+            crate::backend_port::set_host(String::new());
+            crate::backend_port::set(crate::backend_port::DEFAULT_BACKEND_PORT);
+
+            if was_enabled {
+                let _ = self.ensure_headroom_running();
+            }
+        }
+
+        self.invalidate_runtime_status_cache();
+        Ok(())
+    }
+
     pub fn cached_clients(&self) -> Vec<ClientStatus> {
         const TTL: Duration = Duration::from_secs(8);
         let mut cache = self.cached_clients.lock();
@@ -2349,6 +2429,29 @@ impl AppState {
     }
 
     pub fn ensure_headroom_running(&self) -> Result<()> {
+        let is_external = {
+            let profile = self.launch_profile.lock();
+            profile.external_headroom_enabled
+        };
+
+        if is_external {
+            let (host, port) = {
+                let profile = self.launch_profile.lock();
+                (profile.external_headroom_host.clone(), profile.external_headroom_port)
+            };
+            crate::backend_port::set_host(host);
+            crate::backend_port::set(port);
+
+            if is_headroom_proxy_reachable() {
+                *self.last_startup_error.lock() = None;
+                return Ok(());
+            } else {
+                let err_msg = format!("External headroom is not reachable at {}:{}", crate::backend_port::get_host(), crate::backend_port::get());
+                *self.last_startup_error.lock() = Some(err_msg.clone());
+                return Err(anyhow::anyhow!(err_msg));
+            }
+        }
+
         if !self.tool_manager.python_runtime_installed() {
             return Ok(());
         }
@@ -2488,7 +2591,12 @@ impl AppState {
     }
 
     fn compute_runtime_status(&self) -> RuntimeStatus {
-        let installed = self.tool_manager.python_runtime_installed();
+        let is_external = self.launch_profile.lock().external_headroom_enabled;
+        let installed = if is_external {
+            true
+        } else {
+            self.tool_manager.python_runtime_installed()
+        };
         let paused = self.runtime_is_paused();
         let proxy_reachable = is_headroom_proxy_reachable();
         let mcp_configured = self.tool_manager.headroom_mcp_configured();
@@ -2958,6 +3066,14 @@ pub fn tail_lines(text: &str, max_lines: usize) -> Vec<String> {
     lines
 }
 
+fn default_external_host() -> String {
+    "127.0.0.1".to_string()
+}
+
+fn default_external_port() -> u16 {
+    6768
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct LaunchProfile {
     launch_count: u64,
@@ -2971,6 +3087,12 @@ struct LaunchProfile {
     last_launched_app_version: Option<String>,
     #[serde(default)]
     last_runtime_upgrade_failure: Option<RuntimeUpgradeFailure>,
+    #[serde(default)]
+    external_headroom_enabled: bool,
+    #[serde(default = "default_external_host")]
+    external_headroom_host: String,
+    #[serde(default = "default_external_port")]
+    external_headroom_port: u16,
 }
 
 fn persist_launch_profile(path: &std::path::Path, profile: &LaunchProfile) {
@@ -2998,6 +3120,9 @@ impl LaunchProfile {
                 setup_wizard_complete: false,
                 last_launched_app_version: None,
                 last_runtime_upgrade_failure: None,
+                external_headroom_enabled: false,
+                external_headroom_host: default_external_host(),
+                external_headroom_port: default_external_port(),
             }
         };
 
@@ -5402,6 +5527,9 @@ mod tests {
                 error_hint: Some("Reverted to 0.6.5".into()),
                 rollback_restored: true,
             }),
+            external_headroom_enabled: false,
+            external_headroom_host: super::default_external_host(),
+            external_headroom_port: super::default_external_port(),
         };
         super::persist_launch_profile(&path, &profile);
 
@@ -6407,7 +6535,14 @@ mod tests {
 
         let daily_points = parsed.daily_savings();
         assert_eq!(daily_points.len(), 1);
-        assert_eq!(daily_points[0].date, "2026-03-27");
+        let expected_date = Utc
+            .with_ymd_and_hms(2026, 3, 27, 0, 0, 0)
+            .single()
+            .expect("date")
+            .with_timezone(&Local)
+            .format("%Y-%m-%d")
+            .to_string();
+        assert_eq!(daily_points[0].date, expected_date);
         assert_eq!(daily_points[0].estimated_tokens_saved, 175);
         assert!((daily_points[0].estimated_savings_usd - 0.175).abs() < 1e-9);
         assert_eq!(daily_points[0].actual_cost_usd, 0.0);

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -2033,6 +2033,10 @@ impl AppState {
         &self,
         drain_pending_milestones: bool,
     ) -> (DashboardState, PendingMilestones) {
+        let (external_enabled, launch_experience) = {
+            let profile = self.launch_profile.lock();
+            (profile.external_headroom_enabled, profile.launch_experience.clone())
+        };
         let tools = self.tool_manager.list_tools();
         let clients = self.cached_clients();
         let recent_usage = self.recent_usage.lock().clone();
@@ -2098,13 +2102,13 @@ impl AppState {
         (
             DashboardState {
                 app_version: env!("CARGO_PKG_VERSION").into(),
-                launch_experience: self.launch_profile.lock().launch_experience.clone(),
-                bootstrap_complete: if self.launch_profile.lock().external_headroom_enabled {
+                launch_experience,
+                bootstrap_complete: if external_enabled {
                     true
                 } else {
                     self.tool_manager.python_runtime_installed()
                 },
-                python_runtime_installed: if self.launch_profile.lock().external_headroom_enabled {
+                python_runtime_installed: if external_enabled {
                     true
                 } else {
                     self.tool_manager.python_runtime_installed()

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -395,7 +395,7 @@ impl ToolManager {
     }
 
     pub fn rtk_entrypoint(&self) -> PathBuf {
-        self.runtime.bin_dir.join("rtk")
+        find_rtk_on_path().unwrap_or_else(|| self.runtime.bin_dir.join("rtk"))
     }
 
     pub fn headroom_learn_log_path(&self, project_path: &str) -> PathBuf {
@@ -967,17 +967,34 @@ impl ToolManager {
     }
 
     pub fn rtk_installed(&self) -> bool {
-        self.rtk_entrypoint().exists() && self.runtime.tools_dir.join("rtk.json").exists()
+        self.rtk_entrypoint().exists()
+            && (find_rtk_on_path().is_some() || self.runtime.tools_dir.join("rtk.json").exists())
     }
 
     pub fn installed_rtk_version(&self) -> Option<String> {
-        self.read_rtk_receipt()?
-            .get("version")?
-            .as_str()
-            .map(|v| v.to_string())
+        if let Some(r) = self.read_rtk_receipt() {
+            if let Some(v) = r.get("version").and_then(|v| v.as_str()) {
+                return Some(v.to_string());
+            }
+        }
+        if let Some(rtk_path) = find_rtk_on_path() {
+            if let Ok(output) = Command::new(rtk_path).arg("--version").output() {
+                if output.status.success() {
+                    let out_str = String::from_utf8_lossy(&output.stdout);
+                    let version = out_str.trim().trim_start_matches("rtk").trim().to_string();
+                    if !version.is_empty() {
+                        return Some(version);
+                    }
+                }
+            }
+        }
+        None
     }
 
     pub fn rtk_needs_install(&self) -> bool {
+        if find_rtk_on_path().is_some() {
+            return false;
+        }
         !self.rtk_entrypoint().exists()
             || self.installed_rtk_version().as_deref() != Some(RTK_VERSION)
     }
@@ -4456,6 +4473,37 @@ impl std::fmt::Display for HeadroomStartupFailure {
 }
 
 impl std::error::Error for HeadroomStartupFailure {}
+
+pub(crate) fn find_rtk_on_path() -> Option<PathBuf> {
+    if cfg!(test) {
+        return None;
+    }
+    let path_var = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join("rtk");
+        if is_executable_file(&candidate) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(metadata) = std::fs::metadata(path) {
+            return metadata.is_file() && (metadata.permissions().mode() & 0o111 != 0);
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        if let Ok(metadata) = std::fs::metadata(path) {
+            return metadata.is_file();
+        }
+    }
+    false
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5296,27 +5296,29 @@ export default function App() {
                 </div>
               </article>
 
-              <article className="soft-card panel-card">
-                <div className="panel-card__header">
-                  <div>
-                    <h3>Uninstall</h3>
+              {!externalEnabled && runtimeStatus?.localRuntimeInstalled ? (
+                <article className="soft-card panel-card">
+                  <div className="panel-card__header">
+                    <div>
+                      <h3>Uninstall</h3>
+                    </div>
                   </div>
-                </div>
-                <p>
-                  Reverses every change Headroom made: removes the managed Python runtime, the Claude Code
-                  hook, and restores <code>~/.claude/settings.json</code> changes. Headroom will quit when done.
-                </p>
-                <button
-                  className="secondary-button secondary-button--small"
-                  onClick={() => {
-                    setUninstallError(null);
-                    setShowUninstallDialog(true);
-                  }}
-                  type="button"
-                >
-                  Uninstall Headroom
-                </button>
-              </article>
+                  <p>
+                    Reverses every change Headroom made: removes the managed Python runtime, the Claude Code
+                    hook, and restores <code>~/.claude/settings.json</code> changes. Headroom will quit when done.
+                  </p>
+                  <button
+                    className="secondary-button secondary-button--small"
+                    onClick={() => {
+                      setUninstallError(null);
+                      setShowUninstallDialog(true);
+                    }}
+                    type="button"
+                  >
+                    Uninstall Headroom
+                  </button>
+                </article>
+              ) : null}
 
               <button
                 className="contact-link"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5141,7 +5141,10 @@ export default function App() {
                       {
                         name: "Proxy",
                         ok: runtimeStatus?.proxyReachable === true,
-                        suffix: "6767",
+                        suffix: externalEnabled ? `6767 ➔ ${externalPort}` : "6767",
+                        title: externalEnabled
+                          ? `Local intercept proxy (6767) forwarding to external headroom (${externalPort})`
+                          : "Local intercept proxy (6767) forwarding to headroom backend",
                         onClick: () => void invoke("open_headroom_dashboard"),
                       },
                       {
@@ -5162,7 +5165,7 @@ export default function App() {
                               ? false
                               : null,
                       },
-                    ] as { name: string; ok: boolean | null; suffix?: string; onClick?: () => void }[]).map((s) => {
+                    ] as { name: string; ok: boolean | null; suffix?: string; title?: string; onClick?: () => void }[]).map((s) => {
                       const indicatorClass =
                         s.ok === true
                           ? "runtime-status__indicator--ok"
@@ -5175,7 +5178,7 @@ export default function App() {
                           key={s.name}
                           className={`runtime-status__item${s.onClick ? " runtime-status__item--clickable" : ""}`}
                           onClick={s.onClick}
-                          title={s.ok === null ? `${s.name} status unknown` : undefined}
+                          title={s.title || (s.ok === null ? `${s.name} status unknown` : undefined)}
                         >
                           <span className="runtime-status__label">{s.name}:</span>
                           <span className={`runtime-status__indicator ${indicatorClass}`}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -714,6 +714,8 @@ export default function App() {
   const [detectionResult, setDetectionResult] = useState<string | null>(null);
   const [detectedRunningPort, setDetectedRunningPort] = useState<number | null>(null);
   const [saveBusy, setSaveBusy] = useState(false);
+  const [showExternalSetup, setShowExternalSetup] = useState(false);
+  const [wizardExternalError, setWizardExternalError] = useState<string | null>(null);
   const [upgradeActionBusy, setUpgradeActionBusy] = useState<UpgradePlanId | null>(null);
   const [upgradeActionError, setUpgradeActionError] = useState<string | null>(null);
   const [pendingPlanChange, setPendingPlanChange] = useState<{
@@ -1525,9 +1527,13 @@ export default function App() {
         if (result.runningLocally && result.runningPort) {
           setDetectedRunningPort(result.runningPort);
           msg += `Found running headroom instance. `;
-        }
-        if (result.binaryPath) {
-          msg += `Headroom binary found at ${result.binaryPath}.`;
+          if (result.binaryPath) {
+            msg += `Headroom binary found at ${result.binaryPath}.`;
+          } else {
+            msg += `(CLI binary not found on system PATH).`;
+          }
+        } else if (result.binaryPath) {
+          msg += `Headroom binary found at ${result.binaryPath} (not currently running).`;
         } else {
           msg += `Headroom is not installed on this system.`;
         }
@@ -2365,6 +2371,60 @@ export default function App() {
   async function handleFirstLaunchContinue() {
     await autoConfigureClaudeCodeForLauncher();
   }
+  
+  async function handleWizardSaveExternalConfig() {
+    setSaveBusy(true);
+    setWizardExternalError(null);
+    try {
+      await invoke("set_external_headroom_config", {
+        config: {
+          enabled: true,
+          host: externalHost,
+          port: externalPort
+        }
+      });
+      const runtime = await invoke<RuntimeStatus>("get_runtime_status");
+      applyRuntimeStatusIfChanged(runtime);
+      if (runtime.running) {
+        await invoke("complete_setup_wizard");
+        setShowExternalSetup(false);
+        await handleFirstLaunchContinue();
+      } else {
+        setWizardExternalError(`Could not connect to headroom at ${externalHost}:${externalPort}. Make sure the instance is running and reachable.`);
+      }
+    } catch (e: any) {
+      setWizardExternalError(`Failed to save config: ${e.message || e}`);
+    } finally {
+      setSaveBusy(false);
+    }
+  }
+
+  async function handleWizardApplyDetected(port: number) {
+    setSaveBusy(true);
+    setWizardExternalError(null);
+    try {
+      await invoke("set_external_headroom_config", {
+        config: {
+          enabled: true,
+          host: "127.0.0.1",
+          port: port
+        }
+      });
+      const runtime = await invoke<RuntimeStatus>("get_runtime_status");
+      applyRuntimeStatusIfChanged(runtime);
+      if (runtime.running) {
+        await invoke("complete_setup_wizard");
+        setShowExternalSetup(false);
+        await handleFirstLaunchContinue();
+      } else {
+        setWizardExternalError(`Could not connect to headroom at 127.0.0.1:${port}.`);
+      }
+    } catch (e: any) {
+      setWizardExternalError(`Failed to save config: ${e.message || e}`);
+    } finally {
+      setSaveBusy(false);
+    }
+  }
 
   async function runHeadroomLearn(projectPath: string) {
     if (runtimeStatus?.headroomLearnSupported === false) {
@@ -3187,33 +3247,139 @@ export default function App() {
         showSpinner={bootstrapping}
       >
         <h1>
-          Headroom cuts Claude Code costs
-          <br />
-           ~<span className="headline-highlight">50%</span> by trimming prompt bloat.
+          {showExternalSetup ? (
+            "Configure External Headroom"
+          ) : (
+            <>
+              Headroom cuts Claude Code costs
+              <br />
+               ~<span className="headline-highlight">50%</span> by trimming prompt bloat.
+            </>
+          )}
         </h1>
-        <div className="intro-shell__checklist">
-          <article>
-            <strong>Privacy first</strong>
-            <p>
-              Your prompts never touch our servers — everything runs locally on your machine.
+        {!showExternalSetup && (
+          <div className="intro-shell__checklist">
+            <article>
+              <strong>Privacy first</strong>
+              <p>
+                Your prompts never touch our servers — everything runs locally on your machine.
+              </p>
+            </article>
+            <article>
+              <strong>Self-contained</strong>
+              <p>
+                Keeps your runtime clean, never interfering with packages your
+                projects depend on.
+              </p>
+            </article>
+            <article>
+              <strong>Less tokens, no impact</strong>
+              <p>
+                Smart optimization cuts noise before Claude Code sees it, with
+                no impact on the output.
+              </p>
+            </article>
+          </div>
+        )}
+        {showExternalSetup ? (
+          <div style={{ display: "flex", flexDirection: "column", gap: "16px", padding: "16px", background: "var(--surface-sunken, rgba(0,0,0,0.02))", borderRadius: "8px", border: "1px solid var(--border-subtle, rgba(0,0,0,0.05))", width: "100%", boxSizing: "border-box" }}>
+            <p style={{ fontSize: "13px", color: "var(--text-subtle)", margin: 0 }}>
+              Specify the host and port of an existing headroom instance (e.g. CLI or another machine).
             </p>
-          </article>
-          <article>
-            <strong>Self-contained</strong>
-            <p>
-              Keeps your runtime clean, never interfering with packages your
-              projects depend on.
-            </p>
-          </article>
-          <article>
-            <strong>Less tokens, no impact</strong>
-            <p>
-              Smart optimization cuts noise before Claude Code sees it, with
-              no impact on the output.
-            </p>
-          </article>
-        </div>
-        {installComplete ? (
+            
+            <div style={{ display: "flex", gap: "12px" }}>
+              <label className="pricing-auth-field" style={{ flex: "2" }}>
+                <span style={{ fontSize: "11px", textTransform: "uppercase", letterSpacing: "0.5px", color: "var(--text-subtle)", display: "block", marginBottom: "4px" }}>Host / IP</span>
+                <div className="pricing-auth-field__input">
+                  <input
+                    type="text"
+                    value={externalHost}
+                    onChange={(e) => setExternalHost(e.target.value)}
+                    placeholder="127.0.0.1"
+                    disabled={saveBusy}
+                  />
+                </div>
+              </label>
+              
+              <label className="pricing-auth-field" style={{ flex: "1" }}>
+                <span style={{ fontSize: "11px", textTransform: "uppercase", letterSpacing: "0.5px", color: "var(--text-subtle)", display: "block", marginBottom: "4px" }}>Port</span>
+                <div className="pricing-auth-field__input">
+                  <input
+                    type="number"
+                    value={externalPort || ""}
+                    onChange={(e) => setExternalPort(parseInt(e.target.value) || 0)}
+                    placeholder="6768"
+                    disabled={saveBusy}
+                  />
+                </div>
+              </label>
+            </div>
+
+            {wizardExternalError && (
+              <p style={{ fontSize: "12px", color: "var(--danger-text, #c92a2a)", margin: 0 }}>
+                ⚠️ {wizardExternalError}
+              </p>
+            )}
+
+            <div style={{ display: "flex", flexDirection: "column", gap: "8px", marginTop: "4px" }}>
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <button
+                  className="secondary-button secondary-button--small"
+                  onClick={() => {
+                    setWizardExternalError(null);
+                    setShowExternalSetup(false);
+                  }}
+                  disabled={saveBusy}
+                  type="button"
+                >
+                  Back
+                </button>
+                <button
+                  className="primary-button"
+                  style={{ padding: "6px 16px", fontSize: "12px" }}
+                  onClick={() => void handleWizardSaveExternalConfig()}
+                  disabled={saveBusy || !externalHost || !externalPort}
+                  type="button"
+                >
+                  {saveBusy ? "Connecting..." : "Save & Connect"}
+                </button>
+              </div>
+              
+              <div style={{ borderTop: "1px solid var(--border-subtle, rgba(0,0,0,0.05))", paddingTop: "8px", marginTop: "4px" }}>
+                <button
+                  className="secondary-button secondary-button--small"
+                  style={{ width: "100%", justifyContent: "center" }}
+                  onClick={() => void handleDetectHeadroom()}
+                  disabled={detectBusy || saveBusy}
+                  type="button"
+                >
+                  {detectBusy ? "Detecting..." : "Detect headroom install"}
+                </button>
+                
+                {detectionResult && (
+                  <p style={{ fontSize: "11px", color: "var(--text-subtle)", marginTop: "6px", marginBottom: 0, textAlign: "center" }}>
+                    {detectionResult}
+                  </p>
+                )}
+                
+                {detectedRunningPort && (
+                  <div style={{ fontSize: "11px", marginTop: "6px", color: "var(--text-subtle)", textAlign: "center" }}>
+                    💡 Found headroom running on port {detectedRunningPort}.{" "}
+                    <button
+                      className="link-button"
+                      style={{ fontSize: "11px", padding: 0 }}
+                      onClick={() => void handleWizardApplyDetected(detectedRunningPort)}
+                      disabled={saveBusy}
+                      type="button"
+                    >
+                      Use this connection
+                    </button>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        ) : installComplete ? (
           <>
             {runtimeStatus?.running !== true ? (
               <>
@@ -3272,6 +3438,23 @@ export default function App() {
                     Headroom. A timestamped backup is written before any edit.
                   </li>
                 </ul>
+              </div>
+            )}
+            {!bootstrapping && (
+              <div style={{ marginTop: "16px", textAlign: "center" }}>
+                <button
+                  className="link-button"
+                  style={{ fontSize: "12px", color: "var(--text-subtle)", cursor: "pointer" }}
+                  onClick={() => {
+                    setWizardExternalError(null);
+                    setDetectionResult(null);
+                    setDetectedRunningPort(null);
+                    setShowExternalSetup(true);
+                  }}
+                  type="button"
+                >
+                  Already have Headroom installed? Use external headroom.
+                </button>
               </div>
             )}
           </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1871,6 +1871,16 @@ export default function App() {
     return () => unlisten?.();
   }, []);
 
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    void listen("open-settings", () => {
+      setActiveView("settings");
+    }).then((fn) => {
+      unlisten = fn;
+    });
+    return () => unlisten?.();
+  }, []);
+
   // After the user opens a Polar checkout URL, poll pricing status every 5s
   // for up to 5 minutes so we can flip the UI back to "active" within seconds
   // of payment confirmation, instead of waiting out the 60s baseline cadence.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -707,6 +707,13 @@ export default function App() {
   const [showUninstallDialog, setShowUninstallDialog] = useState(false);
   const [uninstallBusy, setUninstallBusy] = useState(false);
   const [uninstallError, setUninstallError] = useState<string | null>(null);
+  const [externalEnabled, setExternalEnabled] = useState(false);
+  const [externalHost, setExternalHost] = useState("127.0.0.1");
+  const [externalPort, setExternalPort] = useState(6768);
+  const [detectBusy, setDetectBusy] = useState(false);
+  const [detectionResult, setDetectionResult] = useState<string | null>(null);
+  const [detectedRunningPort, setDetectedRunningPort] = useState<number | null>(null);
+  const [saveBusy, setSaveBusy] = useState(false);
   const [upgradeActionBusy, setUpgradeActionBusy] = useState<UpgradePlanId | null>(null);
   const [upgradeActionError, setUpgradeActionError] = useState<string | null>(null);
   const [pendingPlanChange, setPendingPlanChange] = useState<{
@@ -1428,6 +1435,13 @@ export default function App() {
     void invoke<boolean>("get_autostart_enabled")
       .then((enabled) => setAutostartEnabled(enabled))
       .catch(() => setAutostartEnabled(false));
+    void invoke<{ enabled: boolean; host: string; port: number }>("get_external_headroom_config")
+      .then((config) => {
+        setExternalEnabled(config.enabled);
+        setExternalHost(config.host);
+        setExternalPort(config.port);
+      })
+      .catch((e) => console.error("Failed to load external config:", e));
   }, [activeView]);
 
   async function handleAutostartToggle(nextEnabled: boolean) {
@@ -1452,6 +1466,98 @@ export default function App() {
         typeof error === "string" ? error : "Uninstall failed. Please try again."
       );
       setUninstallBusy(false);
+    }
+  }
+
+  async function handleToggleExternal(nextEnabled: boolean) {
+    setExternalEnabled(nextEnabled);
+    setSaveBusy(true);
+    try {
+      await invoke("set_external_headroom_config", {
+        config: {
+          enabled: nextEnabled,
+          host: externalHost,
+          port: externalPort
+        }
+      });
+      await refreshRuntimeStatus();
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setSaveBusy(false);
+    }
+  }
+
+  async function handleSaveExternalConfig() {
+    setSaveBusy(true);
+    try {
+      await invoke("set_external_headroom_config", {
+        config: {
+          enabled: externalEnabled,
+          host: externalHost,
+          port: externalPort
+        }
+      });
+      await refreshRuntimeStatus();
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setSaveBusy(false);
+    }
+  }
+
+  async function handleDetectHeadroom() {
+    setDetectBusy(true);
+    setDetectionResult(null);
+    setDetectedRunningPort(null);
+    try {
+      const result = await invoke<{
+        binaryPath?: string;
+        inPath: boolean;
+        runningLocally: boolean;
+        runningPort?: number;
+      } | null>("detect_installed_headroom");
+
+      if (!result) {
+        setDetectionResult("No headroom installation detected.");
+      } else {
+        let msg = "";
+        if (result.runningLocally && result.runningPort) {
+          setDetectedRunningPort(result.runningPort);
+          msg += `Found running headroom instance. `;
+        }
+        if (result.binaryPath) {
+          msg += `Headroom binary found at ${result.binaryPath}.`;
+        } else {
+          msg += `Headroom is not installed on this system.`;
+        }
+        setDetectionResult(msg);
+      }
+    } catch (e: any) {
+      setDetectionResult(`Detection failed: ${e.message || e}`);
+    } finally {
+      setDetectBusy(false);
+    }
+  }
+
+  async function handleApplyDetected(port: number) {
+    setExternalEnabled(true);
+    setExternalHost("127.0.0.1");
+    setExternalPort(port);
+    setSaveBusy(true);
+    try {
+      await invoke("set_external_headroom_config", {
+        config: {
+          enabled: true,
+          host: "127.0.0.1",
+          port: port
+        }
+      });
+      await refreshRuntimeStatus();
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setSaveBusy(false);
     }
   }
 
@@ -4607,6 +4713,110 @@ export default function App() {
                     {pricingStatus.claude.profileFetchError}
                   </p>
                 ) : null}
+              </article>
+
+              <article className="soft-card panel-card">
+                <div className="panel-card__header">
+                  <div>
+                    <h3>Headroom connection</h3>
+                  </div>
+                  <div>
+                    <p>
+                      Configure headroom to connect to an existing install on this machine or another device on the local network.
+                    </p>
+                  </div>
+                </div>
+                <div className="connector-list" style={{ borderTop: "1px solid var(--border-subtle, rgba(0,0,0,0.05))" }}>
+                  <article className="connector-item">
+                    <div>
+                      <h3>Use external headroom</h3>
+                      <p className="connector-item__reason">
+                        Interface with a headroom instance running outside this app (e.g. CLI or another machine).
+                      </p>
+                    </div>
+                    <div className="connector-item__controls">
+                      <button
+                        aria-checked={externalEnabled}
+                        className={`connector-switch${externalEnabled ? " is-on" : ""}`}
+                        disabled={saveBusy}
+                        onClick={() => void handleToggleExternal(!externalEnabled)}
+                        role="switch"
+                        type="button"
+                      >
+                        <span className="connector-switch__thumb" />
+                      </button>
+                    </div>
+                  </article>
+                </div>
+                
+                {externalEnabled && (
+                  <div style={{ display: "flex", flexWrap: "wrap", gap: "12px", padding: "16px", borderTop: "1px solid var(--border-subtle, rgba(0,0,0,0.05))" }}>
+                    <label className="pricing-auth-field" style={{ flex: "1 1 200px" }}>
+                      <span>Host / IP</span>
+                      <div className="pricing-auth-field__input">
+                        <input
+                          type="text"
+                          value={externalHost}
+                          onChange={(e) => setExternalHost(e.target.value)}
+                          placeholder="127.0.0.1"
+                        />
+                      </div>
+                    </label>
+                    <label className="pricing-auth-field" style={{ flex: "1 1 100px" }}>
+                      <span>Port</span>
+                      <div className="pricing-auth-field__input">
+                        <input
+                          type="number"
+                          value={externalPort || ""}
+                          onChange={(e) => setExternalPort(parseInt(e.target.value) || 0)}
+                          placeholder="6768"
+                        />
+                      </div>
+                    </label>
+                    <div style={{ display: "flex", width: "100%", justifyContent: "flex-end", marginTop: "4px" }}>
+                      <button
+                        className="primary-button"
+                        style={{ padding: "6px 12px", fontSize: "12px" }}
+                        onClick={() => void handleSaveExternalConfig()}
+                        disabled={saveBusy || !externalHost || !externalPort}
+                        type="button"
+                      >
+                        {saveBusy ? "Connecting..." : "Save & Connect"}
+                      </button>
+                    </div>
+                  </div>
+                )}
+                
+                <div style={{ display: "flex", flexDirection: "column", gap: "8px", padding: "16px", borderTop: "1px solid var(--border-subtle, rgba(0,0,0,0.05))" }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: "12px", flexWrap: "wrap" }}>
+                    <button
+                      className="secondary-button secondary-button--small"
+                      onClick={() => void handleDetectHeadroom()}
+                      disabled={detectBusy}
+                      type="button"
+                    >
+                      {detectBusy ? "Detecting..." : "Detect headroom install"}
+                    </button>
+                    {detectionResult && (
+                      <span style={{ fontSize: "12px", color: "var(--text-subtle)" }}>
+                        {detectionResult}
+                      </span>
+                    )}
+                  </div>
+                  {detectedRunningPort && (
+                    <div style={{ fontSize: "12px", marginTop: "4px", color: "var(--text-subtle)" }}>
+                      💡 Found headroom running on port {detectedRunningPort}.{" "}
+                      <button
+                        className="link-button"
+                        style={{ fontSize: "12px", padding: 0 }}
+                        onClick={() => void handleApplyDetected(detectedRunningPort)}
+                        type="button"
+                      >
+                        Use this connection
+                      </button>
+                    </div>
+                  )}
+                </div>
               </article>
 
               <article className="soft-card panel-card">

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -148,6 +148,7 @@ export interface RuntimeStatus {
   platform: string;
   supportTier: string;
   installed: boolean;
+  localRuntimeInstalled: boolean;
   running: boolean;
   starting: boolean;
   paused: boolean;

--- a/src/lib/urgentNotifications.test.ts
+++ b/src/lib/urgentNotifications.test.ts
@@ -71,6 +71,7 @@ function makeRuntime(overrides: Partial<RuntimeStatus> = {}): RuntimeStatus {
     platform: "darwin",
     supportTier: "supported",
     installed: true,
+    localRuntimeInstalled: true,
     running: true,
     starting: false,
     paused: false,


### PR DESCRIPTION
Fixes #36 

Introduce support for connecting to an external Headroom instance by host and port. Added ExternalHeadroomConfig and DetectedHeadroom models, backend_port host storage (get_host/set_host and DEFAULT_BACKEND_HOST), and logic to reset test state. Implemented tauri commands to get/set the external config and to detect an installed/running Headroom binary (detect_installed_headroom).

State and AppState were extended: LaunchProfile now includes external_headroom_enabled/host/port, AppState exposes external_headroom_config and set_external_headroom_config, and initialization respects the saved external settings. ensure_headroom_running, memory export, delete_live_learning and other runtime checks now consider external mode and use the configured host+port. proxy_intercept and connection probes were updated to use the configured host rather than hard-coded 127.0.0.1. Added probing helpers to check common endpoints and resolve the appropriate headroom binary when needed.

UI: App.tsx gains controls to toggle external Headroom, edit host/port, detect local installs, apply detected running port, and persist/connect via the new tauri commands.

Also included small test adjustments (launch profile defaults and a date formatting expectation) to match the new defaults and behaviors.

This PR was generated with Antigravity.  I've not had a chance to test it yet, but am about it.