### PR TITLE
0.8.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,10 @@ it unprompted and the harness enforces the rest. Do not re-add it.
 - Frontend changes: `npx tsc --noEmit` and any relevant Vitest suite. For visual changes, see Styling Rules.
 - If a test cannot be run in this environment, say so explicitly rather than skipping silently.
 
+## Wheel Bump Rules
+- Before changing `HEADROOM_PINNED_VERSION`: diff upstream `savings_tracker.py`, `prometheus_metrics.py`, and `server.py` between the old and new pins, and check every consumed field against `stats_contract_pins_every_consumed_path` in state.rs. Upstream has silently redefined persisted savings fields before (0.36.0 widened `compression_savings_usd`); the savings-rate canary in state.rs is the runtime tripwire, this diff is the compile-time one.
+- Re-pick every platform's wheel URL/sha256 when bumping (see the pin comment in tool_manager.rs).
+
 ## Persistence Rules
 Most stability bugs in this codebase's history were violations of one of these five. Follow them for any new code; treat violations found in existing code as bugs.
 - Anything persisted uses `client_adapters::atomic_write` (tmp+rename), never plain `fs::write`. Crash mid-write must not truncate state.

--- a/docs/beta-smoke-test.md
+++ b/docs/beta-smoke-test.md
@@ -169,10 +169,12 @@ grep -c 'body_mutated=true.*source=passthrough' ~/.headroom/logs/proxy.log
 grep 'body_mutated=true.*source=passthrough' ~/.headroom/logs/proxy.log \
   | sed -n 's/.*mutation_reasons=\([^ ]*\).*/\1/p' | tr ',' '\n' | sort | uniq -c
 ```
-Expect *today*: non-zero, listing only `output_shaper` and/or `image_compression`. That is upstream #2990 - on any turn whose history carries a signed `thinking` block, `select_outbound_body` forwards client bytes and discards every mutation, while PERF still counts them as delivered. Baseline observed on 0.8.1-rc.1 / headroom-ai 0.35.0: ~2,900 `output_shaper` and ~765 `image_compression` discards across ~6,400 outbound requests.
+Expect *today*: non-zero, listing only `output_shaper`, `image_compression`, and/or `structural_diff_vs_original`. That is upstream #2990 - on any turn whose history carries a signed `thinking` block, `select_outbound_body` forwards client bytes and discards every mutation, while PERF still counts them as delivered. Baseline observed on 0.8.1-rc.1 / headroom-ai 0.35.0: ~2,900 `output_shaper` and ~765 `image_compression` discards across ~6,400 outbound requests.
+
+`structural_diff_vs_original` is the one to read first, not last. The core compression pipeline never calls `mark_mutated` - grep the package and the reason vocabulary has no entry for it - so compression is only ever noticed by the structural safety net at the end of `handle_anthropic_messages`, which fires when no transform reported a mutation but the final body differs from the parsed original bytes. That makes this reason the label core compression lands under by omission, and a discard under it is the pipeline's own work being thrown away, which costs more than losing a shaping pass. It also means the share is not fixed: measured 7.6%-60% of mutated requests across six logs on 0.8.5-rc.1, tracking how much real compression happened. Do not read a ~3% reading as the `HEADROOM_OUTPUT_HOLDOUT=0.03` control arm - the arm gate and this one are unrelated, and the resemblance is a coincidence of whichever subset you counted.
 
 Two things make this a FAIL rather than a known-issue note:
-- any reason appearing that is **not** `output_shaper` / `image_compression` - a new transform just joined the silent-discard set;
+- any reason appearing that is **not** `output_shaper` / `image_compression` / `structural_diff_vs_original` - a new transform just joined the silent-discard set;
 - a **non-zero count at all**, once a wheel bump lands upstream PR #3015. Delete this paragraph and promote 11b to "expect `0`" at that bump.
 
 Do not try to derive this from PERF `transforms=` instead. That field includes detector-only and no-op entries (`router:noop`, `router:protected:error_output`), so joining it against `source=` reports ~1,100 false positives per log file. `mutation_reasons` is only written when the body actually changed.
@@ -236,12 +238,15 @@ cat /tmp/hr-preupgrade/*.json /tmp/hr-preupgrade/claude-md.txt
 **After installing and launching the rc**, re-run the same three `jq` expressions and diff:
 ```bash
 S=~/Library/Application\ Support/Headroom
+stat -f '%Sm %N' /tmp/hr-preupgrade/*   # must predate THIS install, not an older one
 diff <(jq '{first_seen_at,paywall_first}' "$S/config/headroom-pricing-state.json") /tmp/hr-preupgrade/pricing.json
 diff <(jq '{configured:(.configuredClients|keys),shell:(.managedShellFiles|keys)}' "$S/config/client-setup.json") /tmp/hr-preupgrade/setup.json
 jq '{tokens:.allTimeRecordTokens,recap:.lastWeeklyRecapWeekKey,schema:.schemaVersion}' "$S/config/activity-facts.json"
 ls "$S/config/" | grep -c '\.corrupt$'
 ```
 Expect: `first_seen_at` byte-identical (`paywall_first` may legitimately change - the server owns it), the configured-client and shell-file key sets unchanged, and `0` quarantine files. (Use `grep -c`, not `ls *.corrupt`: zsh aborts the whole line with `no matches found` when the glob is empty, which is the healthy case.)
+
+Check the snapshot's mtime before trusting a clean diff. `/tmp/hr-preupgrade` survives across rcs, so a run that forgot the pre-install step silently diffs against a snapshot from two builds ago - which passes, but tests the wrong upgrade. If the mtime predates the build you just replaced, say so in the report rather than claiming this rc preserved state.
 
 `activity-facts.json` is the deliberate exception: a `schemaVersion` bump intentionally drops the tile slots, so it needs its own comparison rather than a `diff`. What must survive a bump is `allTimeRecordTokens` and `lastWeeklyRecapWeekKey` - wiping those re-fires the weekly recap and resets all-time records for every user, which has happened on four bumps so far.
 

--- a/docs/macos-release.md
+++ b/docs/macos-release.md
@@ -218,9 +218,9 @@ after it, uploads its bundles to the same release, and merges its own entry into
 that `latest.json`. Those jobs are chained rather than parallel because they all
 read-modify-write the one manifest.
 
-Platform coverage differs by channel: staging builds macOS, Windows and Linux;
-stable builds macOS and Windows only. Linux has no job in `release-macos.yml`
-yet, so it ships on the rc channel alone.
+Both channels cover all three platforms: macOS, Windows and Linux. Linux was
+rc-only until `release-macos.yml` gained its own `linux` job, so a stable
+release no longer drops `linux-x86_64` from that channel.
 
 The retired `windows-preview` and `linux-preview` channels had their workflows
 deleted once every platform started building per rc. Their releases stay up

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.5-rc.1",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.8.5-rc.1",
+      "version": "0.8.5",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.4-rc.21",
+  "version": "0.8.5-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.8.4-rc.21",
+      "version": "0.8.5-rc.1",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.4-rc.21",
+  "version": "0.8.5-rc.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.5-rc.1",
+  "version": "0.8.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.8.5-rc.1"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.8.4-rc.21"
+version = "0.8.5-rc.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.8.5-rc.1"
+version = "0.8.5"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.8.4-rc.21"
+version = "0.8.5-rc.1"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1517,6 +1517,18 @@ enum BootstrapFailureKind {
     /// the user's machine — the only fix is a newer app, so the message must
     /// send them to the updater instead of to their network settings.
     UnsupportedPin,
+    /// The OS refused a read/write pip needed -- a TCC prompt denied, an MDM or
+    /// endpoint-protection policy guarding the app-support directory, or a
+    /// half-owned venv left by an install that ran as another user. Retrying
+    /// changes nothing until the permission does, so the message must not send
+    /// the user back to the Try again button.
+    Permission,
+    /// pip fell back to building a package from source and the build failed.
+    /// Since every install passes `--only-binary=:all:` (see `PIP_ONLY_BINARY`)
+    /// this should be unreachable, so reaching it means *we* shipped a lock or
+    /// a vendored wheel that does not cover this machine. Never tell the user
+    /// to install Xcode: needing a compiler at all is our bug, not their setup.
+    SourceBuild,
     Other,
 }
 
@@ -1527,6 +1539,10 @@ impl BootstrapFailureKind {
             BootstrapFailureKind::NoUsableTempDir => "no_usable_tempdir",
             BootstrapFailureKind::NetworkDownload => "network_download",
             BootstrapFailureKind::UnsupportedPin => "unsupported_pin",
+            // Same vocabulary as `pip_failure_category`, so a support mail's
+            // failure_kind lines up with the pip-layer Sentry issue.
+            BootstrapFailureKind::Permission => "permission",
+            BootstrapFailureKind::SourceBuild => "build",
             BootstrapFailureKind::Other => "other",
         }
     }
@@ -1553,6 +1569,10 @@ fn classify_bootstrap_failure(err: &anyhow::Error) -> BootstrapFailureKind {
         BootstrapFailureKind::NoUsableTempDir
     } else if is_unsupported_pin_signal(&haystack) {
         BootstrapFailureKind::UnsupportedPin
+    } else if is_permission_signal(&haystack) {
+        BootstrapFailureKind::Permission
+    } else if is_source_build_signal(&haystack) {
+        BootstrapFailureKind::SourceBuild
     } else if is_network_download_signal(&haystack) {
         BootstrapFailureKind::NetworkDownload
     } else {
@@ -1568,6 +1588,28 @@ fn is_unsupported_pin_signal(text: &str) -> bool {
     let lower = text.to_ascii_lowercase();
     lower.contains("no matching distribution found")
         || lower.contains("could not find a version that satisfies")
+}
+
+/// True when the OS refused an operation pip needed. Shares its signal strings
+/// with `pip_failure_category`'s `permission` bucket so the two layers agree.
+/// Checked before [`is_network_download_signal`] for the same reason as
+/// [`is_unsupported_pin_signal`]: pip's index-URL preamble is full of network
+/// vocabulary that would otherwise win.
+fn is_permission_signal(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains("permission denied")
+        || lower.contains("check the permissions")
+        || lower.contains("access is denied")
+        || lower.contains("errno 13")
+}
+
+/// True when pip tried to build a package from source and failed. Mirrors
+/// `pip_failure_category`'s `build` bucket.
+fn is_source_build_signal(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains("failed building wheel")
+        || lower.contains("microsoft visual c++")
+        || lower.contains("error: subprocess-exited-with-error")
 }
 
 /// True when a bootstrap failure looks like a transient network/download
@@ -1630,11 +1672,26 @@ fn user_message_for(kind: BootstrapFailureKind) -> &'static str {
         }
         BootstrapFailureKind::UnsupportedPin => {
             "Installation failed: this version of Headroom can't build its \
-             runtime on your Mac - one of its components has no release for \
-             your processor. This is a bug in the version you're running, not \
+             runtime on this computer - one of its components has no release \
+             for your processor. This is a bug in the version you're running, not \
              a problem with your machine, and retrying will keep failing. \
              Click Check for updates to get a newer Headroom, which fixes it. \
              If no update is offered, contact support@extraheadroom.com."
+        }
+        BootstrapFailureKind::Permission => {
+            "Installation failed: Headroom wasn't allowed to write the files it \
+             needs. That is almost always security software, an MDM profile, or \
+             a permission prompt that was declined - not your network, and not \
+             something clicking Try again will change. Restart your computer and \
+             reopen Headroom. If it still fails, use Contact support below and \
+             we'll read the details it sends."
+        }
+        BootstrapFailureKind::SourceBuild => {
+            "Installation failed: Headroom couldn't assemble its runtime on this \
+             computer, because one of its components has no prebuilt release for \
+             your system. Nothing is missing on your machine - this is a bug in \
+             the version you're running. Click Check for updates to get a newer \
+             Headroom. If no update is offered, use Contact support below."
         }
         BootstrapFailureKind::Other => {
             "Installation failed: Headroom couldn't download a required file. \
@@ -1676,6 +1733,16 @@ fn capture_bootstrap_failure(err: &anyhow::Error, kind: BootstrapFailureKind) {
         return;
     }
 
+    // `Other` is the grab-bag, and a grab-bag on its own fingerprint is how
+    // RUST-1G reached 123 events that no fix could resolve and no one could
+    // triage -- so the only way to quiet it was to archive it, which is why
+    // nobody was paged. pip already classifies these more finely than we do
+    // (`no-pip`, `missing-file`, ...), so borrow that to split the bucket and
+    // let each distinct cause open -- and alert on -- its own issue. The named
+    // kinds are already specific; leave their fingerprints alone.
+    let other_category = matches!(kind, BootstrapFailureKind::Other)
+        .then(|| tool_manager::pip_failure_category(&tool_manager::compact_pip_failure(err)));
+
     // Transient network/download failures are self-recoverable via the retry
     // button; report them as warnings so they don't pollute the error feed.
     let level = match kind {
@@ -1686,8 +1753,9 @@ fn capture_bootstrap_failure(err: &anyhow::Error, kind: BootstrapFailureKind) {
     if let Some(failure) = cmd_failure {
         sentry::with_scope(
             |scope| {
-                let fp: &[&str] = &["bootstrap_failed", kind.as_str()];
-                scope.set_fingerprint(Some(fp));
+                let mut fp: Vec<&str> = vec!["bootstrap_failed", kind.as_str()];
+                fp.extend(other_category);
+                scope.set_fingerprint(Some(fp.as_slice()));
                 scope.set_tag("failure_kind", kind.as_str());
                 scope.set_tag(
                     "endpoint_protection_suspected",
@@ -1725,8 +1793,9 @@ fn capture_bootstrap_failure(err: &anyhow::Error, kind: BootstrapFailureKind) {
     } else {
         sentry::with_scope(
             |scope| {
-                let fp: &[&str] = &["bootstrap_failed", kind.as_str()];
-                scope.set_fingerprint(Some(fp));
+                let mut fp: Vec<&str> = vec!["bootstrap_failed", kind.as_str()];
+                fp.extend(other_category);
+                scope.set_fingerprint(Some(fp.as_slice()));
                 scope.set_tag("failure_kind", kind.as_str());
                 scope.set_tag(
                     "endpoint_protection_suspected",
@@ -5285,6 +5354,25 @@ fn execute_headroom_learn_run(
                             scope.set_tag("learn_agent", agent.as_tag());
                             scope.set_extra("reason", warnings.clone().into());
                             scope.set_extra("project_name", project_name.to_string().into());
+                            // The marker line ends at its colon: upstream
+                            // appends the child's stderr, and `claude -p
+                            // --output-format stream-json` writes its diagnosis
+                            // to stdout, so `reason` arrives empty and every
+                            // distinct cause -- usage limit, dead local route,
+                            // our own 400 -- collapses onto one fingerprint
+                            // (RUST-74: 14 events over six users' machines with
+                            // nothing in them to tell apart). The analyzer's
+                            // surrounding log lines are the only context left
+                            // on this side of the process boundary.
+                            //
+                            // stderr ONLY. stdout echoes written memory files
+                            // back verbatim (see `learn_step_label`), and that
+                            // is the user's project content -- it must never
+                            // reach Sentry.
+                            scope.set_extra(
+                                "stderr_tail",
+                                crate::state::tail_lines(&stderr, 32).join("\n").into(),
+                            );
                             scope.set_fingerprint(Some(
                                 ["headroom_learn_llm_failure", signature.as_str()].as_slice(),
                             ));
@@ -8244,6 +8332,105 @@ mod tests {
     }
 
     #[test]
+    fn classify_bootstrap_failure_flags_denied_writes_as_permission() {
+        let err: anyhow::Error = make_command_failure(
+            "ERROR: Could not install packages due to an OSError: \
+             [Errno 13] Permission denied: '/Users/x/Library/Application Support/\
+             Headroom/headroom/runtime/venv/lib/python3.12/site-packages/foo'\n\
+             Check the permissions.",
+        )
+        .into();
+        assert!(matches!(
+            classify_bootstrap_failure(&err),
+            BootstrapFailureKind::Permission
+        ));
+    }
+
+    #[test]
+    fn classify_bootstrap_failure_flags_a_source_build_as_source_build() {
+        // Unreachable while every install passes `--only-binary=:all:`; if it
+        // fires, a wheel we promised is missing for this machine.
+        let err: anyhow::Error = make_command_failure(
+            "  error: subprocess-exited-with-error\n\
+             error: command '/usr/bin/clang' failed with exit code 1\n\
+             ERROR: Failed building wheel for hnswlib",
+        )
+        .into();
+        assert!(matches!(
+            classify_bootstrap_failure(&err),
+            BootstrapFailureKind::SourceBuild
+        ));
+    }
+
+    #[test]
+    fn permission_and_source_build_win_over_the_network_heuristic() {
+        // Same trap as `unsupported_pin_wins_over_the_network_heuristic`: pip
+        // names every index it consulted before it names the real failure.
+        for (stderr, expected) in [
+            (
+                "WARNING: Retrying after connection timed out\n\
+                 ERROR: Could not install packages due to an OSError: \
+                 [Errno 13] Permission denied",
+                "permission",
+            ),
+            (
+                "WARNING: Retrying after connection timed out\n\
+                 ERROR: Failed building wheel for hnswlib",
+                "build",
+            ),
+        ] {
+            let err: anyhow::Error = make_command_failure(stderr).into();
+            assert_eq!(classify_bootstrap_failure(&err).as_str(), expected);
+        }
+    }
+
+    #[test]
+    fn no_failure_message_ever_asks_the_user_to_install_a_compiler() {
+        // Needing a toolchain to install a desktop app is our bug, never the
+        // user's homework -- `PIP_ONLY_BINARY` exists so it cannot be theirs.
+        for kind in [
+            BootstrapFailureKind::SslInterception,
+            BootstrapFailureKind::NoUsableTempDir,
+            BootstrapFailureKind::NetworkDownload,
+            BootstrapFailureKind::UnsupportedPin,
+            BootstrapFailureKind::Permission,
+            BootstrapFailureKind::SourceBuild,
+            BootstrapFailureKind::Other,
+        ] {
+            let msg = user_message_for(kind).to_ascii_lowercase();
+            for banned in ["xcode", "command line tools", "compiler", "cargo", "rustup"] {
+                assert!(
+                    !msg.contains(banned),
+                    "{} message tells the user about {banned}: {msg}",
+                    kind.as_str()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn only_retryable_failures_mention_the_network() {
+        // The bug behind RUST-1G was not the bad pin, it was that every cause
+        // printed "check your internet connection" over a button that could
+        // never work. Only NetworkDownload is actually retryable.
+        for kind in [
+            BootstrapFailureKind::UnsupportedPin,
+            BootstrapFailureKind::Permission,
+            BootstrapFailureKind::SourceBuild,
+        ] {
+            let msg = user_message_for(kind).to_ascii_lowercase();
+            assert!(
+                !msg.contains("internet connection"),
+                "{} blames the network: {msg}",
+                kind.as_str()
+            );
+        }
+        assert!(user_message_for(BootstrapFailureKind::NetworkDownload)
+            .to_ascii_lowercase()
+            .contains("internet connection"));
+    }
+
+    #[test]
     fn unsupported_pin_wins_over_the_network_heuristic() {
         // pip echoes every index it consulted before reporting the resolution
         // failure, so a timeout word in that preamble must not steal the
@@ -9057,6 +9244,29 @@ Some unrelated content.
         ] {
             assert_eq!(LearnAgent::parse(agent.as_tag()), Ok(agent));
         }
+    }
+
+    /// RUST-74 arrived with `reason` = "LLM analysis failed: `claude -p ...`
+    /// failed (exit 1):" and nothing after the colon, 14 events over six users'
+    /// machines that no fix could be aimed at. The capture now attaches the
+    /// analyzer's stderr tail -- and must attach ONLY that: stdout echoes
+    /// written memory files back verbatim (see `learn_step_label`), so reading
+    /// it here would start shipping users' project content to Sentry.
+    #[test]
+    fn learn_llm_failure_capture_attaches_stderr_tail_and_never_stdout() {
+        let source = include_str!("lib.rs");
+        let (_, after) = source
+            .split_once(r#"set_tag("learn_outcome", "llm_analysis_failed")"#)
+            .expect("capture block present");
+        let block = &after[..after.find("capture_message").expect("capture block end")];
+        assert!(
+            block.contains("tail_lines(&stderr"),
+            "the analyzer's stderr tail is the only cause context we have: {block}"
+        );
+        assert!(
+            !block.contains("&stdout") && !block.contains("&merged"),
+            "stdout carries memory-file contents and must never reach Sentry: {block}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/proxy_intercept.rs
+++ b/src-tauri/src/proxy_intercept.rs
@@ -763,6 +763,9 @@ async fn handle(
     let parsed_head = find_header_end(&buf).and_then(|end| parse_request_head(&buf[..end + 4]));
     let is_codex = parsed_head.as_ref().is_some_and(is_codex_request_head);
     let is_chatgpt_codex = is_codex && request_uses_chatgpt_auth(&buf);
+    let is_local_backend_path = parsed_head
+        .as_ref()
+        .is_some_and(|head| is_local_proxy_path(&head.path));
     // OpenCode is classified by User-Agent, not path: it speaks both API
     // shapes (`/v1/messages` and `/v1/responses`), so path-based
     // classification would split it between the Claude and Codex buckets.
@@ -921,7 +924,16 @@ async fn handle(
     // !is_grok: a grok request on a non-OpenAI path must not be direct-
     // forwarded to api.anthropic.com with its xAI bearer; the backend stays
     // alive whenever grok is enabled, so falling through is always routable.
-    if !is_codex && !is_opencode && !is_grok && claude_only_bypass.load(Ordering::Acquire) {
+    // Local backend paths (/stats, /readyz, ...) also fall through: the backend
+    // is alive here (it is serving Codex), but the direct forwarder dead-ends
+    // them in its local-path 503 guard, so the dashboard lost the layers a
+    // live backend was ready to serve for the whole claude-only window.
+    if !is_codex
+        && !is_opencode
+        && !is_grok
+        && !is_local_backend_path
+        && claude_only_bypass.load(Ordering::Acquire)
+    {
         forward_direct_to_anthropic(client, buf, &upstream_base).await;
         return;
     }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -8589,6 +8589,16 @@ mod tests {
         let base_dir = temp_test_dir("headroom-stop-lifecycle-lock");
         let state = std::sync::Arc::new(AppState::new_in(base_dir.clone()).expect("app state"));
 
+        // Baseline the same call with the lock free. Everything after the lock
+        // is two process sweeps that shell out (`pkill` / `Get-CimInstance`),
+        // and they cost whatever the machine costs: ~1.2s on a warm CI runner,
+        // ~48s on a cold-cache Windows one still scanning freshly built
+        // binaries. Subtracting it makes the ceiling below bound the LOCK WAIT
+        // rather than the runner -- it was failing on the latter.
+        let started = Instant::now();
+        state.stop_headroom();
+        let baseline = started.elapsed();
+
         let holder = std::sync::Arc::clone(&state);
         let (locked_tx, locked_rx) = std::sync::mpsc::channel();
         let (release_tx, release_rx) = std::sync::mpsc::channel();
@@ -8611,9 +8621,11 @@ mod tests {
             waited >= super::STOP_LIFECYCLE_LOCK_TIMEOUT,
             "returned before the lock timeout ({waited:?}), so it never waited for the lock"
         );
+        let lock_wait = waited.saturating_sub(baseline);
         assert!(
-            waited < super::STOP_LIFECYCLE_LOCK_TIMEOUT * 4,
-            "stop_headroom blocked on the held lifecycle lock for {waited:?}"
+            lock_wait < super::STOP_LIFECYCLE_LOCK_TIMEOUT * 4,
+            "stop_headroom blocked on the held lifecycle lock for {lock_wait:?} \
+             (total {waited:?}, sweep baseline {baseline:?})"
         );
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -5604,11 +5604,24 @@ fn warn_stats_fetch_failed(reason: &str) {
         return;
     }
     *last = Some(Instant::now());
-    let message = format!(
-        "headroom /stats fetch failed ({reason}); dashboard loses the layers only \
-         this endpoint reports (output shaping, tool schema)"
-    );
     let category = stats_fetch_failure_category(reason);
+    // A 4xx means SOMETHING answered 6767 without the backend's routes, and
+    // the readyz gate cannot tell it from an ancient-but-ours proxy (a 404
+    // there deliberately counts as reachable). The listener's identity is the
+    // one fact that splits "foreign squatter" from "orphaned old Headroom" --
+    // RUST-87 shipped three unattributable 404s before this. Throttled to one
+    // lookup per 15-minute warn window, so the lsof subprocess is free here.
+    let held_by = if category.starts_with("http-4") {
+        crate::tool_manager::listener_identity(6767)
+            .map(|who| format!("; port 6767 is held by {who}"))
+            .unwrap_or_default()
+    } else {
+        String::new()
+    };
+    let message = format!(
+        "headroom /stats fetch failed ({reason}){held_by}; dashboard loses the layers \
+         only this endpoint reports (output shaping, tool schema)"
+    );
     sentry::with_scope(
         |scope| {
             scope.set_fingerprint(Some(&["stats-fetch-failed", &category]));
@@ -7056,6 +7069,12 @@ fn group_kill_target(pid: i32) -> Option<String> {
     (pid > 1).then(|| format!("-{pid}"))
 }
 
+/// NTSTATUS 0xC0000142, surfaced by `ExitStatus::code()` as -1073741502 (the
+/// number in RUST-7N's title). Not cfg(windows)-gated so the conversion test
+/// below runs everywhere.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+pub(crate) const STATUS_DLL_INIT_FAILED: i32 = 0xC0000142_u32 as i32;
+
 fn kill_processes_by_command_pattern(exe: &std::path::Path, args_pattern: &str) -> Result<()> {
     // An unresolved runtime path degrades the pattern from "our backend at this
     // exact path" to a loose substring, and `pkill -f` applies it to every
@@ -7123,6 +7142,22 @@ fn kill_processes_by_command_pattern(exe: &std::path::Path, args_pattern: &str) 
             })?;
 
         if status.success() {
+            return Ok(());
+        }
+
+        // STATUS_DLL_INIT_FAILED: powershell cannot start because the user
+        // session is ending (logoff/shutdown reaches stop_headroom via
+        // WM_ENDSESSION). The logoff reaps every process in the session,
+        // orphans included, and the next launch's reclaim_orphan_proxy covers
+        // anything that survives - a sweep that cannot run here has nothing
+        // left to do (RUST-7N). The venv-lock-holder caller loses nothing
+        // either: if powershell is this broken outside a logoff, the pip
+        // install right after fails with its own actionable error.
+        if status.code() == Some(STATUS_DLL_INIT_FAILED) {
+            log::info!(
+                "powershell unavailable (0xC0000142, session ending); skipping process sweep for '{}'",
+                exe.display()
+            );
             return Ok(());
         }
 
@@ -7453,6 +7488,14 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
+    fn status_dll_init_failed_matches_the_exit_code_sentry_reports() {
+        // RUST-7N's title says "powershell exited with status Some(-1073741502)";
+        // the benign-classification in kill_processes_by_command_pattern only
+        // works if the hex constant converts to exactly that decimal.
+        assert_eq!(super::STATUS_DLL_INIT_FAILED, -1073741502);
+    }
+
+    #[test]
     fn stats_fetch_failure_category_splits_the_grab_bag() {
         // RUST-6V held 53 timeouts + 47 404s under one un-resolvable issue.
         use super::stats_fetch_failure_category as cat;
@@ -7488,11 +7531,10 @@ mod tests {
         proxy_readyz_503_body_is_upstream_only, proxy_readyz_status_is_reachable,
         rebuild_persisted_savings_from_records, savings_rate_implausible,
         support_tier_for_platform, tcp_port_accepts_connection, tool_schema_savings_usd,
-        total_dir_size_bytes,
-        warn_stats_fetch_failed, AppState, BootValidationOutcome, ClaudeProjectScan,
-        DailySavingsBucket, Duration, HeadroomDashboardStats, HeadroomSavingsHistoryPoint, Instant,
-        PersistedSavingsState, SavingsObservation, SavingsRecord, SavingsTracker,
-        STATS_FETCH_WARNED_AT, STATS_FETCH_WARN_INTERVAL,
+        total_dir_size_bytes, warn_stats_fetch_failed, AppState, BootValidationOutcome,
+        ClaudeProjectScan, DailySavingsBucket, Duration, HeadroomDashboardStats,
+        HeadroomSavingsHistoryPoint, Instant, PersistedSavingsState, SavingsObservation,
+        SavingsRecord, SavingsTracker, STATS_FETCH_WARNED_AT, STATS_FETCH_WARN_INTERVAL,
     };
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -2496,6 +2496,7 @@ impl AppState {
         let lifetime_estimated_savings_usd = lifetime_compression_savings_usd
             + lifetime_output_savings_usd
             + lifetime_tool_schema_savings_usd;
+        warn_once_if_savings_rate_implausible(&daily_savings);
         // Tokens stay input-only: the card is labelled "Total input tokens
         // saved", and this total also drives the milestone notifications, which
         // must not jump when a new savings layer starts reporting.
@@ -7199,6 +7200,46 @@ fn drop_rollup_backfill<T>(
 /// shallower, so 10% is the conservative choice across providers.
 const CACHE_READ_PRICE_RATIO: f64 = 0.10;
 
+/// True when the buckets imply a savings $/token materially above the $/token
+/// actually paid for input on the same traffic. A saved input token can never
+/// be worth more than sending it would have cost, so a rate past the paid rate
+/// means the upstream wheel changed what `compression_savings_usd` contains
+/// (e.g. 0.36.0 folded full-input-rate tool-schema dollars into it, implying
+/// $33/M on traffic actually paying $5/M). Both rates come from the same
+/// buckets, so the check self-calibrates to the user's model mix; the 1.5x
+/// headroom absorbs mix drift between saved and sent tokens. Volume floors
+/// keep a few cheap requests from tripping it on noise.
+fn savings_rate_implausible(daily_savings: &[DailySavingsPoint]) -> Option<(f64, f64)> {
+    let saved_usd: f64 = daily_savings.iter().map(|p| p.estimated_savings_usd).sum();
+    let saved_tokens: u64 = daily_savings.iter().map(|p| p.estimated_tokens_saved).sum();
+    let paid_usd: f64 = daily_savings.iter().map(|p| p.actual_cost_usd).sum();
+    let sent_tokens: u64 = daily_savings.iter().map(|p| p.total_tokens_sent).sum();
+    if saved_tokens < 1_000_000 || sent_tokens < 1_000_000 || paid_usd < 1.0 {
+        return None;
+    }
+    let savings_rate = saved_usd / saved_tokens as f64;
+    let paid_rate = paid_usd / sent_tokens as f64;
+    (savings_rate > paid_rate * 1.5).then_some((savings_rate * 1e6, paid_rate * 1e6))
+}
+
+/// Warn-only canary, once per process: a contaminated rate silently corrected
+/// is worse than a loud one, so nothing is clamped -- the warn reaches Sentry
+/// through the log bridge and the numbers keep rendering as reported.
+fn warn_once_if_savings_rate_implausible(daily_savings: &[DailySavingsPoint]) {
+    static WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+    if WARNED.load(std::sync::atomic::Ordering::Relaxed) {
+        return;
+    }
+    if let Some((savings_per_m, paid_per_m)) = savings_rate_implausible(daily_savings) {
+        WARNED.store(true, std::sync::atomic::Ordering::Relaxed);
+        log::warn!(
+            "savings rate implausible: buckets imply ${savings_per_m:.2}/M saved vs \
+             ${paid_per_m:.2}/M actually paid for input; upstream savings semantics \
+             likely changed under the pinned wheel"
+        );
+    }
+}
+
 /// Lifetime dollars saved by tool-schema deferral.
 ///
 /// Tool definitions are re-sent on every request and sit at the very front of
@@ -7445,8 +7486,9 @@ mod tests {
         merge_hourly_savings, most_recent_monday, parse_headroom_stats_from_json,
         parse_headroom_stats_history_from_json, parse_ps_cpu_time,
         proxy_readyz_503_body_is_upstream_only, proxy_readyz_status_is_reachable,
-        rebuild_persisted_savings_from_records, support_tier_for_platform,
-        tcp_port_accepts_connection, tool_schema_savings_usd, total_dir_size_bytes,
+        rebuild_persisted_savings_from_records, savings_rate_implausible,
+        support_tier_for_platform, tcp_port_accepts_connection, tool_schema_savings_usd,
+        total_dir_size_bytes,
         warn_stats_fetch_failed, AppState, BootValidationOutcome, ClaudeProjectScan,
         DailySavingsBucket, Duration, HeadroomDashboardStats, HeadroomSavingsHistoryPoint, Instant,
         PersistedSavingsState, SavingsObservation, SavingsRecord, SavingsTracker,
@@ -7557,6 +7599,44 @@ mod tests {
             tool_schema_savings_usd(&[daily("2026-08-05", 0, 0.0)], 2_000_000),
             0.0
         );
+    }
+
+    #[test]
+    fn savings_rate_canary_flags_a_rate_above_what_input_actually_cost() {
+        let with_spend = |tokens: u64, usd: f64, sent: u64, paid: f64| DailySavingsPoint {
+            actual_cost_usd: paid,
+            total_tokens_sent: sent,
+            ..daily("2026-08-21", tokens, usd)
+        };
+
+        // Healthy: $5/M saved on traffic paying $5/M for input.
+        assert_eq!(
+            savings_rate_implausible(&[with_spend(2_000_000, 10.0, 20_000_000, 100.0)]),
+            None
+        );
+
+        // The 0.36.0 fold shape: $33/M implied on traffic paying $5/M.
+        let (savings_per_m, paid_per_m) =
+            savings_rate_implausible(&[with_spend(2_000_000, 66.0, 20_000_000, 100.0)])
+                .expect("contaminated rate must trip the canary");
+        assert!((savings_per_m - 33.0).abs() < 1e-6, "{savings_per_m}");
+        assert!((paid_per_m - 5.0).abs() < 1e-6, "{paid_per_m}");
+
+        // Below the volume/spend floors nothing fires, however wild the ratio:
+        // a handful of cheap requests is noise, not a semantics change.
+        assert_eq!(
+            savings_rate_implausible(&[with_spend(500_000, 66.0, 20_000_000, 100.0)]),
+            None
+        );
+        assert_eq!(
+            savings_rate_implausible(&[with_spend(2_000_000, 66.0, 500_000, 100.0)]),
+            None
+        );
+        assert_eq!(
+            savings_rate_implausible(&[with_spend(2_000_000, 66.0, 20_000_000, 0.5)]),
+            None
+        );
+        assert_eq!(savings_rate_implausible(&[]), None);
     }
 
     #[test]
@@ -9506,6 +9586,95 @@ mod tests {
         assert_eq!(parsed.savings_history.len(), 1);
         // No traffic_learner block in this payload (older backend shape).
         assert!(parsed.learner_progress.is_none());
+    }
+
+    /// The /stats contract, in one place: every primary JSON path this app
+    /// consumes from the backend, each carrying a distinct sentinel. Run this
+    /// against the diff of `savings_tracker.py` / `prometheus_metrics.py` /
+    /// `server.py` before any wheel bump -- when upstream moves or re-defines
+    /// a field (0.36.0 silently widened `compression_savings_usd` to include
+    /// tool-schema dollars), this is the test that should force the
+    /// conversation. A failing assertion here means the bump changes what
+    /// users' savings numbers mean, not just how they are produced.
+    #[test]
+    fn stats_contract_pins_every_consumed_path() {
+        let parsed = parse_headroom_stats_from_json(
+            r#"{
+                "requests": { "total": 41 },
+                "tokens": { "saved": 1200, "input": 34000 },
+                "cost": { "compression_savings_usd": 3.25, "total_input_cost_usd": 7.5 },
+                "prefix_cache": {
+                    "totals": { "cache_write_tokens": 900, "uncached_input_tokens": 100 }
+                },
+                "compression_savings_history": [
+                    { "timestamp": "2026-08-21T09:00:00Z", "total_tokens_saved": 700 },
+                    { "timestamp": "2026-08-21T10:00:00Z", "total_tokens_saved": 1200 }
+                ],
+                "summary": { "compression": { "tool_schema_tokens_saved": 777 } },
+                "savings": {
+                    "by_layer": {
+                        "output_shaping": {
+                            "available": true,
+                            "method": "holdout",
+                            "reduction_percent": 12.5,
+                            "ci_low_percent": 10.0,
+                            "ci_high_percent": 15.0,
+                            "requests": 9,
+                            "tokens_saved": 4321,
+                            "baseline_tokens": 34568
+                        },
+                        "tool_search": { "tokens_saved": 555 }
+                    }
+                },
+                "traffic_learner": {
+                    "requests_processed": 40,
+                    "patterns_extracted": 7,
+                    "patterns_saved": 1,
+                    "pending_patterns": 3,
+                    "min_evidence": 5,
+                    "history_size": 12
+                }
+            }"#,
+        )
+        .expect("contract fixture must parse");
+
+        assert_eq!(parsed.session_requests, Some(41));
+        assert_eq!(parsed.session_estimated_tokens_saved, Some(1200));
+        assert_eq!(parsed.session_estimated_savings_usd, Some(3.25));
+        assert_eq!(parsed.session_actual_cost_usd, Some(7.5));
+        // New-input denominator: cache_write + uncached (1000), never
+        // tokens.input -- re-sent cached prefix must not dilute the ratio.
+        assert_eq!(parsed.session_total_tokens_sent, Some(1000));
+        let pct = parsed.session_savings_pct.expect("pct derived");
+        assert!((pct - 1200.0 / 2200.0 * 100.0).abs() < 1e-9, "{pct}");
+
+        assert_eq!(parsed.savings_history.len(), 2);
+        assert_eq!(parsed.savings_history[0].total_tokens_saved, 700);
+        assert_eq!(parsed.savings_history[1].total_tokens_saved, 1200);
+
+        // summary.compression is the process-cumulative counter and must win
+        // over the windowed by_layer figure (555).
+        assert_eq!(parsed.tool_schema_tokens_saved, Some(777));
+
+        let output = parsed.output_reduction.expect("output layer parsed");
+        assert_eq!(output.method, "holdout");
+        assert!((output.reduction_percent - 12.5).abs() < 1e-9);
+        assert_eq!(output.tokens_saved, 4321);
+        assert_eq!(output.baseline_tokens, 34568);
+
+        let learner = parsed.learner_progress.expect("learner parsed");
+        assert_eq!(learner.pending_patterns, 3);
+
+        // Fallback contract: without the cumulative counter, the windowed
+        // by_layer figure is still accepted for shape.
+        let fallback = parse_headroom_stats_from_json(
+            r#"{
+                "requests": { "total": 1 },
+                "savings": { "by_layer": { "tool_search": { "tokens_saved": 555 } } }
+            }"#,
+        )
+        .expect("fallback fixture must parse");
+        assert_eq!(fallback.tool_schema_tokens_saved, Some(555));
     }
 
     #[test]

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -51,6 +51,20 @@ const HEADROOM_BASELINE_SEED_TIMEOUT: Duration = Duration::from_secs(30);
 /// GitHub's expanded_assets endpoint serves HTML anchors pip can consume via --find-links.
 const VENDOR_WHEELS_INDEX_URL: &str =
     "https://github.com/gglucass/headroom-desktop/releases/expanded_assets/vendor-wheels-v1";
+/// Never let pip build a dependency from source. A user's machine is not
+/// guaranteed to have Xcode Command Line Tools (nor the Rust toolchain
+/// pydantic-core's sdist needs), and requiring either to install a desktop app
+/// is not a bargain we get to make. Every pin we install has a wheel for every
+/// platform we ship -- the one sdist-only dependency, hnswlib, is served as a
+/// prebuilt wheel from `VENDOR_WHEELS_INDEX_URL` -- so in the healthy case this
+/// flag changes nothing. It only bites when a wheel is *missing*: without it
+/// pip silently falls back to the sdist and spends minutes compiling before
+/// dying on a clang/cargo error no user can act on; with it pip fails at once
+/// with "no matching distribution found", which `classify_bootstrap_failure`
+/// already recognises and explains. Deliberately NOT applied to the optional
+/// markitdown/serena addons: their transitive sets are unpinned and unaudited,
+/// and a failed addon leaves a working Headroom behind.
+const PIP_ONLY_BINARY: &str = "--only-binary=:all:";
 // headroom binds on the backend port chosen at spawn time (default 6768);
 // the intercept layer on 6767 forwards to it. The backend port is dynamic
 // because something else on the machine (e.g. rapportd) can claim 6768 at
@@ -2401,6 +2415,22 @@ impl ToolManager {
                         "HEADROOM_SAVINGS_PROFILE",
                         savings_profile_for_runtime(self.installed_headroom_version().as_deref()),
                     )
+                    // cc-switch reconciler. Off upstream by default; the desktop
+                    // opts in so a user who points Claude Code at a third-party
+                    // Anthropic-compatible endpoint (Kimi, DeepSeek, GLM) keeps
+                    // Headroom in the path instead of dropping out of it. The
+                    // reconciler captures that endpoint as the proxy upstream and
+                    // rewrites env.ANTHROPIC_BASE_URL back to us, leaving the
+                    // user's token untouched -- so their traffic is still
+                    // compressed, and token-priced providers are exactly where
+                    // compression is worth the most. Version-gated: see
+                    // cc_switch_reconcile_for_runtime.
+                    .env(
+                        "HEADROOM_CC_SWITCH_RECONCILE",
+                        cc_switch_reconcile_for_runtime(
+                            self.installed_headroom_version().as_deref(),
+                        ),
+                    )
                     // Pre-upstream concurrency. The proxy's own auto is
                     // max(2, min(8, cpu_count)) — hard-capped at 8 to protect the
                     // event loop from CPU-bound compression. The desktop runs with
@@ -3156,6 +3186,7 @@ impl ToolManager {
                 "180",
                 "--retries",
                 "10",
+                PIP_ONLY_BINARY,
                 "--find-links",
                 VENDOR_WHEELS_INDEX_URL,
                 "--extra-index-url",
@@ -3506,17 +3537,44 @@ impl ToolManager {
             .is_ok()
     }
 
+    /// Creates the venv, then installs pip into it as a separate step.
+    ///
+    /// `python -m venv` runs ensurepip through `subprocess.check_output` and
+    /// re-raises only the exit status, so the child's own stderr is captured
+    /// into an exception venv never prints. A failure there reached us as the
+    /// bare string "Command '[... -m ensurepip ...]' returned non-zero exit
+    /// status 1" -- no cause, no keyword for `pip_failure_category` to match,
+    /// so it landed in the `other` grab-bag (Sentry RUST-82, an install-blocking
+    /// dead end on 0.8.4 with nothing in it to act on).
+    ///
+    /// Running the two steps ourselves is what venv does internally, but now
+    /// ensurepip's stderr comes back as a first-class `CommandFailure` that the
+    /// categoriser can bucket. `build_command` already clears
+    /// PYTHONHOME/PYTHONPATH and sets PYTHONNOUSERSITE, which is the isolation
+    /// venv applies to this call, so the explicit invocation is equivalent.
+    ///
+    /// A venv left pip-less by a failure here is not a dead end: it fails
+    /// `managed_venv_has_pip`, so the next launch treats it as absent and
+    /// re-runs this whole function.
     fn create_managed_venv(&self) -> Result<()> {
         run_python_command(
             &self.runtime.standalone_python(),
             &[
                 "-m",
                 "venv",
+                "--without-pip",
                 self.runtime.venv_dir.to_string_lossy().as_ref(),
             ],
             &self.runtime.root_dir,
         )
         .context("creating Headroom-managed virtualenv")?;
+
+        run_python_command(
+            &self.runtime.managed_python(),
+            &["-m", "ensurepip", "--upgrade", "--default-pip"],
+            &self.runtime.root_dir,
+        )
+        .context("installing pip into the Headroom-managed virtualenv")?;
 
         run_python_command(
             &self.runtime.managed_python(),
@@ -3605,6 +3663,7 @@ impl ToolManager {
                 "180",
                 "--retries",
                 "10",
+                PIP_ONLY_BINARY,
                 "--find-links",
                 VENDOR_WHEELS_INDEX_URL,
                 "--extra-index-url",
@@ -3652,6 +3711,7 @@ impl ToolManager {
                 "180",
                 "--retries",
                 "10",
+                PIP_ONLY_BINARY,
                 "--extra-index-url",
                 "https://pypi.org/simple",
                 "--no-deps",
@@ -4533,6 +4593,7 @@ impl ToolManager {
                     "180",
                     "--retries",
                     "10",
+                    PIP_ONLY_BINARY,
                     "--find-links",
                     VENDOR_WHEELS_INDEX_URL,
                     "--extra-index-url",
@@ -4617,6 +4678,7 @@ impl ToolManager {
                 "180",
                 "--retries",
                 "10",
+                PIP_ONLY_BINARY,
                 "--extra-index-url",
                 "https://pypi.org/simple",
                 "--no-deps",
@@ -4727,6 +4789,7 @@ impl ToolManager {
                 "180",
                 "--retries",
                 "10",
+                PIP_ONLY_BINARY,
                 "--extra-index-url",
                 "https://pypi.org/simple",
                 "--no-deps",
@@ -4760,6 +4823,7 @@ impl ToolManager {
                 "180",
                 "--retries",
                 "10",
+                PIP_ONLY_BINARY,
                 "--extra-index-url",
                 "https://pypi.org/simple",
                 "--no-deps",
@@ -4781,6 +4845,7 @@ impl ToolManager {
                 "180",
                 "--retries",
                 "10",
+                PIP_ONLY_BINARY,
                 "--extra-index-url",
                 "https://pypi.org/simple",
                 "--no-deps",
@@ -4807,6 +4872,7 @@ impl ToolManager {
                 "180",
                 "--retries",
                 "10",
+                PIP_ONLY_BINARY,
                 "--find-links",
                 VENDOR_WHEELS_INDEX_URL,
                 "--extra-index-url",
@@ -7368,6 +7434,44 @@ fn savings_profile_for_runtime(installed_version: Option<&str>) -> &'static str 
     }
 }
 
+/// First bundled runtime carrying the cc-switch reconciler's Official-branch
+/// upstream reset (upstream PR #3166). The reconciler itself has shipped since
+/// 0.29.0, but before the reset a switch back to Claude Official left the
+/// previously captured third-party endpoint live on
+/// `HeadroomProxy.ANTHROPIC_API_URL` -- a process-wide class attr -- so every
+/// Anthropic client on this proxy kept reaching e.g. api.deepseek.com while
+/// sending Anthropic OAuth credentials. Bump this the release the fix lands in;
+/// until then the gate below keeps the flag off.
+const CC_SWITCH_RESET_MIN_VERSION: (u64, u64, u64) = (0, 36, 3);
+
+/// Whether to opt this runtime into the cc-switch reconciler.
+///
+/// Defaults to off for an unreadable version and for the 0.28.0 fallback the
+/// app drops to when boot validation times out: enabling the reconciler on a
+/// runtime without the reset is worse than leaving it off, because it only
+/// misroutes AFTER the user has already switched providers once.
+fn cc_switch_reconcile_for_runtime(installed_version: Option<&str>) -> &'static str {
+    let Some(version) = installed_version else {
+        return "0";
+    };
+    let mut parts = version.split('.').map(|p| p.parse::<u64>().ok());
+    let parsed = (
+        parts.next().flatten(),
+        parts.next().flatten(),
+        parts.next().flatten(),
+    );
+    match parsed {
+        (Some(major), Some(minor), Some(patch)) => {
+            if (major, minor, patch) >= CC_SWITCH_RESET_MIN_VERSION {
+                "1"
+            } else {
+                "0"
+            }
+        }
+        _ => "0",
+    }
+}
+
 fn headroom_entrypoint_startup_args(
     installed_version: Option<&str>,
     learn_enabled: bool,
@@ -7437,6 +7541,39 @@ fn expected_proxy_arg_signature(learn_enabled: bool) -> Vec<&'static str> {
 pub fn running_proxy_argv() -> Option<String> {
     let (_, pid) = listener_process(backend_port::get())?;
     ps_command(pid)
+}
+
+/// Identity of whatever is listening on `port`, for diagnostics that need to
+/// tell a foreign squatter from an orphaned old Headroom: a port that answers
+/// HTTP without the backend's routes is invisible to the readyz gate (a 404
+/// there deliberately counts as reachable), so the listener's name is the one
+/// fact that resolves the ambiguity. Best-effort: `None` where lsof is
+/// unavailable (Windows), and the caller's message must read fine without it.
+pub(crate) fn listener_identity(port: u16) -> Option<String> {
+    let (cmd, pid) = listener_process(port)?;
+    Some(format_listener_identity(
+        &cmd,
+        pid,
+        ps_command(pid).as_deref(),
+    ))
+}
+
+fn format_listener_identity(cmd: &str, pid: u32, argv: Option<&str>) -> String {
+    const MAX_ARGV: usize = 160;
+    let argv = argv.map(str::trim).unwrap_or_default();
+    if argv.is_empty() {
+        return format!("{cmd} (pid {pid})");
+    }
+    let mut argv = argv.to_string();
+    if argv.len() > MAX_ARGV {
+        let cut = (0..=MAX_ARGV)
+            .rev()
+            .find(|i| argv.is_char_boundary(*i))
+            .unwrap_or(0);
+        argv.truncate(cut);
+        argv.push_str("...");
+    }
+    format!("{cmd} (pid {pid}): {argv}")
 }
 
 /// True if the running proxy's argv contains every flag we expect this build
@@ -8514,7 +8651,10 @@ fn build_command(binary: &Path, args: &[&str], cwd: &Path) -> Command {
         .env_remove("PYTHONPATH")
         .env_remove("PYTHONSTARTUP")
         .env("PYTHONNOUSERSITE", "1")
-        .env("PYTHONIOENCODING", "utf-8")
+        // `backslashreplace`, matching `proc::command` -- plain "utf-8" here
+        // silently overrode it and re-armed the RUST-7C UnicodeEncodeError kill
+        // for every child this builds (a lone surrogate must not be fatal).
+        .env("PYTHONIOENCODING", "utf-8:backslashreplace")
         .env("LC_ALL", "C.UTF-8")
         .env("LANG", "C.UTF-8")
         .env("PIP_DISABLE_PIP_VERSION_CHECK", "1")
@@ -8604,21 +8744,42 @@ pub(crate) fn compact_pip_failure(err: &anyhow::Error) -> String {
         failure.stdout.as_str()
     };
     let trimmed = source.trim_end();
-    let tail = if trimmed.len() > TAIL_BUDGET {
-        // Byte offset, so walk forward to a char boundary before slicing:
-        // pip on a non-English Windows locale emits multi-byte stderr and
-        // `&trimmed[start..]` would panic mid-character.
-        let mut start = trimmed.len() - TAIL_BUDGET;
-        while !trimmed.is_char_boundary(start) {
-            start += 1;
-        }
-        let aligned = trimmed[start..]
-            .find('\n')
-            .map(|i| start + i + 1)
-            .unwrap_or(start);
-        &trimmed[aligned..]
+    // "The reason lives at the end" holds for pip run directly, but not when it
+    // is reached through ensurepip: pip prints its `ERROR:` diagnosis, then a
+    // Python traceback follows, so the tail is `CalledProcessError ... returned
+    // non-zero exit status 1` -- the one line in the whole stream with no cause
+    // in it. That is how RUST-82 reached triage: an install-blocking venv
+    // failure classified `other`, with nothing in it to act on. Where pip named
+    // a reason, start from it; otherwise the tail is still the best guess.
+    let from_pip_error = if trimmed.starts_with("ERROR: ") {
+        Some(trimmed)
     } else {
-        trimmed
+        trimmed.find("\nERROR: ").map(|i| &trimmed[i + 1..])
+    };
+    let tail = match from_pip_error {
+        // Byte offsets, so walk to a char boundary before slicing: pip on a
+        // non-English Windows locale emits multi-byte stderr and slicing
+        // mid-character would panic.
+        Some(head) if head.len() > TAIL_BUDGET => {
+            let mut end = TAIL_BUDGET;
+            while !head.is_char_boundary(end) {
+                end -= 1;
+            }
+            &head[..end]
+        }
+        Some(head) => head,
+        None if trimmed.len() > TAIL_BUDGET => {
+            let mut start = trimmed.len() - TAIL_BUDGET;
+            while !trimmed.is_char_boundary(start) {
+                start += 1;
+            }
+            let aligned = trimmed[start..]
+                .find('\n')
+                .map(|i| start + i + 1)
+                .unwrap_or(start);
+            &trimmed[aligned..]
+        }
+        None => trimmed,
     };
     let exit = failure
         .exit_code
@@ -8635,7 +8796,7 @@ pub(crate) fn compact_pip_failure(err: &anyhow::Error) -> String {
 /// One flat bucket would be the opposite mistake: resolving a shipped fix would
 /// regress the instant an unrelated cause reappeared (RUST-5Q). These classes
 /// match the buckets triage already sorts these into by hand.
-fn pip_failure_category(compact: &str) -> &'static str {
+pub(crate) fn pip_failure_category(compact: &str) -> &'static str {
     let lower = compact.to_ascii_lowercase();
     if lower.contains("no module named pip") {
         "no-pip"
@@ -9112,10 +9273,11 @@ mod tests {
     use super::rotate_log_if_large;
     use super::{
         addon_unavailable_reason, apply_serena_dashboard_interface, apply_serena_gitignore,
-        bootstrap_requirements_lock_for_target, classify_kompress_prefetch_failure,
-        codebase_memory_distribution_artifact, compact_pip_failure, describe_proxy_port_occupant,
-        diagnose_proxy_port, exe_path_is_under, extract_required_pydantic_core_version,
-        format_all_foreign_bail, format_already_running_bail, headroom_entrypoint_startup_args,
+        bootstrap_requirements_lock_for_target, build_command, cc_switch_reconcile_for_runtime,
+        classify_kompress_prefetch_failure, codebase_memory_distribution_artifact,
+        compact_pip_failure, describe_proxy_port_occupant, diagnose_proxy_port, exe_path_is_under,
+        extract_required_pydantic_core_version, format_all_foreign_bail,
+        format_already_running_bail, headroom_entrypoint_startup_args,
         headroom_python_startup_args, httpx_ca_bundle_bridge_from, is_checksum_mismatch,
         is_outdated_codex, learned_openai_ttl_seconds, ledger_bytes_without_control,
         looks_like_corrupt_venv_error, parse_lsof_listener, parse_major_minor_patch,
@@ -10303,6 +10465,23 @@ mod tests {
     }
 
     #[test]
+    fn listener_identity_formats_and_truncates_on_char_boundaries() {
+        assert_eq!(
+            super::format_listener_identity("nginx", 42, None),
+            "nginx (pid 42)"
+        );
+        assert_eq!(
+            super::format_listener_identity("python3.12", 7, Some("  headroom proxy --port 6767 ")),
+            "python3.12 (pid 7): headroom proxy --port 6767"
+        );
+        // A multibyte char straddling the cap must not panic the truncate.
+        let argv = format!("{}é", "x".repeat(159));
+        let got = super::format_listener_identity("app", 1, Some(&argv));
+        assert!(got.ends_with("..."), "{got}");
+        assert!(got.len() < 200);
+    }
+
+    #[test]
     fn proxy_argv_matches_when_all_expected_flags_present() {
         let argv = "/Users/x/headroom proxy --port 6768 --log-messages \
                     --learn --no-memory-tools --no-memory-context --memory-db-path /tmp/m.db";
@@ -10486,7 +10665,6 @@ mod tests {
         );
     }
 
-    #[test]
     /// The real path observed on a Windows box was
     /// `...\Headroom\headroom\runtime\python\python.exe` -- the BASE
     /// interpreter. A first cut of this gate required "venv" in the path, which
@@ -10567,6 +10745,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn parse_lsof_listener_reads_the_row_below_the_header() {
         let out = "COMMAND   PID USER   FD   TYPE DEVICE SIZE/OFF NODE NAME\n\
                    python  12345 garm    7u  IPv4 0x1234      0t0  TCP 127.0.0.1:6768 (LISTEN)\n";
@@ -10954,6 +11133,31 @@ S(('127.0.0.1', int(sys.argv[1])), H).serve_forever()
         assert_eq!(savings_profile_for_runtime(Some("garbage")), "coding");
     }
 
+    /// The cc-switch reconciler must stay off on any runtime without the
+    /// Official-branch upstream reset (upstream PR #3166). Enabling it there
+    /// leaves a captured third-party endpoint live process-wide after the user
+    /// switches back to Claude Official, so Anthropic OAuth traffic goes to the
+    /// old provider. Unlike the savings persona, an unreadable version fails
+    /// CLOSED: the flag is an opt-in, and off is always the safe answer.
+    #[test]
+    #[serial_test::serial(backend_port)]
+    fn cc_switch_reconcile_gated_on_runtime_version() {
+        assert_eq!(cc_switch_reconcile_for_runtime(Some("0.35.0")), "0");
+        assert_eq!(cc_switch_reconcile_for_runtime(Some("0.36.2")), "0");
+        assert_eq!(cc_switch_reconcile_for_runtime(Some("0.36.3")), "1");
+        assert_eq!(cc_switch_reconcile_for_runtime(Some("0.37.0")), "1");
+        assert_eq!(cc_switch_reconcile_for_runtime(Some("1.0.0")), "1");
+        // Unreadable version or the 0.28.0 boot-validation fallback: stay off.
+        assert_eq!(cc_switch_reconcile_for_runtime(None), "0");
+        assert_eq!(cc_switch_reconcile_for_runtime(Some("garbage")), "0");
+        assert_eq!(cc_switch_reconcile_for_runtime(Some("0.36")), "0");
+        // The currently pinned wheel predates the fix, so this ships inert.
+        assert_eq!(
+            cc_switch_reconcile_for_runtime(Some(HEADROOM_PINNED_VERSION)),
+            "0"
+        );
+    }
+
     /// Regression: `start_headroom_background` previously built `startup_variants`
     /// before pre-flight ran, so when fallback called `backend_port::set(6769)`
     /// the variants still spawned with `--port 6768` and both failed with
@@ -11294,6 +11498,61 @@ after
         .expect("receipt");
         let manager = ToolManager::new(runtime.clone());
         (root, runtime, manager)
+    }
+
+    /// RUST-82: `python -m venv` runs ensurepip through `check_output` and
+    /// re-raises only its exit status, so an install-blocking failure reached
+    /// Sentry as a bare "returned non-zero exit status 1" with the cause
+    /// discarded. Creating the venv without pip and running ensurepip ourselves
+    /// is what venv does internally, but keeps ensurepip's stderr. If anyone
+    /// folds these back into one step, that blind spot returns.
+    #[test]
+    #[cfg(unix)] // exercises a fake shell-script binary; Windows cannot exec it
+    fn create_managed_venv_runs_ensurepip_as_its_own_step() {
+        let (root, runtime, manager) = seed_test_runtime("venv-ensurepip-split");
+        let log = root.join("argv.log");
+        let script = format!("#!/bin/sh\necho \"$@\" >> {}\nexit 0\n", log.display());
+        write_executable(&runtime.standalone_python(), &script);
+        write_executable(&runtime.managed_python(), &script);
+
+        manager.create_managed_venv().expect("fake python succeeds");
+
+        let calls = fs::read_to_string(&log).expect("argv log");
+        let mut lines = calls.lines();
+        assert_eq!(
+            lines.next().map(str::to_string),
+            Some(format!(
+                "-m venv --without-pip {}",
+                runtime.venv_dir.to_string_lossy()
+            )),
+            "venv is created without pip: {calls}"
+        );
+        assert_eq!(
+            lines.next(),
+            Some("-m ensurepip --upgrade --default-pip"),
+            "ensurepip runs as its own command, so its stderr survives: {calls}"
+        );
+        assert_eq!(
+            lines.next(),
+            Some("-m pip --version"),
+            "pip is still verified afterwards: {calls}"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    /// `build_command` set plain "utf-8", silently overriding the
+    /// `utf-8:backslashreplace` that `proc::command` applies on purpose -- which
+    /// re-armed the RUST-7C UnicodeEncodeError kill for every python child
+    /// built here (a lone surrogate in a log line must not be fatal).
+    #[test]
+    fn build_command_keeps_the_backslashreplace_stdio_encoding() {
+        let cmd = build_command(Path::new("python3"), &["-V"], Path::new("."));
+        let encoding = cmd
+            .get_envs()
+            .find(|(key, _)| *key == std::ffi::OsStr::new("PYTHONIOENCODING"))
+            .and_then(|(_, value)| value)
+            .expect("PYTHONIOENCODING is set");
+        assert_eq!(encoding, std::ffi::OsStr::new("utf-8:backslashreplace"));
     }
 
     #[test]
@@ -12989,6 +13248,55 @@ exit 0
         })
     }
 
+    /// RUST-82: an install-blocking venv failure that reached triage with no
+    /// cause in it. Two defects stacked. `python -m venv` runs ensurepip via
+    /// `check_output` and re-raises only the exit status, so all Sentry ever saw
+    /// was "Command '[... -m ensurepip ...]' returned non-zero exit status 1";
+    /// and even once ensurepip is run directly, pip's `ERROR:` line is followed
+    /// by a traceback, so the 300-byte tail kept the traceback and dropped the
+    /// diagnosis. Verified against the real stderr of a failing ensurepip.
+    #[test]
+    fn compact_pip_failure_keeps_pips_diagnosis_ahead_of_a_traceback() {
+        let stderr = concat!(
+            "ERROR: Could not install packages due to an OSError: ",
+            "[Errno 13] Permission denied: '/opt/venv/lib/python3.14/site-packages/pip'\n",
+            "Check the permissions.\n",
+            "\n",
+            "Traceback (most recent call last):\n",
+            "  File \"<frozen runpy>\", line 203, in _run_module_as_main\n",
+            "  File \"/usr/lib/python3.14/ensurepip/__init__.py\", line 88, in _run_pip\n",
+            "    return subprocess.run(cmd, check=True).returncode\n",
+            "  File \"/usr/lib/python3.14/subprocess.py\", line 578, in run\n",
+            "    raise CalledProcessError(retcode, process.args,\n",
+            "subprocess.CalledProcessError: Command '['/opt/venv/bin/python', '-W', ",
+            "'ignore::DeprecationWarning', '-c', 'import runpy...']' ",
+            "returned non-zero exit status 1.\n",
+        );
+        let compact = compact_pip_failure(&pip_failure(stderr));
+        assert!(
+            compact.contains("Permission denied"),
+            "pip named the cause and it must survive: {compact}"
+        );
+        assert_eq!(
+            pip_failure_category(&compact),
+            "permission",
+            "a named cause must not sit in the `other` grab-bag: {compact}"
+        );
+    }
+
+    /// The tail is still right when pip prints no `ERROR:` line at all, so the
+    /// RUST-82 fix must not cost us the ordinary case.
+    #[test]
+    fn compact_pip_failure_still_tails_when_pip_named_no_error() {
+        let stderr = format!(
+            "{}\nno matching distribution found for onnxruntime",
+            "x".repeat(400)
+        );
+        let compact = compact_pip_failure(&pip_failure(&stderr));
+        assert!(compact.ends_with("no matching distribution found for onnxruntime"));
+        assert_eq!(pip_failure_category(&compact), "no-matching-dist");
+    }
+
     #[test]
     fn compact_pip_failure_survives_multibyte_stderr() {
         // Non-English Windows locale: the 300-byte tail offset lands mid-
@@ -12997,6 +13305,27 @@ exit 0
         let compact = compact_pip_failure(&pip_failure(&stderr));
         assert!(compact.starts_with("exit=1; stderr tail: "));
         assert!(compact.contains("エラー"));
+    }
+
+    #[test]
+    fn every_index_resolving_pip_install_is_wheels_only() {
+        // A dependency built from source needs a compiler the user was never
+        // asked to have, and fails minutes later with a clang/cargo error they
+        // cannot act on. `PIP_ONLY_BINARY` prevents that -- but only on the
+        // call sites that carry it, and these arg lists are copy-pasted across
+        // nine of them. Any install that resolves from an index must be
+        // wheels-only; the optional markitdown/serena addons deliberately do
+        // not resolve from `--extra-index-url` and so are not covered here.
+        let source = include_str!("tool_manager.rs");
+        let indexed = source.matches("\"--extra-index-url\",").count();
+        // Split so this needle does not count itself in the scan above.
+        let only_binary = source.matches(concat!("PIP_ONLY_", "BINARY,")).count();
+        assert!(indexed > 0, "sanity: expected index-resolving installs");
+        assert_eq!(
+            indexed, only_binary,
+            "an index-resolving pip install is missing PIP_ONLY_BINARY \
+             ({indexed} indexed installs vs {only_binary} wheels-only)"
+        );
     }
 
     #[test]

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -238,7 +238,7 @@ still compress -- so the flip stays. tool_result blocks compress
 regardless of this flag (the role gate only guards text blocks), so the
 coding token mass is unaffected.
 
-Also ports three fixes owed upstream (remove each once a wheel ships it),
+Also ports four fixes owed upstream (remove each once a wheel ships it),
 gated on HEADROOM_SDK=headroom-desktop-proxy so only the backend process
 pays the proxy import cost:
 Context-limit guard (upstream PR #2942): compression under-reports
@@ -266,6 +266,21 @@ clamp optimized to 0 and record savings rates above 100% ("4,436 -> 0,
 request's tools schema once per compressed HTTP request and widens the
 recorded pair at the outcome funnel so original - optimized == saved.
 Kill switch: HEADROOM_RESPONSES_DENOMINATOR_GUARD=0.
+Codex additional_tools guard (upstream issue #3185): Codex CLI 0.149.0
+stopped sending a top-level tools array on /v1/responses for models its
+capability cache flags (gpt-5.6-sol, its default) -- tool definitions
+ride inside input as items of type "additional_tools". Every tools
+consumer in the proxy (tool_schema_compaction, the output-shaper
+stratum, the tools token counts, the denominator guard above) reads
+only payload["tools"], so those requests classify "notools" and record
+zero savings (2026-08-21: 0/13 afternoon signups and 42/54 active
+codex users with frozen savings). The guard lifts the items' tools into
+a top-level array and drops the items from input before compression;
+the classic encoding is verified accepted by the ChatGPT Codex backend
+(live tool calls execute; Codex 0.142.4 sends it for the same model).
+No version gate: it self-neutralizes when payload["tools"] is already
+present, and 0.36.2 has no additional_tools support either. Kill
+switch: HEADROOM_ADDITIONAL_TOOLS_GUARD=0.
 """
 import faulthandler
 import signal
@@ -715,6 +730,78 @@ if _hd_os.environ.get("HEADROOM_SDK") == "headroom-desktop-proxy":
                     return await _hd_rd_orig_record(self, outcome)
 
                 _hd_rd_server.HeadroomProxy._record_request_outcome = _hd_rd_record
+    except Exception:
+        pass
+
+    # Codex additional_tools guard (upstream issue #3185; remove once a wheel
+    # ships support -- see the module docstring for the failure mode). Applied
+    # AFTER the denominator guard so this wrapper is outermost: the lift runs
+    # first at runtime and every inner layer (denominator widening included)
+    # sees the classic top-level tools shape. In-place on the caller's payload,
+    # so the outbound canonical serialization carries the lifted form too --
+    # deliberate: the ChatGPT Codex backend accepts the classic encoding for
+    # these models (Codex 0.142.4 still sends it), verified with live tool
+    # calls. Kill switch: HEADROOM_ADDITIONAL_TOOLS_GUARD=0.
+    try:
+        if _hd_os.environ.get(
+            "HEADROOM_ADDITIONAL_TOOLS_GUARD", "1"
+        ).strip().lower() not in ("0", "false", "no", "off"):
+            import logging as _hd_at_logging
+
+            import headroom.proxy.handlers.openai as _hd_at_openai
+
+            _hd_at_log = _hd_at_logging.getLogger("headroom.proxy")
+            _hd_at_announced = False
+
+            def _hd_at_lift(payload):
+                # Lift additional_tools input items into a top-level tools
+                # array, in place. No-op (0) unless the request uses the
+                # Codex >= 0.149.0 encoding and has no top-level tools.
+                global _hd_at_announced
+                if not isinstance(payload, dict) or payload.get("tools"):
+                    return 0
+                items = payload.get("input")
+                if not isinstance(items, list):
+                    return 0
+                lifted = []
+                kept = []
+                for item in items:
+                    if (
+                        isinstance(item, dict)
+                        and item.get("type") == "additional_tools"
+                        and isinstance(item.get("tools"), list)
+                        and item["tools"]
+                    ):
+                        lifted.extend(item["tools"])
+                    else:
+                        kept.append(item)
+                if not lifted:
+                    return 0
+                payload["tools"] = lifted
+                payload["input"] = kept
+                if not _hd_at_announced:
+                    _hd_at_announced = True
+                    _hd_at_log.info(
+                        "event=codex_additional_tools_lifted tools=%d "
+                        "(codex >= 0.149.0 encoding; desktop guard active)",
+                        len(lifted),
+                    )
+                return len(lifted)
+
+            _hd_at_orig_compress = (
+                _hd_at_openai.OpenAIHandlerMixin._compress_openai_responses_payload_in_executor
+            )
+
+            async def _hd_at_compress(self, payload, **kwargs):
+                try:
+                    _hd_at_lift(payload)
+                except Exception:
+                    pass
+                return await _hd_at_orig_compress(self, payload, **kwargs)
+
+            _hd_at_openai.OpenAIHandlerMixin._compress_openai_responses_payload_in_executor = (
+                _hd_at_compress
+            )
     except Exception:
         pass
 "#;
@@ -9334,6 +9421,36 @@ mod tests {
         assert!(py.contains("HEADROOM_RESPONSES_DENOMINATOR_GUARD"));
         // The stash must be bounded: entries for failed requests never pop.
         assert!(py.contains("_HD_RD_MAX"));
+    }
+
+    #[test]
+    fn sitecustomize_lifts_codex_additional_tools() {
+        // Upstream issue #3185: Codex CLI 0.149.0 moved tool definitions off
+        // the top-level tools array into input items of type
+        // "additional_tools" (gpt-5.6-sol default), so every tools consumer
+        // classified those requests "notools" and savings recorded zero.
+        // Verified live against the ChatGPT Codex backend on 2026-08-21:
+        // lifted requests compact (608 tokens/turn) and tool calls execute.
+        let py = super::SITECUSTOMIZE_PY;
+        assert!(py.contains("HEADROOM_ADDITIONAL_TOOLS_GUARD"));
+        assert!(py.contains(r#"item.get("type") == "additional_tools""#));
+        // Self-neutralizes on classic-encoding requests: a present top-level
+        // tools array must short-circuit the lift.
+        assert!(py.contains(r#"or payload.get("tools"):"#));
+        // The wrapper must be installed on the executor seam (the single
+        // funnel for HTTP, WS, and passthrough responses compression)...
+        assert!(py.contains(
+            "_hd_at_openai.OpenAIHandlerMixin._compress_openai_responses_payload_in_executor = ("
+        ));
+        // ...and AFTER the denominator guard's wrapper of the same method, so
+        // the lift is outermost and the widening sees the lifted tools.
+        let lift_pos = py
+            .find("_hd_at_openai.OpenAIHandlerMixin")
+            .expect("lift patch present");
+        let denom_pos = py
+            .find("_hd_rd_openai.OpenAIHandlerMixin")
+            .expect("denominator patch present");
+        assert!(denom_pos < lift_pos);
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.8.4-rc.21",
+  "version": "0.8.5-rc.1",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.8.5-rc.1",
+  "version": "0.8.5",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Promotes `0.8.5-rc.1` to stable.

Beta smoke test run on `0.8.5-rc.1` (macOS): checks 1, 2, 7, 8, 9, 10, 11a, 12, 13, 14, 15 PASS. Checks 3 and 4 correctly skipped (RTK and memory tools off on the test install). Checks 5, 6 and the Codex pass are manual and were not run.

Check 11b reported `structural_diff_vs_original` outside the doc's expected reason set. Investigated: it is not a new transform. The compression pipeline never calls `mark_mutated`, so compression is only ever witnessed by the structural safety net, and the reason predates this build (present in every rotated log back to Aug 20, wheel unchanged at 0.35.0). The discard itself is upstream #2990, unchanged. Smoke-test doc updated on `staging` accordingly.

No release notes for this version, by request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)