### PR TITLE
fix(homebrew): rename cask token to headroom, bump to 0.7.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 **Option A — Homebrew:**
 
 ```bash
-brew install --cask headroom-desktop
+brew install --cask headroom
 ```
 
 **Option B — manual download:**

--- a/docs/macos-release.md
+++ b/docs/macos-release.md
@@ -253,8 +253,13 @@ After the stable workflow publishes `vX.Y.Z`, it re-points the rolling `staging`
 Homebrew users can install the latest signed release with:
 
 ```bash
-brew install --cask headroom-desktop
+brew install --cask headroom
 ```
+
+The cask token is `headroom`, not `headroom-desktop`. Homebrew's new-cask audit
+rejects any token ending in `desktop` (also `mac`, `osx`, `macos`, `launcher`),
+and the rule is `--new`-only so a plain `brew audit --cask --strict` run will not
+catch a rename back. Verify with `brew audit --cask --new --strict headroom`.
 
 The cask is versioned (`version "X.Y.Z"`, not `version :latest`) and points at
 the tagged release's `Headroom_X.Y.Z_mac.dmg` asset directly, since each stable
@@ -265,12 +270,12 @@ built-in updater between cask bumps.
 
 ### Maintaining the cask
 
-The cask source at `packaging/homebrew/headroom-desktop.rb` in this repo is a
+The cask source at `packaging/homebrew/headroom.rb` in this repo is a
 submission template, not a maintained artifact: `scripts/bump-version.sh` only
 touches `package.json`, `tauri.conf.json`, and `Cargo.toml`, and the `sha256`
 can't be filled in until CI has built and notarized the DMG, so it goes stale
 on the next release. To ship it, open a PR against
 [`homebrew/homebrew-cask`](https://github.com/homebrew/homebrew-cask) adding the
-file at `Casks/h/headroom-desktop.rb`. Once merged there, the tap becomes the
+file at `Casks/h/headroom.rb`. Once merged there, the tap becomes the
 source of truth and BrewTestBot maintains `version` and `sha256` automatically
 via `livecheck`.

--- a/packaging/homebrew/headroom.rb
+++ b/packaging/homebrew/headroom.rb
@@ -1,10 +1,10 @@
-cask "headroom-desktop" do
-  version "0.7.4"
-  sha256 "ca58f2b017395c352a6961bb43a53d375827f5e43694b542d60576b86be05734"
+cask "headroom" do
+  version "0.7.5"
+  sha256 "6c31a0511430e2a7b235ca290c4ada1b7de2f8051ccad35c84bc18ecb46abad2"
 
   url "https://github.com/gglucass/headroom-desktop/releases/download/v#{version}/Headroom_#{version}_mac.dmg",
       verified: "github.com/gglucass/headroom-desktop/"
-  name "Headroom Desktop"
+  name "Headroom"
   desc "Reduce token usage for Claude Code and Codex"
   homepage "https://extraheadroom.com/"
 


### PR DESCRIPTION
Follow-up to #48. The cask as merged cannot be submitted to `homebrew/homebrew-cask`.

## The problem

```
$ brew audit --cask --new --strict headroom-desktop
Error: 1 problem in 1 cask detected.
 - cask token mentions desktop
```

`Cask::Audit#audit_token_bad_words` rejects any token ending in `desktop` (also `mac`, `osx`, `macos`, `launcher`). The rule returns early unless `new_cask?`, so the `brew audit --cask --strict` run we both did on #48 passes and never surfaces it. It only fires under `--new`, which is what homebrew-cask CI runs on a new submission.

The token was originally `headroom` and commit `a8f8664` renamed it to `headroom-desktop`, which is the rename that breaks submission.

## Changes

- `packaging/homebrew/headroom-desktop.rb` -> `packaging/homebrew/headroom.rb`, token `headroom`. Confirmed free upstream: `formulae.brew.sh/api/cask/headroom.json` and `/api/formula/headroom.json` both 404.
- `name "Headroom Desktop"` -> `name "Headroom"`, matching the actual bundle (`Headroom.app`).
- `version "0.7.4"` -> `"0.7.5"` with the verified digest. v0.7.5 published today, so the 0.7.4 pin was already superseded and homebrew-cask CI rejects a stale version.
- `brew install --cask headroom` in README and `docs/macos-release.md`.
- Doc note recording why the token cannot end in `desktop`, and that plain `--strict` will not catch a rename back.

## Verification

```
$ brew style --cask headroom
1 file inspected, no offenses detected

$ brew audit --cask --new --strict headroom
(no output, exit 0)

$ brew livecheck --cask headroom
headroom: 0.7.5 ==> 0.7.5
```

sha256 confirmed against the release asset:

```
$ shasum -a 256 Headroom_0.7.5_mac.dmg
6c31a0511430e2a7b235ca290c4ada1b7de2f8051ccad35c84bc18ecb46abad2
```

Once this lands, the `homebrew/homebrew-cask` PR adds this file at `Casks/h/headroom.rb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)