### PR TITLE
0.8.6

### DIFF
--- a/.github/release-notes/0.8.5.md
+++ b/.github/release-notes/0.8.5.md
@@ -1,0 +1,1 @@
+Codex hotfix. Please update if you use Codex.

--- a/.github/release-notes/0.8.6.md
+++ b/.github/release-notes/0.8.6.md
@@ -1,0 +1,1 @@
+More Codex stability fixes, please update if you use Codex.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.6-rc.1",
+  "version": "0.8.6-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.8.6-rc.1",
+      "version": "0.8.6-rc.2",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.5-rc.1",
+  "version": "0.8.6-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.8.5-rc.1",
+      "version": "0.8.6-rc.1",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.6-rc.2",
+  "version": "0.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.8.6-rc.2",
+      "version": "0.8.6",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.5-rc.1",
+  "version": "0.8.6-rc.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.6-rc.2",
+  "version": "0.8.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.6-rc.1",
+  "version": "0.8.6-rc.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.8.6-rc.1"
+version = "0.8.6-rc.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.8.6-rc.2"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.8.5-rc.1"
+version = "0.8.6-rc.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.8.5-rc.1"
+version = "0.8.6-rc.1"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.8.6-rc.2"
+version = "0.8.6"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.8.6-rc.1"
+version = "0.8.6-rc.2"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/src/client_adapters.rs
+++ b/src-tauri/src/client_adapters.rs
@@ -481,6 +481,10 @@ fn apply_client_setup_once(client_id: &str) -> Result<ClientSetupResult> {
             );
             if normalized_setup_id(client_id) == "codex_cli" {
                 steps.push(
+                    "Quit and reopen any Codex desktop app, CLI, or IDE sessions to load the managed provider."
+                        .into(),
+                );
+                steps.push(
                     "In Codex, run /hooks and trust the Headroom routing guard so it can warn you if routing breaks (re-trust if Headroom updates the guard)."
                         .into(),
                 );
@@ -740,13 +744,12 @@ pub fn list_client_connectors(
                 || setup_state
                     .remembered_clients
                     .contains_key(normalized_setup_id(spec.id));
-            let verified = if enabled {
-                verify_client_setup(spec.id)
-                    .map(|result| result.verified)
-                    .unwrap_or(false)
+            let verification = if enabled {
+                verify_client_setup(spec.id).ok()
             } else {
-                false
+                None
             };
+            let verified = verification.as_ref().is_some_and(|result| result.verified);
 
             ClientConnectorStatus {
                 client_id: spec.id.to_string(),
@@ -755,6 +758,7 @@ pub fn list_client_connectors(
                 enabled,
                 verified,
                 last_configured_at: configured_timestamp(&setup_state, spec.id),
+                verification,
             }
         })
         .collect();
@@ -8331,6 +8335,58 @@ export ANTHROPIC_BASE_URL=http://127.0.0.1:6767
             "quit-time clear after a pause must keep the restore snapshot, got: {:?}",
             state.remembered_clients
         );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn list_client_connectors_carries_verification_only_for_enabled_clients() {
+        // The connector panel keys its status line off these two fields: an
+        // enabled client must arrive with its checks attached (the panel has
+        // no other way to say what is wrong), and a disabled one must carry
+        // none, so the list never implies it verified something it skipped.
+        let _home = TestHome::new();
+        super::apply_client_setup("codex").expect("apply_client_setup succeeds");
+
+        // installed: false is the Codex desktop-app/IDE user -- they share
+        // ~/.codex/config.toml with the CLI, so the connector is configurable
+        // and verifiable without the CLI binary on disk.
+        let detected = vec![crate::models::ClientStatus {
+            id: "codex".to_string(),
+            name: "Codex".to_string(),
+            installed: false,
+            configured: true,
+            health: crate::models::ClientHealth::Healthy,
+            notes: Vec::new(),
+        }];
+        let connectors = super::list_client_connectors(&detected).expect("listing succeeds");
+
+        let codex = connectors
+            .iter()
+            .find(|connector| connector.client_id == "codex")
+            .expect("codex connector listed");
+        assert!(!codex.installed);
+        assert!(codex.enabled);
+        assert!(codex.verified);
+        let verification = codex
+            .verification
+            .as_ref()
+            .expect("verification attached for an enabled client");
+        assert_eq!(verification.verified, codex.verified);
+        assert!(
+            verification
+                .checks
+                .iter()
+                .any(|check| check.contains("config.toml")),
+            "config.toml check reported, got: {:?}",
+            verification.checks
+        );
+
+        let grok = connectors
+            .iter()
+            .find(|connector| connector.client_id == "grok_build")
+            .expect("grok connector listed");
+        assert!(!grok.enabled);
+        assert!(grok.verification.is_none());
     }
 
     #[test]

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -100,6 +100,23 @@ fn is_updater_endpoint_error(msg: &str) -> bool {
     msg.contains("update endpoint did not respond with a successful status code")
 }
 
+// tao panics with this on Windows session end (sign-out, shutdown, restart): the
+// event loop reaches a window whose state the OS already tore down while handling
+// WM_ENDSESSION. Our own teardown has run by then and the process is exiting
+// either way, so nothing is lost and no release can change the outcome. Fixed in
+// tao 0.37.0, which tauri-runtime-wry cannot take yet -- 2.11.4, the latest, still
+// requires `tao ^0.35.0`. RUST-84 and RUST-8D are the same panic from two more
+// hosts. Drop the event; re-check when tauri moves the pin.
+fn is_windows_session_end_panic(msg: &str) -> bool {
+    msg.contains("cannot move state from Destroyed")
+}
+
+// Environmental or otherwise unfixable-by-release: keep the local log, never
+// send. One predicate so panics and log records answer it the same way.
+fn is_unreportable(msg: &str) -> bool {
+    is_disk_full(msg) || is_windows_session_end_panic(msg)
+}
+
 // Drop transient transport errors (offline laptop, flaky wifi, upstream blip)
 // from Sentry. They still hit the local log file via write_record.
 fn skip_sentry(target: &str, msg: &str) -> bool {
@@ -298,6 +315,28 @@ fn skip_sentry(target: &str, msg: &str) -> bool {
     if target.starts_with("headroom_desktop_lib") && msg.starts_with("tray: set_tooltip failed") {
         return true;
     }
+    // tauri-runtime-wry logs a BARE `{e}` when webview.evaluate_script fails, so
+    // every Tauri emit to a webview that is minimized, suspended or already torn
+    // down bridges here as an error with no context and no call site. On one
+    // Windows host that is a per-emit loop: RUST-6H took 988 events in 24h from
+    // `Jan2022` alone, more than the entire fleet's Sentry volume over the same
+    // window. Nothing is actionable -- the backend keeps proxying, only the UI
+    // misses the event, and it heals when the webview comes back. Matched on the
+    // wry error Display because that is the whole message; keep the local log.
+    if target.starts_with("tauri_runtime_wry") && msg.starts_with("WebView2 error:") {
+        return true;
+    }
+    // Stopping without the lifecycle lock is the DESIGNED path, not a failure:
+    // `stop_headroom` deliberately caps its wait so a quit racing a launch can
+    // never hang the app with the window stuck on "Restarting...". The pkill
+    // sweep reaps whatever the racing spawn leaves behind. It fires on ordinary
+    // quit-during-launch across unrelated hosts (RUST-7Z), and there is no fix
+    // to ship -- the alternative is the unbounded wait this replaced.
+    if target.starts_with("headroom_desktop_lib::state")
+        && msg.starts_with("stop_headroom: lifecycle lock still held")
+    {
+        return true;
+    }
     false
 }
 
@@ -329,17 +368,17 @@ pub(crate) fn scrub_home(msg: &str) -> String {
 pub(crate) fn sanitize_event(
     event: sentry::protocol::Event<'static>,
 ) -> Option<sentry::protocol::Event<'static>> {
-    let environmental = event.message.as_deref().is_some_and(is_disk_full)
+    let environmental = event.message.as_deref().is_some_and(is_unreportable)
         || event
             .logentry
             .as_ref()
-            .is_some_and(|entry| is_disk_full(&entry.message))
+            .is_some_and(|entry| is_unreportable(&entry.message))
         || event
             .exception
             .values
             .iter()
             .filter_map(|exception| exception.value.as_deref())
-            .any(is_disk_full);
+            .any(is_unreportable);
     if environmental {
         return None;
     }
@@ -618,6 +657,53 @@ mod tests {
             "headroom_desktop_lib",
             "uninstall: removing serena failed: removing ~\\AppData\\Local\\Headroom\\headroom\\serena-venv: Access is denied. (os error 5)"
         ));
+    }
+
+    #[test]
+    fn skips_wry_evaluate_script_failures_but_not_other_wry_errors() {
+        // RUST-6H: 988 events in 24h from one Windows host, every one of them
+        // this bare wry Display bridged from tauri-runtime-wry's `log::error!("{e}")`.
+        assert!(skip_sentry(
+            "tauri_runtime_wry",
+            "WebView2 error: WindowsError(Error { code: HRESULT(0x8007139F), message: \"The group or resource is not in the correct state to perform the requested operation.\" })"
+        ));
+        // Other wry failures still report -- only the evaluate_script shape floods.
+        assert!(!skip_sentry(
+            "tauri_runtime_wry",
+            "failed to navigate to url http://localhost:1420: some error"
+        ));
+        // And the string alone is not a licence to drop it from our own modules.
+        assert!(!skip_sentry(
+            "headroom_desktop_lib::state",
+            "WebView2 error: something we emitted ourselves"
+        ));
+    }
+
+    #[test]
+    fn skips_stop_headroom_lifecycle_lock_fallback() {
+        // RUST-7Z: the capped wait IS the fix for the unbounded one; quitting
+        // during a launch takes this branch by design, on any platform.
+        assert!(skip_sentry(
+            "headroom_desktop_lib::state",
+            "stop_headroom: lifecycle lock still held after 2s; stopping without it"
+        ));
+        assert!(!skip_sentry(
+            "headroom_desktop_lib::state",
+            "stop_headroom: something else entirely"
+        ));
+    }
+
+    #[test]
+    fn drops_the_windows_session_end_panic() {
+        use super::is_unreportable;
+        // RUST-84/8D: tao's WM_ENDSESSION panic. Arrives as a panic through
+        // sentry's own integration, so skip_sentry never sees it -- sanitize_event
+        // is the only gate, and it reads this predicate.
+        assert!(is_unreportable("cannot move state from Destroyed"));
+        assert!(!is_unreportable("cannot move state from Running"));
+        // The disk-full rule this predicate absorbed still holds.
+        assert!(is_unreportable("write failed: No space left on device"));
+        assert!(!is_unreportable("write failed: permission denied"));
     }
 
     #[test]

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -321,9 +321,13 @@ fn skip_sentry(target: &str, msg: &str) -> bool {
     // Windows host that is a per-emit loop: RUST-6H took 988 events in 24h from
     // `Jan2022` alone, more than the entire fleet's Sentry volume over the same
     // window. Nothing is actionable -- the backend keeps proxying, only the UI
-    // misses the event, and it heals when the webview comes back. Matched on the
-    // wry error Display because that is the whole message; keep the local log.
-    if target.starts_with("tauri_runtime_wry") && msg.starts_with("WebView2 error:") {
+    // misses the event, and it heals when the webview comes back. Match the
+    // known transient HRESULT rather than wry's generic prefix so webview
+    // creation and startup failures still reach Sentry; keep the local log.
+    if target.starts_with("tauri_runtime_wry")
+        && msg.starts_with("WebView2 error:")
+        && msg.contains("HRESULT(0x8007139F)")
+    {
         return true;
     }
     // Stopping without the lifecycle lock is the DESIGNED path, not a failure:
@@ -667,7 +671,11 @@ mod tests {
             "tauri_runtime_wry",
             "WebView2 error: WindowsError(Error { code: HRESULT(0x8007139F), message: \"The group or resource is not in the correct state to perform the requested operation.\" })"
         ));
-        // Other wry failures still report -- only the evaluate_script shape floods.
+        // Other bare WebView2 errors may be creation/startup failures.
+        assert!(!skip_sentry(
+            "tauri_runtime_wry",
+            "WebView2 error: WindowsError(Error { code: HRESULT(0x80004005), message: \"Unspecified error.\" })"
+        ));
         assert!(!skip_sentry(
             "tauri_runtime_wry",
             "failed to navigate to url http://localhost:1420: some error"

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -395,6 +395,8 @@ pub struct ClientConnectorStatus {
     pub enabled: bool,
     pub verified: bool,
     pub last_configured_at: Option<String>,
+    #[serde(default)]
+    pub verification: Option<ClientSetupVerification>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -848,6 +850,11 @@ pub enum CodexPlanTier {
     Free,
     Go,
     Plus,
+    /// ChatGPT Pro Lite, the ~$100/mo mid-tier between Plus and Pro. Seen in
+    /// the fleet from 2026-08 (caught by the `plan_raw` passthrough) before
+    /// OpenAI announced it; any other spelling still falls through to
+    /// `Unknown` and rides out as a raw claim.
+    ProLite,
     Pro,
     Team,
     Business,
@@ -865,6 +872,7 @@ impl CodexPlanTier {
             "free" => CodexPlanTier::Free,
             "go" => CodexPlanTier::Go,
             "plus" => CodexPlanTier::Plus,
+            "prolite" => CodexPlanTier::ProLite,
             "pro" => CodexPlanTier::Pro,
             "team" => CodexPlanTier::Team,
             "business" => CodexPlanTier::Business,
@@ -884,6 +892,7 @@ impl CodexPlanTier {
             CodexPlanTier::Free => "free",
             CodexPlanTier::Go => "go",
             CodexPlanTier::Plus => "plus",
+            CodexPlanTier::ProLite => "prolite",
             CodexPlanTier::Pro => "pro",
             CodexPlanTier::Team => "team",
             CodexPlanTier::Business => "business",
@@ -921,9 +930,9 @@ pub fn headroom_tier_for_codex_plan(plan: &CodexPlanTier) -> Option<HeadroomSubs
         CodexPlanTier::Go | CodexPlanTier::Plus | CodexPlanTier::Team | CodexPlanTier::Business => {
             Some(HeadroomSubscriptionTier::Pro)
         }
-        CodexPlanTier::SelfServeBusinessUsageBased | CodexPlanTier::Edu => {
-            Some(HeadroomSubscriptionTier::Max5x)
-        }
+        CodexPlanTier::ProLite
+        | CodexPlanTier::SelfServeBusinessUsageBased
+        | CodexPlanTier::Edu => Some(HeadroomSubscriptionTier::Max5x),
         CodexPlanTier::Pro
         | CodexPlanTier::Enterprise
         | CodexPlanTier::EnterpriseCbpUsageBased
@@ -1271,6 +1280,9 @@ mod tests {
     fn codex_plan_tier_from_claim_is_trimmed_case_insensitive_with_unknown_fallback() {
         assert_eq!(CodexPlanTier::from_claim("Plus"), CodexPlanTier::Plus);
         assert_eq!(CodexPlanTier::from_claim("  TEAM "), CodexPlanTier::Team);
+        // ChatGPT Pro Lite: the claim OpenAI mints for the ~$100/mo mid-tier.
+        assert_eq!(CodexPlanTier::from_claim("prolite"), CodexPlanTier::ProLite);
+        assert_eq!(CodexPlanTier::ProLite.as_header_str(), "prolite");
         assert_eq!(
             CodexPlanTier::from_claim("chatgptpaidplan"),
             CodexPlanTier::Unknown
@@ -1299,6 +1311,7 @@ mod tests {
             assert_eq!(headroom_tier_for_codex_plan(&plan), Some(Max20x));
         }
         for plan in [
+            CodexPlanTier::ProLite,
             CodexPlanTier::SelfServeBusinessUsageBased,
             CodexPlanTier::Edu,
         ] {

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -935,7 +935,10 @@ fn metered_window(snapshot: &CodexRateLimitSnapshot) -> Option<&crate::models::C
 /// a weekly window — the gate depends on it and we previously had no field
 /// visibility. Credits ride along to spot seats burning workspace credits
 /// beyond their plan allowance (post-April-2026 credit-billed Codex): the
-/// upsell cohort the plan claim alone can't identify.
+/// upsell cohort the plan claim alone can't identify. Field result after four
+/// days (prod, 2026-08-22): 14 identities reported credits, 11 of them `0` on
+/// consumer Plus/Pro, and only one Business row - Business seats publish
+/// `primary=0@0` windows, so this string is all we will ever get from them.
 fn codex_usage_windows_summary(snapshot: &CodexRateLimitSnapshot) -> String {
     let part = |name: &str, window: Option<&crate::models::CodexUsageWindow>| {
         window.map(|w| match w.window_minutes {
@@ -2342,11 +2345,13 @@ fn codex_billing_type(plan: &CodexPlanTier, has_org: bool) -> Option<String> {
         | CodexPlanTier::Enterprise
         | CodexPlanTier::EnterpriseCbpUsageBased
         | CodexPlanTier::Edu => Some(plan.as_header_str().to_string()),
-        CodexPlanTier::Go | CodexPlanTier::Plus | CodexPlanTier::Pro => Some(if has_org {
-            plan.as_header_str().to_string()
-        } else {
-            "subscription".to_string()
-        }),
+        CodexPlanTier::Go | CodexPlanTier::Plus | CodexPlanTier::ProLite | CodexPlanTier::Pro => {
+            Some(if has_org {
+                plan.as_header_str().to_string()
+            } else {
+                "subscription".to_string()
+            })
+        }
     }
 }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -7235,26 +7235,36 @@ fn drop_rollup_backfill<T>(
 /// shallower, so 10% is the conservative choice across providers.
 const CACHE_READ_PRICE_RATIO: f64 = 0.10;
 
-/// True when the buckets imply a savings $/token materially above the $/token
-/// actually paid for input on the same traffic. A saved input token can never
-/// be worth more than sending it would have cost, so a rate past the paid rate
-/// means the upstream wheel changed what `compression_savings_usd` contains
-/// (e.g. 0.36.0 folded full-input-rate tool-schema dollars into it, implying
-/// $33/M on traffic actually paying $5/M). Both rates come from the same
-/// buckets, so the check self-calibrates to the user's model mix; the 1.5x
-/// headroom absorbs mix drift between saved and sent tokens. Volume floors
-/// keep a few cheap requests from tripping it on noise.
-fn savings_rate_implausible(daily_savings: &[DailySavingsPoint]) -> Option<(f64, f64)> {
+/// The most any provider bills for a single input token, in USD per million.
+/// Claude Fable 5 tops the Anthropic table at $10/M; the headroom above it
+/// absorbs a pricier model shipping before this constant is revisited.
+const MAX_PLAUSIBLE_INPUT_USD_PER_M: f64 = 15.0;
+
+/// True when the buckets imply a savings $/token that no provider charges for
+/// an input token. A saved input token is worth exactly the rate it would have
+/// been billed at, so a rate above every published input price means the
+/// upstream wheel changed what `compression_savings_usd` contains (0.36.0
+/// folded full-input-rate tool-schema dollars into it, implying $33/M).
+///
+/// The first cut compared against the rate actually paid on the same buckets --
+/// self-calibrating, and wrong: `total_tokens_sent` counts provider cache
+/// reads, which bill at a tenth of fresh input, so the paid rate is diluted by
+/// the user's cache hit rate. Past ~37% reads that dilution alone clears a 1.5x
+/// check, and Claude Code routinely runs 80%+. RUST-89/8C is what that cost: 12
+/// events across 9 hosts on the pinned, uncontaminated 0.35.0, plus a live
+/// /stats here reading 5.9x. The buckets carry no cache-free denominator
+/// (`cache_read_tokens` is None for any day the app did not observe), so the
+/// check is an absolute ceiling instead. Price paid: contamination that stays
+/// under the ceiling on a cheap-model mix goes unseen.
+fn savings_rate_implausible(daily_savings: &[DailySavingsPoint]) -> Option<f64> {
     let saved_usd: f64 = daily_savings.iter().map(|p| p.estimated_savings_usd).sum();
     let saved_tokens: u64 = daily_savings.iter().map(|p| p.estimated_tokens_saved).sum();
-    let paid_usd: f64 = daily_savings.iter().map(|p| p.actual_cost_usd).sum();
-    let sent_tokens: u64 = daily_savings.iter().map(|p| p.total_tokens_sent).sum();
-    if saved_tokens < 1_000_000 || sent_tokens < 1_000_000 || paid_usd < 1.0 {
+    // Volume floors: a handful of cheap requests is noise, not a semantics change.
+    if saved_tokens < 1_000_000 || saved_usd < 1.0 {
         return None;
     }
-    let savings_rate = saved_usd / saved_tokens as f64;
-    let paid_rate = paid_usd / sent_tokens as f64;
-    (savings_rate > paid_rate * 1.5).then_some((savings_rate * 1e6, paid_rate * 1e6))
+    let savings_per_m = saved_usd / saved_tokens as f64 * 1e6;
+    (savings_per_m > MAX_PLAUSIBLE_INPUT_USD_PER_M).then_some(savings_per_m)
 }
 
 /// Warn-only canary, once per process: a contaminated rate silently corrected
@@ -7265,12 +7275,12 @@ fn warn_once_if_savings_rate_implausible(daily_savings: &[DailySavingsPoint]) {
     if WARNED.load(std::sync::atomic::Ordering::Relaxed) {
         return;
     }
-    if let Some((savings_per_m, paid_per_m)) = savings_rate_implausible(daily_savings) {
+    if let Some(savings_per_m) = savings_rate_implausible(daily_savings) {
         WARNED.store(true, std::sync::atomic::Ordering::Relaxed);
         log::warn!(
-            "savings rate implausible: buckets imply ${savings_per_m:.2}/M saved vs \
-             ${paid_per_m:.2}/M actually paid for input; upstream savings semantics \
-             likely changed under the pinned wheel"
+            "savings rate implausible: buckets imply ${savings_per_m:.2}/M saved, above the \
+             ${MAX_PLAUSIBLE_INPUT_USD_PER_M:.2}/M ceiling for an input token; upstream savings \
+             semantics likely changed under the pinned wheel"
         );
     }
 }
@@ -7644,38 +7654,42 @@ mod tests {
     }
 
     #[test]
-    fn savings_rate_canary_flags_a_rate_above_what_input_actually_cost() {
+    fn savings_rate_canary_flags_a_rate_no_input_token_can_cost() {
         let with_spend = |tokens: u64, usd: f64, sent: u64, paid: f64| DailySavingsPoint {
             actual_cost_usd: paid,
             total_tokens_sent: sent,
             ..daily("2026-08-21", tokens, usd)
         };
 
-        // Healthy: $5/M saved on traffic paying $5/M for input.
+        // Healthy: $5/M saved, Opus 5's input rate.
         assert_eq!(
             savings_rate_implausible(&[with_spend(2_000_000, 10.0, 20_000_000, 100.0)]),
             None
         );
 
-        // The 0.36.0 fold shape: $33/M implied on traffic paying $5/M.
-        let (savings_per_m, paid_per_m) =
+        // The 0.36.0 fold shape: $33/M implied, past every published input price.
+        let savings_per_m =
             savings_rate_implausible(&[with_spend(2_000_000, 66.0, 20_000_000, 100.0)])
                 .expect("contaminated rate must trip the canary");
         assert!((savings_per_m - 33.0).abs() < 1e-6, "{savings_per_m}");
-        assert!((paid_per_m - 5.0).abs() < 1e-6, "{paid_per_m}");
 
-        // Below the volume/spend floors nothing fires, however wild the ratio:
+        // RUST-89/8C: a cache-heavy user on the pinned wheel. $5/M saved against
+        // 20M tokens sent for $17 -- a $0.85/M paid rate, because cache reads
+        // bill at a tenth and dominate the denominator. The old relative check
+        // read that as 5.9x and fired; a plausible savings rate must not.
+        assert_eq!(
+            savings_rate_implausible(&[with_spend(2_000_000, 10.0, 20_000_000, 17.0)]),
+            None
+        );
+
+        // Below the volume/spend floors nothing fires, however wild the rate:
         // a handful of cheap requests is noise, not a semantics change.
         assert_eq!(
             savings_rate_implausible(&[with_spend(500_000, 66.0, 20_000_000, 100.0)]),
             None
         );
         assert_eq!(
-            savings_rate_implausible(&[with_spend(2_000_000, 66.0, 500_000, 100.0)]),
-            None
-        );
-        assert_eq!(
-            savings_rate_implausible(&[with_spend(2_000_000, 66.0, 20_000_000, 0.5)]),
+            savings_rate_implausible(&[with_spend(2_000_000, 0.5, 20_000_000, 100.0)]),
             None
         );
         assert_eq!(savings_rate_implausible(&[]), None);

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -872,35 +872,38 @@ if _hd_os.environ.get("HEADROOM_SDK") == "headroom-desktop-proxy":
             async def _hd_at_compress(self, payload, **kwargs):
                 global _hd_at_warned
                 plan = []
+                result = None
                 try:
                     _hd_at_lift(payload, plan)
                 except Exception:
                     # The plan is deliberately kept: a lift that raised after
                     # mutating the payload is undone by the restore below.
                     pass
-                result = await _hd_at_orig_compress(self, payload, **kwargs)
-                if plan:
-                    try:
-                        # result[0] is what the call sites forward; the caller
-                        # payload is restored too, for the paths that forward
-                        # the object they passed in when nothing was modified.
+                try:
+                    result = await _hd_at_orig_compress(self, payload, **kwargs)
+                finally:
+                    if plan:
                         targets = [payload]
-                        out = result[0] if isinstance(result, tuple) and result else None
-                        if isinstance(out, dict) and out is not payload:
-                            targets.append(out)
-                        failed = [t for t in targets if not _hd_at_restore(t, plan)]
-                    except Exception:
-                        failed = targets
-                    if failed and not _hd_at_warned:
-                        # Logged once: the lifted shape is about to go out and
-                        # a stateful client will lose its tools after this
-                        # turn. Never silent.
-                        _hd_at_warned = True
-                        _hd_at_log.warning(
-                            "event=codex_additional_tools_restore_failed "
-                            "(forwarding lifted shape; set "
-                            "HEADROOM_ADDITIONAL_TOOLS_GUARD=0 to opt out)"
-                        )
+                        try:
+                            # result[0] is what the call sites forward; the caller
+                            # payload is restored too, for the paths that forward
+                            # the object they passed in when nothing was modified.
+                            out = result[0] if isinstance(result, tuple) and result else None
+                            if isinstance(out, dict) and out is not payload:
+                                targets.append(out)
+                            failed = [t for t in targets if not _hd_at_restore(t, plan)]
+                        except Exception:
+                            failed = targets
+                        if failed and not _hd_at_warned:
+                            # Logged once: the lifted shape is about to go out and
+                            # a stateful client will lose its tools after this
+                            # turn. Never silent.
+                            _hd_at_warned = True
+                            _hd_at_log.warning(
+                                "event=codex_additional_tools_restore_failed "
+                                "(forwarding lifted shape; set "
+                                "HEADROOM_ADDITIONAL_TOOLS_GUARD=0 to opt out)"
+                            )
                 return result
 
             _hd_at_openai.OpenAIHandlerMixin._compress_openai_responses_payload_in_executor = (
@@ -9733,6 +9736,87 @@ mod tests {
             .find("_hd_rd_openai.OpenAIHandlerMixin")
             .expect("denominator patch present");
         assert!(denom_pos < lift_pos);
+    }
+
+    #[test]
+    fn sitecustomize_restores_codex_additional_tools_when_compression_raises() {
+        let py = super::SITECUSTOMIZE_PY;
+        let guard = &py[py
+            .find("    # Codex additional_tools guard")
+            .expect("additional_tools guard present")..];
+        let mut script = r#"
+import asyncio
+import copy
+import os as _hd_os
+import sys
+import types
+
+headroom = types.ModuleType("headroom")
+headroom.__path__ = []
+proxy = types.ModuleType("headroom.proxy")
+proxy.__path__ = []
+handlers = types.ModuleType("headroom.proxy.handlers")
+handlers.__path__ = []
+openai = types.ModuleType("headroom.proxy.handlers.openai")
+
+class OpenAIHandlerMixin:
+    async def _compress_openai_responses_payload_in_executor(self, payload, **kwargs):
+        assert payload.get("tools"), payload
+        raise TimeoutError("boom")
+
+openai.OpenAIHandlerMixin = OpenAIHandlerMixin
+headroom.proxy = proxy
+proxy.handlers = handlers
+handlers.openai = openai
+sys.modules.update({
+    "headroom": headroom,
+    "headroom.proxy": proxy,
+    "headroom.proxy.handlers": handlers,
+    "headroom.proxy.handlers.openai": openai,
+})
+"#
+        .to_string();
+        script.push_str("if True:\n");
+        script.push_str(guard);
+        script.push_str(
+            r#"
+payload = {
+    "input": [
+        {"type": "message", "content": "before"},
+        {
+            "type": "additional_tools",
+            "id": "carrier",
+            "tools": [{"type": "function", "name": "shell"}],
+        },
+        {"type": "message", "content": "after"},
+    ]
+}
+original = copy.deepcopy(payload)
+
+async def verify():
+    try:
+        await OpenAIHandlerMixin()._compress_openai_responses_payload_in_executor(payload)
+    except TimeoutError:
+        pass
+    else:
+        raise AssertionError("compressor did not raise")
+    assert payload == original, (payload, original)
+
+asyncio.run(verify())
+"#,
+        );
+
+        let python = if cfg!(windows) { "python" } else { "python3" };
+        let out = match crate::proc::command(python).args(["-c", &script]).output() {
+            Ok(out) => out,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return,
+            Err(e) => panic!("spawn failed: {e}"),
+        };
+        assert!(
+            out.status.success(),
+            "additional_tools exception round-trip failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
     }
 
     #[test]

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -289,9 +289,12 @@ stratum, the tools token counts, the denominator guard above) reads
 only payload["tools"], so those requests classify "notools" and record
 zero savings (2026-08-21: 0/13 afternoon signups and 42/54 active
 codex users with frozen savings). The guard lifts the items' tools into
-a top-level array and drops the items from input before compression;
-the classic encoding is verified accepted by the ChatGPT Codex backend
-(live tool calls execute; Codex 0.142.4 sends it for the same model).
+a top-level array before compression and puts the compacted definitions
+back into the carrier before the payload is forwarded. The lift is
+internal only: tools is a per-request parameter while additional_tools
+is an input item, so forwarding the lifted shape costs a stateful
+session (Codex TUI/app-server over WS) its whole tool surface after
+turn one -- upstream #3194, the 0.36.3 regression from the same lift.
 No version gate: it self-neutralizes when payload["tools"] is already
 present, and 0.36.2 has no additional_tools support either. Kill
 switch: HEADROOM_ADDITIONAL_TOOLS_GUARD=0.
@@ -751,11 +754,11 @@ if _hd_os.environ.get("HEADROOM_SDK") == "headroom-desktop-proxy":
     # ships support -- see the module docstring for the failure mode). Applied
     # AFTER the denominator guard so this wrapper is outermost: the lift runs
     # first at runtime and every inner layer (denominator widening included)
-    # sees the classic top-level tools shape. In-place on the caller's payload,
-    # so the outbound canonical serialization carries the lifted form too --
-    # deliberate: the ChatGPT Codex backend accepts the classic encoding for
-    # these models (Codex 0.142.4 still sends it), verified with live tool
-    # calls. Kill switch: HEADROOM_ADDITIONAL_TOOLS_GUARD=0.
+    # sees the classic top-level tools shape. Symmetric: the lift is in place
+    # for the compression pass only, and the carrier goes back on the wire
+    # before the payload is forwarded (see _hd_at_restore -- forwarding the
+    # lifted shape is upstream's 0.36.3 regression, #3194). Kill switch:
+    # HEADROOM_ADDITIONAL_TOOLS_GUARD=0.
     try:
         if _hd_os.environ.get(
             "HEADROOM_ADDITIONAL_TOOLS_GUARD", "1"
@@ -767,10 +770,14 @@ if _hd_os.environ.get("HEADROOM_SDK") == "headroom-desktop-proxy":
             _hd_at_log = _hd_at_logging.getLogger("headroom.proxy")
             _hd_at_announced = False
 
-            def _hd_at_lift(payload):
+            _hd_at_warned = False
+
+            def _hd_at_lift(payload, plan):
                 # Lift additional_tools input items into a top-level tools
-                # array, in place. No-op (0) unless the request uses the
-                # Codex >= 0.149.0 encoding and has no top-level tools.
+                # array, in place, recording the carrier in `plan` so the
+                # forwarded payload can be put back the way Codex sent it.
+                # No-op (0) unless the request uses the Codex >= 0.149.0
+                # encoding and has no top-level tools.
                 global _hd_at_announced
                 if not isinstance(payload, dict) or payload.get("tools"):
                     return 0
@@ -779,6 +786,7 @@ if _hd_os.environ.get("HEADROOM_SDK") == "headroom-desktop-proxy":
                     return 0
                 lifted = []
                 kept = []
+                carrier = None
                 for item in items:
                     if (
                         isinstance(item, dict)
@@ -786,6 +794,17 @@ if _hd_os.environ.get("HEADROOM_SDK") == "headroom-desktop-proxy":
                         and isinstance(item.get("tools"), list)
                         and item["tools"]
                     ):
+                        if carrier is None:
+                            # Restore template: the carrier's own fields
+                            # minus the definitions, plus its position among
+                            # the items that survive the lift. Codex sends a
+                            # single carrier; extra carriers merge into this
+                            # one rather than being split on a boundary that
+                            # compaction may have invalidated.
+                            carrier = (
+                                {k: v for k, v in item.items() if k != "tools"},
+                                len(kept),
+                            )
                         lifted.extend(item["tools"])
                     else:
                         kept.append(item)
@@ -793,6 +812,7 @@ if _hd_os.environ.get("HEADROOM_SDK") == "headroom-desktop-proxy":
                     return 0
                 payload["tools"] = lifted
                 payload["input"] = kept
+                plan.append((carrier[0], carrier[1], list(lifted)))
                 if not _hd_at_announced:
                     _hd_at_announced = True
                     _hd_at_log.info(
@@ -802,16 +822,86 @@ if _hd_os.environ.get("HEADROOM_SDK") == "headroom-desktop-proxy":
                     )
                 return len(lifted)
 
+            def _hd_at_restore(payload, plan):
+                # Put the definitions back into the carrier Codex sent them
+                # in, post-compaction, and drop the top-level array. The lift
+                # is an internal normalization for the tools consumers; the
+                # forwarded shape must match what the client sent. `tools` is
+                # a per-request parameter while additional_tools is an input
+                # item and therefore part of the transcript, so a stateful
+                # session (Codex TUI/app-server over WS) declares its tools
+                # once and relies on the transcript for every later turn --
+                # forwarding the lifted shape leaves that transcript
+                # tool-less: turn one works, then all shell/filesystem access
+                # vanishes for the rest of the session (upstream #3194).
+                if not isinstance(payload, dict) or not plan:
+                    return 0
+                items = payload.get("input")
+                if not isinstance(items, list):
+                    return 0
+                if any(
+                    isinstance(item, dict)
+                    and item.get("type") == "additional_tools"
+                    and item.get("tools")
+                    for item in items
+                ):
+                    # Already in carrier form; restoring again would
+                    # duplicate the definitions. Keeps the restore idempotent.
+                    return 0
+                template, position, original = plan[0]
+                tools = payload.get("tools")
+                if not isinstance(tools, list) or not tools:
+                    # A consumer emptied the array. Restoring what Codex sent
+                    # is strictly safer than forwarding a tool-less payload.
+                    tools = original
+                if not tools:
+                    return 0
+                carrier = dict(template)
+                carrier["type"] = "additional_tools"
+                carrier["tools"] = list(tools)
+                restored = list(items)
+                restored.insert(min(max(position, 0), len(restored)), carrier)
+                payload["input"] = restored
+                payload.pop("tools", None)
+                return len(carrier["tools"])
+
             _hd_at_orig_compress = (
                 _hd_at_openai.OpenAIHandlerMixin._compress_openai_responses_payload_in_executor
             )
 
             async def _hd_at_compress(self, payload, **kwargs):
+                global _hd_at_warned
+                plan = []
                 try:
-                    _hd_at_lift(payload)
+                    _hd_at_lift(payload, plan)
                 except Exception:
+                    # The plan is deliberately kept: a lift that raised after
+                    # mutating the payload is undone by the restore below.
                     pass
-                return await _hd_at_orig_compress(self, payload, **kwargs)
+                result = await _hd_at_orig_compress(self, payload, **kwargs)
+                if plan:
+                    try:
+                        # result[0] is what the call sites forward; the caller
+                        # payload is restored too, for the paths that forward
+                        # the object they passed in when nothing was modified.
+                        targets = [payload]
+                        out = result[0] if isinstance(result, tuple) and result else None
+                        if isinstance(out, dict) and out is not payload:
+                            targets.append(out)
+                        failed = [t for t in targets if not _hd_at_restore(t, plan)]
+                    except Exception:
+                        failed = targets
+                    if failed and not _hd_at_warned:
+                        # Logged once: the lifted shape is about to go out and
+                        # a stateful client will lose its tools after this
+                        # turn. Never silent.
+                        _hd_at_warned = True
+                        _hd_at_log.warning(
+                            "event=codex_additional_tools_restore_failed "
+                            "(forwarding lifted shape; set "
+                            "HEADROOM_ADDITIONAL_TOOLS_GUARD=0 to opt out)"
+                        )
+                return result
 
             _hd_at_openai.OpenAIHandlerMixin._compress_openai_responses_payload_in_executor = (
                 _hd_at_compress
@@ -9604,6 +9694,36 @@ mod tests {
         assert!(py.contains(
             "_hd_at_openai.OpenAIHandlerMixin._compress_openai_responses_payload_in_executor = ("
         ));
+        // ...and the lift must be symmetric. Upstream #3194: tools is a
+        // per-request parameter, additional_tools is an input item and so
+        // part of the transcript, so a stateful Codex session (TUI/app-server
+        // over WS) declares its tools once and relies on the transcript
+        // afterwards -- forwarding the lifted shape gives it tools on turn
+        // one and none for the rest of the session. The carrier goes back,
+        // carrying the compacted definitions, before the payload is
+        // forwarded, and the top-level array is dropped.
+        assert!(py.contains("def _hd_at_restore(payload, plan):"));
+        assert!(py.contains(r#"payload.pop("tools", None)"#));
+        assert!(py.contains("failed = [t for t in targets if not _hd_at_restore(t, plan)]"));
+        // Both what the call sites forward (result[0]) and the payload the
+        // caller passed in are restored.
+        assert!(py.contains("out = result[0] if isinstance(result, tuple) and result else None"));
+        assert!(py.contains("targets = [payload]"));
+        // Restoring an already-restored payload must not duplicate the
+        // definitions, and an emptied array falls back to what Codex sent
+        // rather than forwarding a tool-less payload.
+        assert!(py.contains("if not isinstance(tools, list) or not tools:"));
+        assert!(py.contains("tools = original"));
+        // A restore that cannot happen is logged, never silent.
+        assert!(py.contains("event=codex_additional_tools_restore_failed"));
+        let restore_pos = py.find("def _hd_at_restore").expect("restore present");
+        let call_pos = py
+            .find("failed = [t for t in targets")
+            .expect("restore call present");
+        let orig_pos = py
+            .find("result = await _hd_at_orig_compress")
+            .expect("inner compress call present");
+        assert!(restore_pos < orig_pos && orig_pos < call_pos);
         // ...and AFTER the denominator guard's wrapper of the same method, so
         // the lift is outermost and the widening sees the lifted tools.
         let lift_pos = py

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.8.6-rc.2",
+  "version": "0.8.6",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.8.6-rc.1",
+  "version": "0.8.6-rc.2",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.8.5-rc.1",
+  "version": "0.8.6-rc.1",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -131,6 +131,7 @@ import {
   formatSelectedDayLabel,
   getEnabledSupportedConnectors,
   hasEnabledConnector,
+  hasNeverScanned,
   hourOfDayTickFormatter,
   mergeProviderSavingsForDisplay,
   percent1,
@@ -6566,6 +6567,7 @@ export default function App() {
                                   {!isRunning ? (
                                     <OptimizePanel
                                       projectPath={project.projectPath}
+                                      neverScanned={hasNeverScanned(project)}
                                       refreshSignal={
                                         isLatestLearnProject && !headroomLearnStatus.running
                                           ? Date.parse(headroomLearnStatus.finishedAt ?? "") || 0

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,6 +107,7 @@ import {
   aggregateClientConnectors,
   addDays,
   addMonths,
+  baseUrlTakeoverNotice,
   buildHourlySavingsChartData,
   buildHourlySavingsWindow,
   buildMonthlySavingsChartData,
@@ -116,6 +117,8 @@ import {
   outputReductionForWindow,
   compactNumber,
   connectorDashboardStatus,
+  connectorStatusLine,
+  clientSetupNotice,
   currency,
   currencyExact,
   dayOfMonthTickFormatter,
@@ -307,7 +310,7 @@ const connectorSetupDetails: Record<string, string> = {
   claude_code:
     "Headroom injects ANTHROPIC_BASE_URL into shell profiles and ~/.claude/settings.json so Claude Code connects through Headroom.",
   codex:
-    "Headroom writes a managed provider block to ~/.codex/config.toml and exports OPENAI_BASE_URL in your shell profiles so Codex connects through Headroom. It also installs a guard hook that warns you inside Codex if routing ever breaks - run /hooks in Codex once to trust it (re-trust after a Headroom update).",
+    "Codex CLI, the IDE extension, and the desktop app share ~/.codex/config.toml. Headroom adds a managed provider there and an OPENAI_BASE_URL shell export, plus a SessionStart guard that warns when routing breaks. In Codex CLI, run /hooks once to review and trust the guard (and again after it changes).",
   grok_build:
     "Headroom writes a managed proxy block to ~/.grok/config.toml and exports GROK_CLI_CHAT_PROXY_BASE_URL in your shell profiles so Grok Build connects through Headroom.",
   opencode:
@@ -346,7 +349,7 @@ const connectorUnavailableReasons: Record<string, string> = {
   claude_code:
     "Claude Code was not detected. Install the Claude Code CLI and restart Headroom. Note that Claude Code inside the Claude desktop app cannot be optimized: Anthropic's desktop app does not use the CLI's configuration, so Headroom never sees its requests. That is their design decision, not something Headroom can configure around.",
   codex:
-    "Codex was not detected. Install the Codex CLI and restart Headroom.",
+    "Codex CLI was not detected. Headroom can still configure the Codex desktop app and IDE extension; install the CLI only if you also want terminal use.",
   grok_build:
     "Grok Build was not detected. Install Grok Build and restart Headroom.",
   opencode:
@@ -569,10 +572,6 @@ function FirstSavingsChecklist({
       )}
     </div>
   );
-}
-
-function baseUrlTakeoverNotice(replaced: string): string {
-  return `Claude Code was routed through ${replaced}. Headroom now handles routing while enabled and restores this address when you disable the connector.`;
 }
 
 const idleHeadroomLearnStatus: HeadroomLearnStatus = {
@@ -4456,9 +4455,7 @@ export default function App() {
         const result = await invoke<ClientSetupResult>("apply_client_setup", {
           clientId: connector.clientId,
         });
-        setConnectorsNotice(
-          result.replacedBaseUrl ? baseUrlTakeoverNotice(result.replacedBaseUrl) : null
-        );
+        setConnectorsNotice(clientSetupNotice(connector.name, result));
       } else {
         await invoke("disable_client_setup", { clientId: connector.clientId });
         setConnectorsNotice(null);
@@ -5125,7 +5122,7 @@ export default function App() {
               const unavailableReason = getConnectorUnavailableReason(connector);
               const detectionWarning = getConnectorDetectionWarning(connector);
               const supportWarning = getConnectorSupportWarning(connector);
-              const needsRestart = connector.enabled && !connector.verified;
+              const statusLine = connectorStatusLine(connector);
               const gateBlocksEnable = connectorGateBlocksEnable(connector);
               return (
                 <article className="connector-item" key={connector.clientId}>
@@ -5175,10 +5172,8 @@ export default function App() {
                         {supportWarning}
                       </p>
                     ) : null}
-                    {needsRestart ? (
-                      <p className="connector-item__restart">
-                        Restart {connector.name} to apply changes.
-                      </p>
+                    {statusLine ? (
+                      <p className={`connector-item__${statusLine.tone}`}>{statusLine.text}</p>
                     ) : null}
                     {(detectionWarning ?? unavailableReason) ? (
                       <p className="connector-item__reason">
@@ -5394,8 +5389,8 @@ export default function App() {
       .filter((plan): plan is UpgradePlan => plan !== undefined);
     const paywallPlanFit: Record<string, string> = {
       pro: "For Claude Pro or ChatGPT Plus",
-      max5x: "Claude Max x5 & Codex Pro x5",
-      max20x: "Claude Max x20 & Codex Pro x20"
+      max5x: "Claude Max x5 & ChatGPT Pro Lite",
+      max20x: "Claude Max x20 & ChatGPT Pro"
     };
     const signedIn = pricingStatus?.authenticated === true;
     return (
@@ -7372,6 +7367,7 @@ export default function App() {
                     const unavailableReason = getConnectorUnavailableReason(connector);
                     const detectionWarning = getConnectorDetectionWarning(connector);
                     const gateBlocksEnable = connectorGateBlocksEnable(connector);
+                    const statusLine = connectorStatusLine(connector);
                     const toggleDisabled =
                       connectorsBusy ||
                       !canConfigureConnectorWithoutDetection(connector) ||
@@ -7399,14 +7395,50 @@ export default function App() {
                             </button>
                           </h3>
                           {openConnectorHelpId === connector.clientId ? (
-                            <p className="connector-tooltip">
-                              {connectorSetupDetails[connector.clientId] ??
-                                "Headroom applies local connector configuration."}
-                            </p>
+                            <div className="connector-tooltip">
+                              <p>
+                                {connectorSetupDetails[connector.clientId] ??
+                                  "Headroom applies local connector configuration."}
+                              </p>
+                              {connector.enabled ? (
+                                <div className="connector-diagnostics">
+                                  <strong>Connection checks</strong>
+                                  {connector.verification ? (
+                                    <ul>
+                                      {connector.verification.checks.map((check) => (
+                                        <li className="is-good" key={check}>
+                                          ✓ {check}
+                                        </li>
+                                      ))}
+                                      {connector.verification.failures.map((failure) => (
+                                        <li className="is-bad" key={failure}>
+                                          × {failure}
+                                        </li>
+                                      ))}
+                                      {!connector.verification.proxyReachable ? (
+                                        <li className="is-waiting">
+                                          … Headroom proxy is not answering on 127.0.0.1:6767.
+                                        </li>
+                                      ) : null}
+                                    </ul>
+                                  ) : (
+                                    <p>Verification details are not available yet.</p>
+                                  )}
+                                  <button
+                                    className="addon-card__link connector-diagnostics__refresh"
+                                    disabled={connectorsBusy}
+                                    onClick={() => void refreshConnectors()}
+                                    type="button"
+                                  >
+                                    {connectorsBusy ? "Checking…" : "Re-check"}
+                                  </button>
+                                </div>
+                              ) : null}
+                            </div>
                           ) : null}
-                          {connector.enabled && !connector.verified && connector.installed ? (
-                            <p className="connector-item__restart">
-                              Restart {connector.name} to start routing through Headroom.
+                          {statusLine ? (
+                            <p className={`connector-item__${statusLine.tone}`}>
+                              {statusLine.text}
                             </p>
                           ) : null}
                           {(detectionWarning ?? unavailableReason) ? (

--- a/src/components/OptimizePanel.test.tsx
+++ b/src/components/OptimizePanel.test.tsx
@@ -65,6 +65,24 @@ describe("OptimizePanel", () => {
     ).toBeDisabled();
   });
 
+  it("collapses to a single 'not scanned yet' pill when Learn has never run", () => {
+    render(
+      <OptimizePanel
+        projectPath="/proj"
+        preloadedApplied={{ claudeMd: [], memoryMd: [] }}
+        neverScanned
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /not scanned yet/i })).toBeDisabled();
+    expect(
+      screen.queryByRole("button", { name: /learnings in CLAUDE.local\.md/i })
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /reminders in MEMORY\.md/i })
+    ).toBeNull();
+  });
+
   it("opens the CLAUDE.md modal with the section list when the pill is clicked", async () => {
     render(
       <OptimizePanel projectPath="/proj" preloadedApplied={samplePatterns} />

--- a/src/components/OptimizePanel.tsx
+++ b/src/components/OptimizePanel.tsx
@@ -19,6 +19,9 @@ interface OptimizePanelProps {
   // Called after the panel mutates applied patterns (delete) so the parent
   // can refetch the shared aggregate. Only used when preloadedApplied is set.
   onAppliedMutated?: () => void;
+  // Learn has never run here, so zero counts mean "not scanned yet" rather
+  // than "scanned and found nothing". Collapses the two pills into one.
+  neverScanned?: boolean;
 }
 
 type ModalKind = null | "claude" | "memory";
@@ -28,6 +31,7 @@ export function OptimizePanel({
   refreshSignal,
   preloadedApplied,
   onAppliedMutated,
+  neverScanned = false,
 }: OptimizePanelProps) {
   const hasPreloadedApplied = preloadedApplied !== undefined;
   const [applied, setApplied] = useState<AppliedPatterns | null>(
@@ -107,6 +111,16 @@ export function OptimizePanel({
   const memoryCount = applied?.memoryMd.reduce((n, s) => n + s.bullets.length, 0) ?? 0;
   const claudeDisabled = applied === null || claudeCount === 0;
   const memoryDisabled = applied === null || memoryCount === 0;
+
+  if (neverScanned) {
+    return (
+      <span className="optimize-panel__pills">
+        <button type="button" className="optimize-panel__pill optimize-panel__pill--empty" disabled>
+          not scanned yet
+        </button>
+      </span>
+    );
+  }
 
   return (
     <>

--- a/src/lib/appHelpers.ts
+++ b/src/lib/appHelpers.ts
@@ -510,13 +510,13 @@ export function getUpgradePlans(
         "Use on all your devices with one account",
         "Email-based support"
       ], "Get Pro"),
-      max5x: paidPlan("max5x", "Max x5", "For Claude Max x5 or ChatGPT Pro x5 accounts", "Includes:", [
-        "Unlimited use with Claude Max x5 or ChatGPT Pro x5",
+      max5x: paidPlan("max5x", "Max x5", "For Claude Max x5 or ChatGPT Pro Lite accounts", "Includes:", [
+        "Unlimited use with Claude Max x5 or ChatGPT Pro Lite",
         "Use on all your devices with one account",
         "Email-based support"
       ], "Get Max x5"),
-      max20x: paidPlan("max20x", "Max x20", "For Claude Max x20 or ChatGPT Pro x20 accounts", "Includes:", [
-        "Unlimited use with Claude Max x20 or ChatGPT Pro x20",
+      max20x: paidPlan("max20x", "Max x20", "For Claude Max x20 or ChatGPT Pro accounts", "Includes:", [
+        "Unlimited use with Claude Max x20 or ChatGPT Pro",
         "Use on all your devices with one account",
         "Priority support"
       ], "Get Max x20"),

--- a/src/lib/dashboardHelpers.test.ts
+++ b/src/lib/dashboardHelpers.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   aggregateClientConnectors,
+  baseUrlTakeoverNotice,
   buildHourlySavingsChartData,
   buildHourlySavingsWindow,
   buildMonthlySavingsChartData,
@@ -10,6 +11,8 @@ import {
   outputReductionForWindow,
   compactNumber,
   connectorDashboardStatus,
+  connectorStatusLine,
+  clientSetupNotice,
   currency,
   currencyExact,
   dayOfMonthTickFormatter,
@@ -28,6 +31,7 @@ import {
 } from "./dashboardHelpers";
 import type {
   ClientConnectorStatus,
+  ClientSetupResult,
   DailySavingsPoint,
   HourlySavingsPoint
 } from "./types";
@@ -215,6 +219,82 @@ describe("dashboard helpers", () => {
       "cursor",
       "zed"
     ]);
+  });
+
+  it("keeps connector setup follow-up steps visible", () => {
+    const result: ClientSetupResult = {
+      clientId: "codex",
+      applied: true,
+      alreadyConfigured: false,
+      summary: "Configured",
+      changedFiles: [],
+      backupFiles: [],
+      nextSteps: ["Restart Codex.", "Run /hooks."],
+      verification: {
+        clientId: "codex",
+        verified: true,
+        proxyReachable: true,
+        checks: [],
+        failures: []
+      }
+    };
+
+    expect(clientSetupNotice("Codex", result)).toBe(
+      "Codex is configured through Headroom. Restart Codex. Run /hooks."
+    );
+    expect(baseUrlTakeoverNotice("https://gateway.example")).toContain(
+      "https://gateway.example"
+    );
+  });
+
+  it("reports connector status without mistaking an unrestarted client for a broken one", () => {
+    const now = Date.parse("2026-08-22T12:00:00Z");
+    const base: ClientConnectorStatus = {
+      clientId: "codex",
+      name: "Codex",
+      installed: false,
+      enabled: true,
+      verified: true,
+      lastConfiguredAt: "2026-08-22T11:00:00Z",
+      verification: {
+        clientId: "codex",
+        verified: true,
+        proxyReachable: true,
+        checks: ["Found Headroom-managed provider block in ~/.codex/config.toml."],
+        failures: []
+      }
+    };
+
+    // Just configured: the one thing Headroom cannot do for the user.
+    expect(connectorStatusLine(base, now)).toEqual({
+      text: "Quit and reopen Codex if it was running when you enabled this.",
+      tone: "restart"
+    });
+    // ...and it stops nagging a working setup the next day.
+    expect(connectorStatusLine(base, now + 25 * 60 * 60 * 1000)).toBeNull();
+    // Not installed is not a fault: Codex desktop/IDE share ~/.codex/config.toml.
+    expect(connectorStatusLine({ ...base, lastConfiguredAt: null }, now)).toBeNull();
+    expect(connectorStatusLine({ ...base, enabled: false }, now)).toBeNull();
+
+    expect(connectorStatusLine({ ...base, verified: false }, now)).toEqual({
+      text: "Setup is incomplete - open the info panel for the exact checks.",
+      tone: "reason"
+    });
+    expect(
+      connectorStatusLine({ ...base, verified: false, verification: null }, now)
+    ).toEqual({
+      text: "Setup could not be verified - open the info panel and re-check.",
+      tone: "reason"
+    });
+    expect(
+      connectorStatusLine(
+        { ...base, verification: { ...base.verification!, proxyReachable: false } },
+        now
+      )
+    ).toEqual({
+      text: "Configured. Headroom's proxy is not answering on 127.0.0.1:6767 yet.",
+      tone: "reason"
+    });
   });
 
   it("keeps codex, grok_build and opencode alongside claude_code as supported connectors", () => {

--- a/src/lib/dashboardHelpers.test.ts
+++ b/src/lib/dashboardHelpers.test.ts
@@ -21,6 +21,7 @@ import {
   formatDateTime,
   formatDayKey,
   formatLearnStatus,
+  hasNeverScanned,
   getEnabledSupportedConnectors,
   hasEnabledConnector,
   hourOfDayTickFormatter,
@@ -360,6 +361,9 @@ describe("dashboard helpers", () => {
     expect(formatLearnStatus({ lastLearnRanAt: "2026-03-27T08:00:00Z" })).toBe("last scan: today");
     expect(formatLearnStatus({ lastLearnRanAt: "2026-03-26T08:00:00Z" })).toBe("last scan: yesterday");
     expect(formatLearnStatus({ lastLearnRanAt: "2026-03-22T08:00:00Z" })).toBe("last scan: 5 days ago");
+    expect(hasNeverScanned({ lastLearnRanAt: null })).toBe(true);
+    expect(hasNeverScanned({ lastLearnRanAt: "invalid" })).toBe(true);
+    expect(hasNeverScanned({ lastLearnRanAt: "2026-03-22T08:00:00Z" })).toBe(false);
   });
 });
 

--- a/src/lib/dashboardHelpers.ts
+++ b/src/lib/dashboardHelpers.ts
@@ -1,5 +1,6 @@
 import type {
   ClientConnectorStatus,
+  ClientSetupResult,
   DailySavingsPoint,
   HourlySavingsPoint,
   ProviderSavingsPoint
@@ -550,6 +551,64 @@ const SUPPORTED_CONNECTOR_IDS = new Set([
   "opencode"
 ]);
 
+export function baseUrlTakeoverNotice(replaced: string): string {
+  return `This client was routed through ${replaced}. Headroom now handles routing while enabled and restores this address when you disable the connector.`;
+}
+
+export function clientSetupNotice(clientName: string, result: ClientSetupResult): string {
+  return [
+    result.replacedBaseUrl
+      ? baseUrlTakeoverNotice(result.replacedBaseUrl)
+      : `${clientName} is configured through Headroom.`,
+    ...result.nextSteps
+  ].join(" ");
+}
+
+export type ConnectorStatusLine = {
+  text: string;
+  tone: "reason" | "restart";
+};
+
+// A client picks up routing only when it restarts, and nothing local tells us
+// whether the user did. Rather than nag forever, the hint rides the configure
+// timestamp: relevant right after enabling, gone by the next day.
+const RESTART_HINT_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+export function connectorStatusLine(
+  connector: ClientConnectorStatus,
+  now: number = Date.now()
+): ConnectorStatusLine | null {
+  if (!connector.enabled) {
+    return null;
+  }
+  // `verified` attests only that Headroom wrote what it needed to write, so it
+  // is a setup failure, never "the client has not restarted yet".
+  if (!connector.verified) {
+    return {
+      text: connector.verification
+        ? "Setup is incomplete - open the info panel for the exact checks."
+        : "Setup could not be verified - open the info panel and re-check.",
+      tone: "reason"
+    };
+  }
+  if (connector.verification && !connector.verification.proxyReachable) {
+    return {
+      text: "Configured. Headroom's proxy is not answering on 127.0.0.1:6767 yet.",
+      tone: "reason"
+    };
+  }
+  const configuredAt = connector.lastConfiguredAt
+    ? Date.parse(connector.lastConfiguredAt)
+    : Number.NaN;
+  if (Number.isFinite(configuredAt) && now - configuredAt < RESTART_HINT_WINDOW_MS) {
+    return {
+      text: `Quit and reopen ${connector.name} if it was running when you enabled this.`,
+      tone: "restart"
+    };
+  }
+  return null;
+}
+
 export function aggregateClientConnectors(connectors: ClientConnectorStatus[]) {
   return connectors.filter((connector) =>
     SUPPORTED_CONNECTOR_IDS.has(connector.clientId)
@@ -603,4 +662,3 @@ export function connectorDashboardStatus(
   }
   return { label: "Active", tone: "active" };
 }
-

--- a/src/lib/dashboardHelpers.ts
+++ b/src/lib/dashboardHelpers.ts
@@ -527,14 +527,25 @@ export function formatRelativeTime(
   }).format(d);
 }
 
+function parsedLearnDate(project: { lastLearnRanAt: string | null }): Date | null {
+  if (!project.lastLearnRanAt) {
+    return null;
+  }
+  const parsed = new Date(project.lastLearnRanAt);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+// True when Learn has never produced a usable timestamp for this project, so
+// empty pattern counts mean "not scanned yet" rather than "scanned, found none".
+export function hasNeverScanned(project: { lastLearnRanAt: string | null }): boolean {
+  return parsedLearnDate(project) === null;
+}
+
 export function formatLearnStatus(project: {
   lastLearnRanAt: string | null;
 }): string {
-  if (!project.lastLearnRanAt) {
-    return "never scan";
-  }
-  const parsed = new Date(project.lastLearnRanAt);
-  if (Number.isNaN(parsed.getTime())) {
+  const parsed = parsedLearnDate(project);
+  if (!parsed) {
     return "never scan";
   }
   const diffMs = Date.now() - parsed.getTime();

--- a/src/lib/launcherHelpers.test.ts
+++ b/src/lib/launcherHelpers.test.ts
@@ -254,6 +254,8 @@ describe("launcher helpers", () => {
       // Standard Business/Team seats carry a Plus-level Codex allowance.
       expect(recommendedHeadroomTier(null, "team")).toBe("pro");
       expect(recommendedHeadroomTier(null, "business")).toBe("pro");
+      // ChatGPT Pro Lite is ~$100/mo, the Claude Max x5 price point.
+      expect(recommendedHeadroomTier(null, "prolite")).toBe("max5x");
       expect(recommendedHeadroomTier(null, "self_serve_business_usage_based")).toBe("max5x");
       expect(recommendedHeadroomTier(null, "edu")).toBe("max5x");
       expect(recommendedHeadroomTier(null, "pro")).toBe("max20x");

--- a/src/lib/launcherHelpers.ts
+++ b/src/lib/launcherHelpers.ts
@@ -93,7 +93,9 @@ export function recommendedHeadroomTier(
     codexTier === "team" ||
     codexTier === "business"
       ? "pro"
-    : codexTier === "self_serve_business_usage_based" || codexTier === "edu"
+    : codexTier === "prolite" ||
+        codexTier === "self_serve_business_usage_based" ||
+        codexTier === "edu"
       ? "max5x"
     : codexTier === "pro" ||
         codexTier === "enterprise" ||

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -254,6 +254,7 @@ export interface ClientConnectorStatus {
   enabled: boolean;
   verified: boolean;
   lastConfiguredAt?: string | null;
+  verification?: ClientSetupVerification | null;
 }
 
 export interface RuntimeStatus {
@@ -524,6 +525,7 @@ export type CodexPlanTier =
   | "free"
   | "go"
   | "plus"
+  | "prolite"
   | "pro"
   | "team"
   | "business"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,11 +11,18 @@ if (!navigator.userAgent.includes("Mac")) {
   document.documentElement.dataset.vibrancy = "none";
 }
 
-Sentry.init({
-  dsn: import.meta.env.VITE_SENTRY_DSN,
-  integrations: [Sentry.browserTracingIntegration()],
-  tracesSampleRate: 0.1,
-});
+// Packaged builds only. `npm run dev` serves this page to a plain browser, where
+// window.__TAURI_INTERNALS__ does not exist, so every startup invoke and event
+// listener throws on it -- RUST-8A/8B are 16 events of that, reported against no
+// release from a dev machine. Sentry calls are no-ops until init, so the rest of
+// the app's capture sites stay silent in dev rather than needing their own guard.
+if (import.meta.env.PROD) {
+  Sentry.init({
+    dsn: import.meta.env.VITE_SENTRY_DSN,
+    integrations: [Sentry.browserTracingIntegration()],
+    tracesSampleRate: 0.1,
+  });
+}
 
 function hideBootLoading() {
   const bootLoading = document.getElementById("boot-loading");

--- a/src/styles.css
+++ b/src/styles.css
@@ -61,6 +61,10 @@
   --warning-tint:       rgba(203, 128, 39, 0.12);
   --danger:             #c14b24;
   --danger-tint:        rgba(193, 75, 36, 0.12);
+  /* Passing-check green. Same pair .connector-state.is-good has always used
+     in both modes, promoted to a token so text on a plain surface can reach
+     for it without re-inlining the hex. */
+  --success:            #1f4a36;
 
   /* Activity feed badge accents — one hue per event kind */
   --activity-train-strong:     #2a5e80;
@@ -104,6 +108,7 @@
     --warning-tint:       rgba(220, 143, 26, 0.2);
     --danger:             #e76d3d;
     --danger-tint:        rgba(193, 75, 36, 0.2);
+    --success:            #6cbf9b;
 
     --activity-train-strong:     #8ac0e0;
     --activity-train-tint:       rgba(80, 150, 200, 0.22);
@@ -4005,6 +4010,44 @@ details[open] .optimize-minimal__details summary::after {
   line-height: 1.35;
   color: #59514a !important;
   max-width: 56ch;
+}
+
+.connector-tooltip > p {
+  margin: 0;
+}
+
+.connector-diagnostics {
+  margin-top: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--surface-sunken);
+}
+
+.connector-diagnostics ul {
+  margin: 5px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.connector-diagnostics li {
+  margin-top: 3px;
+}
+
+.connector-diagnostics .is-good {
+  color: var(--success);
+}
+
+.connector-diagnostics .is-bad {
+  color: var(--danger);
+}
+
+.connector-diagnostics .is-waiting {
+  color: var(--warning);
+}
+
+.connector-diagnostics__refresh {
+  margin-top: 6px;
 }
 
 .connector-tooltip--warning {


### PR DESCRIPTION
Stable promotion of the verified staging tip.

**What ships**
- Codex `additional_tools` guard now restores the carrier in a `finally`, so a compression exception can no longer forward the lifted (tool-less) shape on the HTTP fail-open path (upstream #3194).
- Sentry: the wry WebView2 skip is narrowed to the transient `HRESULT(0x8007139F)` flood (RUST-6H), so webview creation and startup failures report again.
- Learn: the Optimize pills collapse to a single "not scanned yet" pill when Learn has never run for a project.

**Verification**
- `cargo test --lib`: 944 passed, 0 failed
- `cargo fmt --check`, `npx tsc --noEmit`, `npx vitest run` (388 tests), `check-no-console`: clean
- Full embedded `SITECUSTOMIZE_PY` compiles under CPython
- rc-ancestor: `v0.8.6-rc.2` (fe387aa) is the parent of this bump

Release notes for the in-app update dialog: `.github/release-notes/0.8.6.md`.
