### PR TITLE
Flip the watchdog bypass before capturing give-up diagnostics

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5453,10 +5453,28 @@ fn spawn_proxy_watchdog(app: AppHandle) {
                 log::info!(
                     "watchdog: giving up after {MAX_CONSECUTIVE_FAILURES} failures; pausing runtime and bypassing to Anthropic"
                 );
+                // Flip bypass FIRST so the Rust intercept passes new
+                // requests straight through to Anthropic instead of returning
+                // 502 in the window between Python being torn down and the
+                // user noticing. See proxy_intercept.rs:161 — without this,
+                // every request lands on the unreachable backend branch.
+                //
+                // "First" means before the diagnostic capture below, not just
+                // before stop_headroom: capture_watchdog_give_up re-probes the
+                // backend and sleeps ~4s to sample a CPU rate, so capturing
+                // first held every request on the dead-backend branch for that
+                // whole window purely to decide a Sentry level. Storing the
+                // flag tears nothing down, so the capture still observes the
+                // same pre-teardown state.
+                state
+                    .proxy_bypass
+                    .store(true, std::sync::atomic::Ordering::Release);
                 // Capture once per down episode, BEFORE stop_headroom tears
                 // down the tracked child and the proxy log handle, so the
                 // exit status and log tail reflect the failure we're about
-                // to recover from.
+                // to recover from. `bypass_active` is the snapshot read at the
+                // top of this tick, so the flip above does not change what is
+                // reported.
                 capture_watchdog_give_up(
                     &*state,
                     consecutive_failures,
@@ -5465,14 +5483,6 @@ fn spawn_proxy_watchdog(app: AppHandle) {
                     readyz_body,
                     last_wall_jump.map(|(at, gap)| (at.elapsed().as_secs(), gap)),
                 );
-                // Flip bypass FIRST so the Rust intercept passes new
-                // requests straight through to Anthropic instead of returning
-                // 502 in the window between Python being torn down and the
-                // user noticing. See proxy_intercept.rs:161 — without this,
-                // every request lands on the unreachable backend branch.
-                state
-                    .proxy_bypass
-                    .store(true, std::sync::atomic::Ordering::Release);
                 state.set_runtime_paused(true);
                 // Mark this as an AUTO pause (distinct from a user pause) so the
                 // self-heal loop above will keep retrying and the UI shows the
@@ -7453,6 +7463,32 @@ Some unrelated content.
         assert_eq!(auto_resume_backoff(2), Duration::from_secs(120));
         assert_eq!(auto_resume_backoff(3), Duration::from_secs(300));
         assert_eq!(auto_resume_backoff(50), Duration::from_secs(300));
+    }
+
+    /// Ordering guard for the give-up path. `capture_watchdog_give_up`
+    /// re-probes the backend and sleeps ~4s to sample a CPU rate, so running it
+    /// before the bypass flip holds every in-flight request on the unreachable
+    /// backend branch for that whole window — purely to decide a Sentry level.
+    /// Setting the flag tears nothing down, so it must come first.
+    #[test]
+    fn watchdog_give_up_flips_bypass_before_capturing_diagnostics() {
+        let source = include_str!("lib.rs");
+        let start = source
+            .find("fn spawn_proxy_watchdog")
+            .expect("watchdog implementation exists");
+        let body = &source[start..];
+
+        let bypass_flip = body
+            .find(".store(true, std::sync::atomic::Ordering::Release)")
+            .expect("give-up path flips proxy_bypass");
+        let capture = body
+            .find("capture_watchdog_give_up(")
+            .expect("give-up path captures diagnostics");
+
+        assert!(
+            bypass_flip < capture,
+            "proxy_bypass must be set before capture_watchdog_give_up, which sleeps ~4s"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

In `spawn_proxy_watchdog`'s give-up path, the comment above the bypass flip says:

> Flip bypass **FIRST** so the Rust intercept passes new requests straight through to Anthropic instead of returning 502 in the window between Python being torn down and the user noticing.

But "first" only held relative to `stop_headroom()`. `capture_watchdog_give_up` ran ahead of it — and that function re-probes the backend and then **sleeps 4 seconds** to sample a CPU rate:

```rust
let cpu_actively_burning = match (tracked_pid, process_cpu_secs) {
    (Some(pid), Some(before)) => {
        let started = std::time::Instant::now();
        std::thread::sleep(std::time::Duration::from_secs(4));
        ...
```

That sample exists only to decide whether the Sentry event goes out at `Warning` or `Error` (the `cpu_deadlock_signal` branch). Meanwhile every request arriving in that window still lands on the unreachable-backend branch in `proxy_intercept` — exactly the 502s the bypass is there to prevent.

It bites hardest in the case where the diagnostics matter most: the alive-but-wedged child is the one that *has* a tracked pid and a CPU reading, so the 4s sleep actually runs. On that path it lands on top of the preceding `classify_backend_readyz` probes (up to 2 × 5s), so the user can sit on a dead backend for a good while after the watchdog has already decided to bypass.

## Fix

Move the `proxy_bypass` store above the capture. Two invariants I checked before moving it:

- **The capture still sees pre-teardown state.** The comment on `capture_watchdog_give_up` requires it to run before `stop_headroom()` tears down the tracked child handle and the proxy log. Storing an `AtomicBool` tears nothing down; `stop_headroom()` is further below and unchanged.
- **Telemetry is unaffected.** The reported `bypass_active` is the local snapshot read at the top of the tick (`let bypass_active = state.proxy_bypass.load(...)`), not a re-read, so flipping the flag earlier does not change the payload. `capture_watchdog_give_up` itself never reads `proxy_bypass`.

Net effect: the bypass is live before the diagnostics run instead of ~4s+ after.

## Test

Adds an ordering guard in the same source-inspection style as the existing `macos_notifications_do_not_wait_for_clicks` test, since a pure statement reorder has no other seam to assert on.

```
cargo test --manifest-path src-tauri/Cargo.toml --lib watchdog
test result: ok. 14 passed; 0 failed
```

Frontend build (`npm run build`) passes.

On the full `--lib` run I get 5 failing tests, but they fail identically on a pristine `main` on this machine, so they look environmental rather than related to this change — `smoke_test_*` dying with `killed by signal 9`, `pre_upstream_concurrency_stays_within_bounds` returning a host-cpu-dependent `36`, and `intercept_falls_back_direct_when_backend_is_unreachable` timing out (I had Headroom itself running and holding the ports). Worth a sanity check on your side in case any of those are meaningful to you.

## Base branch

Targeting `staging` rather than `main`, since the README describes `main` as branch-protected with an rc-ancestor check. Happy to retarget.
