### PR TITLE
Re-cut 0.8.6: proxy-verify skip guard + first_optimized_request beacon fix

### DIFF
--- a/src-tauri/src/proxy_intercept.rs
+++ b/src-tauri/src/proxy_intercept.rs
@@ -999,7 +999,16 @@ async fn handle(
     // funnel signal: it can't fire on bypass/direct-to-provider or before the
     // backend is up (e.g. during bootstrap). Once per process; server is
     // first-write-wins so an extra send is cheap.
-    if !FIRST_OPTIMIZED_REQUEST_REPORTED.swap(true, Ordering::AcqRel) {
+    //
+    // `!is_local_backend_path` is load-bearing, not a tidy-up: the desktop polls
+    // its own dashboard through this listener (`127.0.0.1:6767/stats`), so
+    // without the guard the app fired this beacon at itself on the first
+    // successful poll after bootstrap -- landing in the same second as
+    // `bootstrap_completed`, before any client was even configured, and
+    // overstating the funnel step past the number of installs that finished
+    // bootstrapping. Same exclusion the per-client counters above already make.
+    // Note it also gates the `swap`: a local poll must not burn the one-shot.
+    if !is_local_backend_path && !FIRST_OPTIMIZED_REQUEST_REPORTED.swap(true, Ordering::AcqRel) {
         crate::pricing::report_funnel_step_device_only("first_optimized_request");
     }
     if parsed_head.as_ref().is_some_and(is_prompt_request_head)
@@ -2618,7 +2627,7 @@ mod tests {
         set_response_content_length, should_report_throttled, stamp_client_header,
         stamp_codex_client_header, stamp_headroom_bypass_header, stamp_request_header,
         strip_request_header, BypassFlag, CodexTerminalReader, ModelsRewrite, ParsedRequestHead,
-        SharedToken,
+        SharedToken, FIRST_OPTIMIZED_REQUEST_REPORTED,
     };
     use crate::backend_port;
     use crate::bearer::BearerToken;
@@ -2992,6 +3001,85 @@ mod tests {
                 .value_if_fresh(Duration::from_secs(60))
                 .map(|s| s.to_string()),
             Some("test-token-123".to_string())
+        );
+
+        run_task.abort();
+        backend_port::reset_for_tests();
+    }
+
+    /// The desktop polls its own dashboard through this listener
+    /// (`127.0.0.1:6767/stats`), so a local path reaching a live backend must
+    /// not fire the `first_optimized_request` funnel beacon -- it is supposed to
+    /// mean "a coding tool sent a request", and self-polling made it fire in the
+    /// same second bootstrap finished, before any client was configured.
+    ///
+    /// Only the negative case is asserted: letting the beacon fire would spawn a
+    /// thread POSTing to the real headroom-web.
+    #[tokio::test]
+    #[serial(backend_port)]
+    async fn local_backend_path_does_not_fire_first_optimized_request() {
+        use std::sync::atomic::Ordering;
+
+        let (backend_listener, backend_addr) = bind_ephemeral().await;
+        let backend_task = tokio::spawn(async move {
+            let (mut sock, _) = backend_listener.accept().await.expect("backend accept");
+            read_until_header_end(&mut sock).await;
+            let _ = sock
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+                .await;
+        });
+        backend_port::set(backend_addr.port());
+
+        // Other tests in this serial group may have flipped the one-shot; clear
+        // it so the assertion below is about this request and not test order.
+        FIRST_OPTIMIZED_REQUEST_REPORTED.store(false, Ordering::Release);
+
+        let intercept_listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("intercept bind");
+        let intercept_addr = intercept_listener.local_addr().expect("intercept addr");
+        drop(intercept_listener);
+        let (fresh_bearer_tx, _fresh_bearer_rx) = std::sync::mpsc::channel::<()>();
+        // Unroutable on purpose -- see the sibling test: a stray direct fallback
+        // must fail fast locally instead of calling api.anthropic.com.
+        let upstream_base = Arc::new("http://127.0.0.1:1".to_string());
+        let run_task = tokio::spawn(async move {
+            let _ = run(
+                intercept_addr,
+                Arc::new(Mutex::new(None)),
+                Arc::new(Mutex::new(None)),
+                Arc::new(Mutex::new(None)),
+                Arc::new(AtomicBool::new(false)),
+                Arc::new(AtomicBool::new(false)),
+                Arc::new(AtomicBool::new(false)),
+                fresh_bearer_tx,
+                upstream_base,
+                Arc::new(Mutex::new(None)),
+            )
+            .await;
+        });
+
+        let mut client = None;
+        for _ in 0..50 {
+            if let Ok(stream) = TcpStream::connect(intercept_addr).await {
+                client = Some(stream);
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        let mut client = client.expect("connect to intercept");
+        client
+            .write_all(b"GET /stats HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+            .await
+            .expect("write stats probe");
+
+        // The backend task completing proves the request was forwarded, so the
+        // beacon's fire site was reached and the guard is what held it back.
+        backend_task.await.expect("backend served the stats probe");
+
+        assert!(
+            !FIRST_OPTIMIZED_REQUEST_REPORTED.load(Ordering::Acquire),
+            "/stats is the app polling itself, not client traffic"
         );
 
         run_task.abort();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -142,6 +142,7 @@ import {
 } from "./lib/dashboardHelpers";
 import {
   buildInitialProxyVerificationRows,
+  formatConnectorNameList,
   getClaudeConnector,
   getContactRequestValidationError,
   getInitialLauncherStage,
@@ -813,7 +814,7 @@ function WindowRateChip({
     <div className="output-chip" ref={ref}>
       <button
         type="button"
-        className={`output-chip__button${open ? " is-open" : ""}`}
+        className={`output-chip__button${badge === "estimated" ? " output-chip__button--estimated" : ""}${open ? " is-open" : ""}`}
         aria-expanded={open}
         aria-label={`${title} details`}
         onClick={(e) => {
@@ -888,7 +889,7 @@ function OutputReductionChip({
     <div className="output-chip" ref={ref}>
       <button
         type="button"
-        className={`output-chip__button${open ? " is-open" : ""}`}
+        className={`output-chip__button${isMeasured ? "" : " output-chip__button--estimated"}${open ? " is-open" : ""}`}
         aria-expanded={open}
         aria-label="Output token reduction details"
         onClick={(e) => {
@@ -1624,6 +1625,13 @@ export default function App() {
   const [proxyVerificationHint, setProxyVerificationHint] = useState<
     { text: string; tone: "info" | "error" } | null
   >(null);
+  // Leaving the verify step unverified takes two clicks: the first arms the
+  // warning, the second leaves. 86% of installs used to click straight past
+  // this screen (median 26s, 45% under 15s) and the ones that did went on to
+  // send a first prompt 59% of the time vs 76% for the ones that waited -- the
+  // single biggest activation leak in onboarding, and invisible in support
+  // reports because nothing errors.
+  const [proxyVerifySkipArmed, setProxyVerifySkipArmed] = useState(false);
   const proxyVerificationRequestAnchorRef = useRef<Record<string, number> | null>(null);
   const [runtimeStatus, setRuntimeStatus] = useState<RuntimeStatus | null>(null);
   // Fresh install (no runtime on disk yet). Drives the onboarding email-harvest
@@ -4441,6 +4449,7 @@ export default function App() {
 
     setLauncherStage("proxy_verify");
     setProxyVerificationHint(null);
+    setProxyVerifySkipArmed(false);
     setProxyVerificationRows(buildInitialProxyVerificationRows(fresh));
     // Reset to null so the polling effect re-anchors on its first reachable
     // /stats reading. Setting it here would risk anchoring on a stale value
@@ -5297,6 +5306,12 @@ export default function App() {
     const allVerified =
       hasEnabledApps &&
       proxyVerificationRows.every((row) => row.state === "verified");
+    const unverified = proxyVerificationRows.filter((row) => row.state !== "verified");
+    const unverifiedNames = formatConnectorNameList(unverified.map((row) => row.name));
+    const finishSetup = () => {
+      void invoke("complete_setup_wizard");
+      setLauncherStage("post_install");
+    };
 
     return (
       <LauncherShell
@@ -5309,7 +5324,10 @@ export default function App() {
         <div className="post-install__lead">
           <h1>Test your setup</h1>
           <p>
-            Send "Say hi" in each connected tool to verify the connection is working. You may need to restart it first.
+            Restart each tool below, then send it any message - "Say hi" is
+            enough. Tools only pick up Headroom's setting when they launch, so
+            the restart is usually the missing step. This screen ticks over by
+            itself as each one checks in.
           </p>
           {hasEnabledApps ? (
             <div className="connector-list">
@@ -5348,6 +5366,13 @@ export default function App() {
               {proxyVerificationHint.text}
             </p>
           ) : null}
+          {!allVerified && proxyVerifySkipArmed ? (
+            <p className="install-progress__notice">
+              {hasEnabledApps
+                ? `We have not detected any ${unverifiedNames} activity flowing through our savings pipeline yet. You can skip and continue for now, but Headroom can only compress requests it sees, so your savings are likely to stay at zero. Restart ${unverifiedNames} to fix this.`
+                : "Headroom has nothing to optimize until a coding agent is connected and its requests flow through our savings pipeline. Your savings will stay at zero. You can connect one later from within the app if you prefer."}
+            </p>
+          ) : null}
         </div>
         <div className="post-install__actions">
           <button
@@ -5359,16 +5384,32 @@ export default function App() {
           >
             Back
           </button>
-          <button
-            className="primary-button primary-button--large primary-button--success"
-            onClick={() => {
-              void invoke("complete_setup_wizard");
-              setLauncherStage("post_install");
-            }}
-            type="button"
-          >
-            Continue
-          </button>
+          {allVerified ? (
+            <button
+              className="primary-button primary-button--large primary-button--success"
+              onClick={finishSetup}
+              type="button"
+            >
+              Continue
+            </button>
+          ) : (
+            // Deliberately not a primary button: leaving without a single
+            // verified connector is the path that ends in "Headroom didn't
+            // work", so it should not look like the happy path.
+            <button
+              className="secondary-button"
+              onClick={() => {
+                if (proxyVerifySkipArmed) {
+                  finishSetup();
+                  return;
+                }
+                setProxyVerifySkipArmed(true);
+              }}
+              type="button"
+            >
+              {proxyVerifySkipArmed ? "Skip anyway" : "Skip for now"}
+            </button>
+          )}
         </div>
       </LauncherShell>
     );

--- a/src/lib/launcherHelpers.test.ts
+++ b/src/lib/launcherHelpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildInitialProxyVerificationRows,
+  formatConnectorNameList,
   getClaudeConnector,
   getContactRequestValidationError,
   getInitialLauncherStage,
@@ -275,5 +276,18 @@ describe("launcher helpers", () => {
       expect(recommendedHeadroomTier("free", "free")).toBe("pro");
       expect(recommendedHeadroomTier("unknown", "unknown")).toBe("pro");
     });
+  });
+});
+
+describe("formatConnectorNameList", () => {
+  // Feeds the proxy-verify skip warning, which names the connectors that never
+  // checked in. Four can be enabled at once, so the 3+ case is real.
+  it("reads naturally at every connector count", () => {
+    expect(formatConnectorNameList([])).toBe("");
+    expect(formatConnectorNameList(["Claude Code"])).toBe("Claude Code");
+    expect(formatConnectorNameList(["Claude Code", "Codex"])).toBe("Claude Code and Codex");
+    expect(formatConnectorNameList(["Claude Code", "Codex", "OpenCode"])).toBe(
+      "Claude Code, Codex and OpenCode"
+    );
   });
 });

--- a/src/lib/launcherHelpers.ts
+++ b/src/lib/launcherHelpers.ts
@@ -224,3 +224,14 @@ export function buildInitialProxyVerificationRows(
       message: `Waiting for a ${connector.name} prompt...`
     }));
 }
+
+/// Join connector names for the skip warning on the proxy-verify step. Up to
+/// four connectors can be enabled at once, so a plain `join(" and ")` mangles
+/// the 3+ case. `Intl.ListFormat` does this properly but needs an ES2021 lib,
+/// and one warning line is not worth raising the whole project's target.
+export function formatConnectorNameList(names: string[]): string {
+  if (names.length <= 1) {
+    return names.join("");
+  }
+  return `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
+}


### PR DESCRIPTION
Re-cut of 0.8.6. The original v0.8.6 release and tag have been deleted; this
republishes the same version number with two onboarding/telemetry fixes folded in.

Safe to re-cut because 0.8.6 was 12 minutes old with no recorded adoption. Anyone
who did update in that window keeps the old build until the next release --
accepted tradeoff, the changes here only affect the install wizard and a funnel
beacon.

## What is in it

**Proxy-verify step is no longer a blind click-through.** 64 installs reached
"Test your setup" over the last three days and 9 verified. Median dwell was 26s,
45% under 15s, and those fast clickers sent a first prompt 59% of the time vs 76%
for the ones who waited. `Continue` now only appears once every connector
verifies; otherwise the exit is a secondary `Skip for now` that takes two clicks,
the first arming a warning that names the connectors which never checked in.

**`first_optimized_request` no longer fires at the app itself.** Its fire site
had no `is_local_proxy_path` guard, and the desktop polls its own dashboard
through this listener, so it landed on the first `/stats` poll after bootstrap --
before any client was configured. Cohort count read 68 against 65
`bootstrap_completed`. `first_prompt_request` stays the honest signal.

Held back: the output-shaping baseline work (`MIN_BASELINE_N`) is stashed, not in
this build.

## Verification

`cargo test --lib` 945 passed / 0 failed - `cargo fmt --check` clean - `tsc --noEmit`
clean - `vitest` 389 passed - `check-colors` and `check-no-console` pass.
Not visually verified in a running launcher; the skip warning reuses the existing
`.install-progress__notice` class, which is already built on the `--warning`
tokens defined in both light and dark.

Release notes for 0.8.6 are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
