### PR TITLE
feat(grok-build): add Grok Build client connector support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ src-tauri/target
 src-tauri/gen
 announcement-recordings
 headroom_memory.db
+
+# Local git worktrees (isolated feature branches)
+.worktrees/

--- a/src-tauri/src/client_adapters.rs
+++ b/src-tauri/src/client_adapters.rs
@@ -18,6 +18,7 @@ use crate::storage::{app_data_dir, config_file};
 const HEADROOM_PROXY_URL: &str = "http://127.0.0.1:6767";
 const HEADROOM_ANTHROPIC_BASE_URL: &str = "http://127.0.0.1:6767";
 const HEADROOM_OPENAI_BASE_URL: &str = "http://127.0.0.1:6767/v1";
+const HEADROOM_GROK_PROXY_BASE_URL: &str = "http://127.0.0.1:6767/v1";
 const ZSH_PROFILE_FILE: &str = ".zprofile";
 const ZSH_RC_FILE: &str = ".zshrc";
 const BASH_PROFILE_FILE: &str = ".bash_profile";
@@ -39,7 +40,7 @@ struct ManagedClientSpec {
     name: &'static str,
 }
 
-const MANAGED_CLIENT_SPECS: [ManagedClientSpec; 2] = [
+const MANAGED_CLIENT_SPECS: [ManagedClientSpec; 3] = [
     ManagedClientSpec {
         id: "claude_code",
         name: "Claude Code",
@@ -47,6 +48,10 @@ const MANAGED_CLIENT_SPECS: [ManagedClientSpec; 2] = [
     ManagedClientSpec {
         id: "codex",
         name: "Codex",
+    },
+    ManagedClientSpec {
+        id: "grok_build",
+        name: "Grok Build",
     },
 ];
 
@@ -63,6 +68,7 @@ pub fn detect_clients() -> Vec<ClientStatus> {
     vec![
         detect_claude_code_client(is_configured(&setup_state, "claude_code")),
         detect_codex_client(is_configured(&setup_state, "codex")),
+        detect_grok_build_client(is_configured(&setup_state, "grok_build")),
     ]
 }
 
@@ -342,6 +348,30 @@ pub fn apply_client_setup(client_id: &str) -> Result<ClientSetupResult> {
             // Codex history list stays whole once it routes through Headroom.
             retag_codex_thread_providers(CODEX_NATIVE_PROVIDER, CODEX_HEADROOM_PROVIDER);
         }
+        "grok_build" => {
+            let shell_targets = resolve_client_shell_targets(&state, client_id)?;
+            let mut updates = configure_grok_proxy_block()?;
+            let env_block = format!(
+                "export GROK_CLI_CHAT_PROXY_BASE_URL={}",
+                HEADROOM_GROK_PROXY_BASE_URL
+            );
+            match shell_step_best_effort(configure_shell_block(
+                &shell_targets,
+                "grok_build",
+                &env_block,
+            ))? {
+                Some(mut shell) => {
+                    updates.0.append(&mut shell.0);
+                    updates.1.append(&mut shell.1);
+                }
+                None => shell_unwritable = true,
+            }
+            changed_files.extend(updates.0);
+            backup_files.extend(updates.1);
+            state
+                .managed_shell_files
+                .insert(state_id.clone(), serialize_paths(&shell_targets));
+        }
         other => return Err(anyhow!("Automatic setup is not supported yet for {other}.",)),
     }
 
@@ -386,6 +416,7 @@ pub fn apply_client_setup(client_id: &str) -> Result<ClientSetupResult> {
                 "Run one {} prompt and verify activity appears in Headroom.",
                 match normalized_setup_id(client_id) {
                     "codex_cli" => "Codex",
+                    "grok_build" => "Grok Build",
                     _ => "Claude Code",
                 }
             ));
@@ -526,6 +557,39 @@ pub fn verify_client_setup(client_id: &str) -> Result<ClientSetupVerification> {
                 }
             });
         }
+        "grok_build" => {
+            let state = load_setup_state();
+            let shell_targets = resolve_client_shell_targets(&state, client_id)?;
+            let shell_ok = shell_block_contains_in_files(
+                &shell_targets,
+                "grok_build",
+                "GROK_CLI_CHAT_PROXY_BASE_URL",
+                HEADROOM_GROK_PROXY_BASE_URL,
+            )?;
+            let toml_ok = grok_proxy_block_matches()?;
+
+            if shell_ok {
+                checks.push(
+                    "Found Grok Build GROK_CLI_CHAT_PROXY_BASE_URL export in managed shell block."
+                        .into(),
+                );
+            }
+            if toml_ok {
+                checks
+                    .push("Found Headroom-managed proxy block in ~/.grok/config.toml.".into());
+            }
+            if !toml_ok {
+                failures.push(
+                    "Headroom-managed proxy block was not found in ~/.grok/config.toml.".into(),
+                );
+            }
+            if !shell_ok {
+                failures.push(
+                    "Grok Build GROK_CLI_CHAT_PROXY_BASE_URL export was not found in shell profiles."
+                        .into(),
+                );
+            }
+        }
         other => return Err(anyhow!("Verification is not supported yet for {other}.",)),
     }
 
@@ -553,6 +617,10 @@ pub fn is_claude_code_enabled() -> bool {
 
 pub fn is_codex_enabled() -> bool {
     is_configured(&load_setup_state(), "codex_cli")
+}
+
+pub fn is_grok_build_enabled() -> bool {
+    is_configured(&load_setup_state(), "grok_build")
 }
 
 pub fn list_client_connectors(
@@ -659,6 +727,7 @@ pub fn disable_client_setup(client_id: &str) -> Result<()> {
                 .cloned();
             remove_vscode_connector_keys(preserved.as_deref())?;
         }
+        "grok_build" => disable_grok_build()?,
         other => {
             return Err(anyhow!(
                 "Automatic setup disable is not supported yet for {other}.",
@@ -863,6 +932,7 @@ pub fn perform_full_cleanup() -> Vec<String> {
     backup_targets.push(codex_config_toml_path());
     backup_targets.push(codex_hooks_json_path());
     backup_targets.push(codex_guard_hook_path());
+    backup_targets.push(grok_config_toml_path());
     backup_targets.push(
         home_dir()
             .join("Library")
@@ -2438,6 +2508,158 @@ fn bracket_delta(line: &str) -> i32 {
     delta
 }
 
+const GROK_PROXY_BLOCK_ID: &str = "grok_build_proxy";
+
+fn grok_config_toml_path() -> PathBuf {
+    grok_home().join("config.toml")
+}
+
+fn grok_proxy_body() -> String {
+    format!(
+        "[model.grok-build]\nbase_url = \"{base}\"",
+        base = HEADROOM_GROK_PROXY_BASE_URL
+    )
+}
+
+fn strip_grok_managed_toml(content: &str) -> String {
+    strip_marker_block(content, GROK_PROXY_BLOCK_ID)
+}
+
+fn render_grok_config(existing: &str) -> String {
+    let mid = strip_grok_managed_toml(existing);
+    let mid = mid.trim();
+
+    let mut out = codex_marker_block(GROK_PROXY_BLOCK_ID, &grok_proxy_body());
+    if !mid.is_empty() {
+        out.push('\n');
+        out.push_str(mid);
+        out.push('\n');
+    }
+    out
+}
+
+fn configure_grok_proxy_block() -> Result<(Vec<String>, Vec<String>)> {
+    let path = grok_config_toml_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+    let existing = if path.exists() {
+        std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?
+    } else {
+        String::new()
+    };
+
+    let updated = render_grok_config(&existing);
+    if updated == existing {
+        return Ok((Vec::new(), Vec::new()));
+    }
+
+    let backup = backup_if_exists(&path)?;
+    std::fs::write(&path, &updated).with_context(|| format!("writing {}", path.display()))?;
+
+    let mut backup_files = Vec::new();
+    if let Some(backup_path) = backup {
+        backup_files.push(backup_path.display().to_string());
+    }
+    Ok((vec![path.display().to_string()], backup_files))
+}
+
+fn grok_proxy_block_matches() -> Result<bool> {
+    let path = grok_config_toml_path();
+    if !path.exists() {
+        return Ok(false);
+    }
+    let content =
+        std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    let base_url = format!("base_url = \"{}\"", HEADROOM_GROK_PROXY_BASE_URL);
+    Ok(marker_block_contains(&content, GROK_PROXY_BLOCK_ID, &base_url))
+}
+
+fn remove_grok_proxy_block() -> Result<()> {
+    let path = grok_config_toml_path();
+    if !path.exists() {
+        return Ok(());
+    }
+    let existing =
+        std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    let stripped = strip_grok_managed_toml(&existing);
+    let normalized = {
+        let trimmed = stripped.trim();
+        if trimmed.is_empty() {
+            String::new()
+        } else {
+            format!("{trimmed}\n")
+        }
+    };
+    if normalized == existing {
+        return Ok(());
+    }
+    let _ = backup_if_exists(&path)?;
+    std::fs::write(&path, &normalized).with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
+}
+
+fn disable_grok_build() -> Result<()> {
+    remove_grok_proxy_block()?;
+    let shell_targets = all_shell_paths();
+    let _ = remove_shell_block(&shell_targets, "grok_build");
+    Ok(())
+}
+
+/// Rewrite the `command` of the `[mcp_servers.headroom]` table in
+/// `~/.grok/config.toml` to the absolute `entrypoint`. Mirrors
+/// [`pin_codex_mcp_command`]: the upstream Python registrar writes a bare
+/// `command = "headroom"` that relies on PATH, which dangles when the managed
+/// runtime relocates.
+pub fn pin_grok_mcp_command(entrypoint: &Path) -> Result<Option<String>> {
+    let path = grok_config_toml_path();
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content =
+        std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+
+    let target_line = format!("command = {}", toml_basic_string(&entrypoint.to_string_lossy()));
+
+    let mut in_headroom_table = false;
+    let mut replaced = false;
+    let mut out: Vec<String> = Vec::with_capacity(content.lines().count());
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            in_headroom_table = trimmed == "[mcp_servers.headroom]";
+            out.push(line.to_string());
+            continue;
+        }
+        if in_headroom_table
+            && !replaced
+            && trimmed
+                .split_once('=')
+                .is_some_and(|(key, _)| key.trim() == "command")
+        {
+            out.push(target_line.clone());
+            replaced = true;
+            continue;
+        }
+        out.push(line.to_string());
+    }
+
+    if !replaced {
+        return Ok(None);
+    }
+    let mut rebuilt = out.join("\n");
+    if content.ends_with('\n') {
+        rebuilt.push('\n');
+    }
+    if rebuilt == content {
+        return Ok(None);
+    }
+    let _ = backup_if_exists(&path)?;
+    std::fs::write(&path, rebuilt).with_context(|| format!("writing {}", path.display()))?;
+    Ok(Some(path.display().to_string()))
+}
+
 fn toml_basic_string(value: &str) -> String {
     format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
 }
@@ -3962,6 +4184,14 @@ fn codex_home() -> PathBuf {
         .unwrap_or_else(|| home_dir().join(".codex"))
 }
 
+/// Grok Build's home directory. Honors `$GROK_HOME` when set, else `~/.grok`.
+fn grok_home() -> PathBuf {
+    std::env::var_os("GROK_HOME")
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home_dir().join(".grok"))
+}
+
 fn detect_claude_code_client(configured: bool) -> ClientStatus {
     let executable = claude_code_candidate_paths()
         .into_iter()
@@ -4148,6 +4378,79 @@ fn detect_codex_client(configured: bool) -> ClientStatus {
         health: ClientHealth::NotDetected,
         notes: vec!["Not detected on this machine yet.".into()],
     }
+}
+
+fn detect_grok_build_client(configured: bool) -> ClientStatus {
+    let executable = grok_candidate_paths()
+        .into_iter()
+        .find(|path| path.exists())
+        .or_else(|| find_on_path(&["grok"]));
+
+    let detected = executable
+        .as_ref()
+        .map(|path| format!("Detected at {}", path.display()))
+        .or_else(|| {
+            grok_user_state_exists()
+                .then(|| format!("Detected Grok Build data in {}.", grok_home().display()))
+        });
+
+    if let Some(detected_note) = detected {
+        return ClientStatus {
+            id: "grok_build".into(),
+            name: "Grok Build".into(),
+            installed: true,
+            configured,
+            health: if configured {
+                ClientHealth::Healthy
+            } else {
+                ClientHealth::Attention
+            },
+            notes: if configured {
+                vec![detected_note, "Configured by Headroom.".into()]
+            } else {
+                vec![
+                    detected_note,
+                    "Route Grok Build through Headroom's localhost proxy so prompts stay lean."
+                        .into(),
+                ]
+            },
+        };
+    }
+
+    ClientStatus {
+        id: "grok_build".into(),
+        name: "Grok Build".into(),
+        installed: false,
+        configured: false,
+        health: ClientHealth::NotDetected,
+        notes: vec!["Not detected on this machine yet.".into()],
+    }
+}
+
+fn grok_candidate_paths() -> Vec<PathBuf> {
+    let home = home_dir();
+    let mut candidates = vec![
+        PathBuf::from("/usr/local/bin/grok"),
+        PathBuf::from("/opt/homebrew/bin/grok"),
+        home.join(".grok").join("downloads").join("grok-macos-aarch64"),
+        home.join(".grok").join("downloads").join("grok-macos-x86_64"),
+    ];
+
+    let user_bin_dirs = vec![
+        home.join(".local").join("bin"),
+        home.join("bin"),
+        home.join(".cargo").join("bin"),
+    ];
+    candidates.extend(binary_candidates_in_dirs(&user_bin_dirs, &["grok"]));
+    dedupe_paths(candidates)
+}
+
+fn grok_user_state_exists() -> bool {
+    let grok_root = grok_home();
+    grok_root.join("config.toml").exists()
+        || grok_root.join("auth.json").exists()
+        || grok_root.join("sessions").exists()
+        || grok_root.join("downloads").exists()
 }
 
 fn codex_candidate_paths() -> Vec<PathBuf> {
@@ -6134,6 +6437,49 @@ export ANTHROPIC_BASE_URL=http://127.0.0.1:6767
         assert!(
             !combined_after.contains("OPENAI_BASE_URL=http://127.0.0.1:6767/v1"),
             "shell export removed on disable, got:\n{combined_after}"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn apply_then_verify_then_disable_grok_build_round_trip() {
+        let home = TestHome::new();
+        fs::write(home.path().join(".zshrc"), "# user zshrc\n").unwrap();
+        fs::write(home.path().join(".zshenv"), "# user zshenv\n").unwrap();
+
+        let result =
+            super::apply_client_setup("grok_build").expect("apply_client_setup succeeds");
+        assert!(result.applied);
+        assert_eq!(result.client_id, "grok_build");
+
+        let config_toml = home.path().join(".grok").join("config.toml");
+        let toml = fs::read_to_string(&config_toml).expect("grok config.toml written");
+        assert!(
+            toml.contains("# >>> headroom:grok_build_proxy >>>"),
+            "managed marker present, got:\n{toml}"
+        );
+        assert!(
+            toml.contains("base_url = \"http://127.0.0.1:6767/v1\""),
+            "proxy base_url set, got:\n{toml}"
+        );
+
+        let zshrc = fs::read_to_string(home.path().join(".zshrc")).unwrap();
+        let zshenv = fs::read_to_string(home.path().join(".zshenv")).unwrap();
+        let combined = format!("{zshrc}\n{zshenv}");
+        assert!(
+            combined.contains("GROK_CLI_CHAT_PROXY_BASE_URL=http://127.0.0.1:6767/v1"),
+            "GROK_CLI_CHAT_PROXY_BASE_URL exported, got:\n{combined}"
+        );
+
+        let verification =
+            super::verify_client_setup("grok_build").expect("verify_client_setup succeeds");
+        assert!(verification.failures.is_empty(), "{:?}", verification.failures);
+
+        super::disable_client_setup("grok_build").expect("disable_client_setup succeeds");
+        let toml_after = fs::read_to_string(&config_toml).unwrap_or_default();
+        assert!(
+            !toml_after.contains("# >>> headroom:grok_build_proxy >>>"),
+            "managed block removed on disable, got:\n{toml_after}"
         );
     }
 

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -3585,6 +3585,7 @@ impl ToolManager {
         // absolute entrypoint so it survives runtime moves. Best-effort: a
         // failure here must not break the Claude integration below.
         let _ = crate::client_adapters::pin_codex_mcp_command(&entrypoint);
+        let _ = crate::client_adapters::pin_grok_mcp_command(&entrypoint);
 
         // Ground truth: did Claude Code actually see the server? The Python
         // CLI's fallback branch writes ~/.claude/mcp.json (legacy, ignored by

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -235,7 +235,9 @@ const connectorSetupDetails: Record<string, string> = {
   claude_code:
     "Headroom injects ANTHROPIC_BASE_URL into shell profiles and ~/.claude/settings.json so Claude Code connects through Headroom. Token-saving add-ons like RTK are optional: install them from the add-ons list and Headroom wires up the PATH entry and auto-rewrite hook only then.",
   codex:
-    "Headroom writes a managed provider block to ~/.codex/config.toml and exports OPENAI_BASE_URL in your shell profiles so Codex connects through Headroom. It also installs a guard hook that warns you inside Codex if routing ever breaks - run /hooks in Codex once to trust it (re-trust after a Headroom update)."
+    "Headroom writes a managed provider block to ~/.codex/config.toml and exports OPENAI_BASE_URL in your shell profiles so Codex connects through Headroom. It also installs a guard hook that warns you inside Codex if routing ever breaks - run /hooks in Codex once to trust it (re-trust after a Headroom update).",
+  grok_build:
+    "Headroom writes a managed proxy block to ~/.grok/config.toml and exports GROK_CLI_CHAT_PROXY_BASE_URL in your shell profiles so Grok Build connects through Headroom."
 };
 
 const connectorSupportWarnings: Record<string, string> = {};
@@ -244,7 +246,9 @@ const connectorUnavailableReasons: Record<string, string> = {
   claude_code:
     "Claude Code was not detected. Install Claude Code and restart Headroom.",
   codex:
-    "Codex was not detected. Install the Codex CLI and restart Headroom."
+    "Codex was not detected. Install the Codex CLI and restart Headroom.",
+  grok_build:
+    "Grok Build was not detected. Install Grok Build and restart Headroom."
 };
 
 const launcherConnectorFallback: ClientConnectorStatus[] = [
@@ -258,6 +262,13 @@ const launcherConnectorFallback: ClientConnectorStatus[] = [
   {
     clientId: "codex",
     name: "Codex",
+    installed: false,
+    enabled: false,
+    verified: false
+  },
+  {
+    clientId: "grok_build",
+    name: "Grok Build",
     installed: false,
     enabled: false,
     verified: false
@@ -2717,7 +2728,8 @@ export default function App() {
     return (
       connector.installed ||
       connector.clientId === "claude_code" ||
-      connector.clientId === "codex"
+      connector.clientId === "codex" ||
+      connector.clientId === "grok_build"
     );
   }
 

--- a/src/lib/dashboardHelpers.test.ts
+++ b/src/lib/dashboardHelpers.test.ts
@@ -176,16 +176,17 @@ describe("dashboard helpers", () => {
     ]);
   });
 
-  it("keeps codex alongside claude_code as a supported connector", () => {
+  it("keeps codex and grok_build alongside claude_code as supported connectors", () => {
     const connectors: ClientConnectorStatus[] = [
       { clientId: "codex", name: "Codex", installed: true, enabled: false, verified: false },
+      { clientId: "grok_build", name: "Grok Build", installed: true, enabled: false, verified: false },
       { clientId: "claude_code", name: "Claude Code", installed: true, enabled: true, verified: true },
       { clientId: "cursor", name: "Cursor", installed: true, enabled: false, verified: false }
     ];
 
     expect(
       aggregateClientConnectors(connectors).map((connector) => connector.clientId).sort()
-    ).toEqual(["claude_code", "codex"]);
+    ).toEqual(["claude_code", "codex", "grok_build"]);
   });
 
   it("reports enabled supported connectors regardless of which tool", () => {
@@ -234,7 +235,7 @@ describe("dashboard helpers", () => {
 });
 
 describe("mergeProviderSavingsForDisplay", () => {
-  it("folds anthropic and unknown into Claude Code (listed first) and openai into Codex", () => {
+  it("folds anthropic and unknown into Claude Code, openai into Codex, and xai into Grok Build", () => {
     const merged = mergeProviderSavingsForDisplay([
       {
         provider: "openai",
@@ -256,6 +257,13 @@ describe("mergeProviderSavingsForDisplay", () => {
         estimatedTokensSaved: 15,
         actualCostUsd: 0.03,
         totalTokensSent: 20
+      },
+      {
+        provider: "xai",
+        estimatedSavingsUsd: 0.02,
+        estimatedTokensSaved: 25,
+        actualCostUsd: 0.08,
+        totalTokensSent: 50
       }
     ]);
 
@@ -273,6 +281,13 @@ describe("mergeProviderSavingsForDisplay", () => {
         estimatedTokensSaved: 40,
         actualCostUsd: 0.16,
         totalTokensSent: 80
+      },
+      {
+        label: "Grok Build",
+        estimatedSavingsUsd: 0.02,
+        estimatedTokensSaved: 25,
+        actualCostUsd: 0.08,
+        totalTokensSent: 50
       }
     ]);
   });

--- a/src/lib/dashboardHelpers.ts
+++ b/src/lib/dashboardHelpers.ts
@@ -220,17 +220,31 @@ export function mergeProviderSavingsForDisplay(
       estimatedTokensSaved: 0,
       actualCostUsd: 0,
       totalTokensSent: 0
+    },
+    grok: {
+      label: "Grok Build",
+      count: 0,
+      estimatedSavingsUsd: 0,
+      estimatedTokensSaved: 0,
+      actualCostUsd: 0,
+      totalTokensSent: 0
     }
   };
   for (const point of byProvider) {
-    const group = point.provider.toLowerCase() === "openai" ? groups.codex : groups.claude;
+    const provider = point.provider.toLowerCase();
+    const group =
+      provider === "openai"
+        ? groups.codex
+        : provider === "xai"
+          ? groups.grok
+          : groups.claude;
     group.count += 1;
     group.estimatedSavingsUsd += point.estimatedSavingsUsd;
     group.estimatedTokensSaved += point.estimatedTokensSaved;
     group.actualCostUsd += point.actualCostUsd;
     group.totalTokensSent += point.totalTokensSent;
   }
-  return [groups.claude, groups.codex]
+  return [groups.claude, groups.codex, groups.grok]
     .filter((group) => group.count > 0)
     .map(({ count: _count, ...display }) => display);
 }
@@ -369,7 +383,7 @@ export function formatLearnStatus(project: {
   return `last scan: ${diffDays} days ago`;
 }
 
-const SUPPORTED_CONNECTOR_IDS = new Set(["claude_code", "codex"]);
+const SUPPORTED_CONNECTOR_IDS = new Set(["claude_code", "codex", "grok_build"]);
 
 export function aggregateClientConnectors(connectors: ClientConnectorStatus[]) {
   return connectors.filter((connector) =>


### PR DESCRIPTION
## Summary

Desktop companion to the upstream Headroom Grok Build work in headroomlabs-ai/headroom#1629.

Adds `grok_build` as a third managed client connector alongside Claude Code and Codex:

- **Detection** — `~/.grok`, `GROK_HOME`, and the `grok` binary
- **Setup** — managed `[model.grok-build] base_url` proxy block in `~/.grok/config.toml` plus `GROK_CLI_CHAT_PROXY_BASE_URL` shell export
- **MCP pinning** — `pin_grok_mcp_command()` on launch so `[mcp_servers.headroom]` survives runtime relocations (same pattern as Codex)
- **UI** — connector appears in launcher/setup, savings chart attributes `xai` provider traffic to Grok Build

## Related PR

- headroomlabs-ai/headroom#1629 — `headroom wrap grok-build`, GrokRegistrar, install/telemetry wiring

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml apply_then_verify_then_disable_grok_build_round_trip`
- [x] `npm run test:frontend -- src/lib/dashboardHelpers.test.ts`
- [x] `npx tsc --noEmit`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`

## Verification evidence

_Run locally on 2026-07-01 from `.worktrees/feat-grok-build` (branch `feat/grok-build`, commit `d6fa1db`). Evidence recorded here only — not committed to the repo._

### Automated tests

**`cargo test apply_then_verify_then_disable_grok_build_round_trip`**

```
running 1 test
test client_adapters::tests::apply_then_verify_then_disable_grok_build_round_trip ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 649 filtered out; finished in 0.02s
```

**`npm run test:frontend -- src/lib/dashboardHelpers.test.ts`**

```
 ✓ src/lib/dashboardHelpers.test.ts (13 tests)

 Test Files  1 passed (1)
      Tests  13 passed (13)
```

**`npx tsc --noEmit`** — exit 0

**`cargo check --manifest-path src-tauri/Cargo.toml`** — finished successfully (one `dead_code` warning for `is_grok_build_enabled`)

### GUI screengrabs (feat/grok-build dev build)

Screenshots are hosted on a temporary draft release in the fork for PR embedding only — not added to this repo.

**Native Tauri launcher window during bootstrap** (`npm run tauri dev`, captured with `screencapture -l<windowID>`)

![Native Headroom launcher window during bootstrap](https://github.com/aashishtamsya/headroom-desktop/releases/download/untagged-0326cdabe4083d5e9580/21-launcher.png)

**Connector setup screen showing Grok Build** (feat/grok-build branch markup + `styles.css`, rendered for capture while the dev app was still on the bootstrap screen)

![Connector setup screen with Grok Build connector and setup tooltip](https://github.com/aashishtamsya/headroom-desktop/releases/download/untagged-0326cdabe4083d5e9580/23-connector-setup-grok-build.png)

_Grok Build appears alongside Claude Code and Codex in the launcher `client_setup` flow, with the managed `~/.grok/config.toml` + `GROK_CLI_CHAT_PROXY_BASE_URL` setup copy from `connectorSetupDetails.grok_build`._

**Grok Build config injection shape (managed proxy block)**

![Grok Build proxy override injected into config.toml](https://github.com/aashishtamsya/headroom-desktop/releases/download/untagged-0326cdabe4083d5e9580/02-config-injection.png)

## Notes

- Includes `chore: ignore local .worktrees directory` from local dev worktree setup.
- Temporary screenshot assets: draft release `pr42-evidence-temp` on `aashishtamsya/headroom-desktop` (for PR evidence only).
