### PR TITLE
0.8.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,3 +150,84 @@ jobs:
         # --no-fail-fast: enumerate every Windows failure in one run instead of
         # one class per approve/fix round while the platform is being hardened.
         run: cargo nextest run --no-fail-fast --manifest-path src-tauri/Cargo.toml
+
+  test-macos:
+    runs-on: macos-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12 (runtime lock check)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: macOS arm64 runtime lock resolves to wheels only
+        # Same gate as the Linux and Windows jobs, for the primary platform.
+        # The macOS lock splits pins by environment marker (onnxruntime 1.27.0
+        # on arm64, 1.23.2 on Intel), so this job only proves the arm64 branch
+        # resolves; macos-intel-lock covers the other. No --platform: pip
+        # matches wheel tags exactly rather than accepting older compatible
+        # ones, so resolving for the runner's own arch is the truer model.
+        run: >
+          python -m pip install --dry-run --no-deps --only-binary=:all:
+          --find-links https://github.com/gglucass/headroom-desktop/releases/expanded_assets/vendor-wheels-v1
+          -r src-tauri/python/headroom-requirements.lock
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            src-tauri -> target
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Run app test suite
+        # macOS is the primary platform but was previously only gated inside
+        # the release workflows, so a macOS-only regression reached staging
+        # green and surfaced at release cut. Gate it on PR instead.
+        run: ./scripts/verify-release.sh
+
+  macos-intel-lock:
+    # Intel Macs still receive the shipped app: the release builds
+    # --target universal-apple-darwin. A pin whose macOS wheels are arm64-only
+    # is a bootstrap dead end for every Intel user (RUST, 2026-08-20:
+    # onnxruntime resolved to a version with no x86_64 macOS wheel and the
+    # install could not complete). Only Python is needed, so this stays a thin
+    # job rather than a second full test matrix entry.
+    # macos-15-intel is the last x86_64 image Actions offers, available until
+    # roughly August 2027; macos-13 was retired in December 2025.
+    runs-on: macos-15-intel
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12 (runtime lock check)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: macOS x86_64 runtime lock resolves to wheels only
+        run: >
+          python -m pip install --dry-run --no-deps --only-binary=:all:
+          --find-links https://github.com/gglucass/headroom-desktop/releases/expanded_assets/vendor-wheels-v1
+          -r src-tauri/python/headroom-requirements.lock

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.7-rc.6",
+  "version": "0.8.7-rc.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.8.7-rc.6",
+      "version": "0.8.7-rc.7",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.7-rc.7",
+  "version": "0.8.7-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.8.7-rc.7",
+      "version": "0.8.7-rc.8",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.6",
+  "version": "0.8.7-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.8.6",
+      "version": "0.8.7-rc.1",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.7-rc.2",
+  "version": "0.8.7-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.8.7-rc.2",
+      "version": "0.8.7-rc.3",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.7-rc.8",
+  "version": "0.8.7-rc.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.8.7-rc.8",
+      "version": "0.8.7-rc.9",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.7-rc.3",
+  "version": "0.8.7-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.8.7-rc.3",
+      "version": "0.8.7-rc.4",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.7-rc.9",
+  "version": "0.8.7-rc.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.8.7-rc.9",
+      "version": "0.8.7-rc.10",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.7-rc.1",
+  "version": "0.8.7-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.8.7-rc.1",
+      "version": "0.8.7-rc.2",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.7-rc.5",
+  "version": "0.8.7-rc.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.8.7-rc.5",
+      "version": "0.8.7-rc.6",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.7-rc.4",
+  "version": "0.8.7-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.8.7-rc.4",
+      "version": "0.8.7-rc.5",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.7-rc.10",
+  "version": "0.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.8.7-rc.10",
+      "version": "0.8.7",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.6",
+  "version": "0.8.7-rc.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.7-rc.8",
+  "version": "0.8.7-rc.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.7-rc.1",
+  "version": "0.8.7-rc.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.7-rc.5",
+  "version": "0.8.7-rc.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.7-rc.2",
+  "version": "0.8.7-rc.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.7-rc.3",
+  "version": "0.8.7-rc.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.7-rc.9",
+  "version": "0.8.7-rc.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.7-rc.10",
+  "version": "0.8.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.7-rc.6",
+  "version": "0.8.7-rc.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.7-rc.7",
+  "version": "0.8.7-rc.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.8.7-rc.4",
+  "version": "0.8.7-rc.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.8.7-rc.4"
+version = "0.8.7-rc.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.8.7-rc.10"
+version = "0.8.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.8.7-rc.7"
+version = "0.8.7-rc.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.8.7-rc.2"
+version = "0.8.7-rc.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.8.7-rc.8"
+version = "0.8.7-rc.9"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.8.7-rc.1"
+version = "0.8.7-rc.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.8.7-rc.5"
+version = "0.8.7-rc.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.8.7-rc.6"
+version = "0.8.7-rc.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.8.6"
+version = "0.8.7-rc.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.8.7-rc.3"
+version = "0.8.7-rc.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.8.7-rc.9"
+version = "0.8.7-rc.10"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.8.7-rc.2"
+version = "0.8.7-rc.3"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.8.7-rc.7"
+version = "0.8.7-rc.8"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.8.7-rc.10"
+version = "0.8.7"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.8.7-rc.4"
+version = "0.8.7-rc.5"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.8.7-rc.8"
+version = "0.8.7-rc.9"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.8.6"
+version = "0.8.7-rc.1"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.8.7-rc.9"
+version = "0.8.7-rc.10"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.8.7-rc.1"
+version = "0.8.7-rc.2"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.8.7-rc.3"
+version = "0.8.7-rc.4"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.8.7-rc.6"
+version = "0.8.7-rc.7"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.8.7-rc.5"
+version = "0.8.7-rc.6"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/src/analytics.rs
+++ b/src-tauri/src/analytics.rs
@@ -48,6 +48,11 @@ const ALLOWED_EVENTS: &[&str] = &[
     "caveman_enabled",
     "caveman_disabled",
     "caveman_uninstalled",
+    // Open-source plugin/CLI coexistence, at most once per app start and only
+    // when something is actually present. Tells us how many users run the OSS
+    // Claude Code plugin next to the app, whether its bare hook was absorbed, and
+    // how many have an OSS proxy on :8787 taking traffic we never see.
+    "oss_plugin_detected",
     // Feature engagement: learn runs (per run, `agent` property) and Activity
     // tab opens (once per app run, mirroring app_started's cadence).
     "headroom_learn_run",

--- a/src-tauri/src/claude_cli.rs
+++ b/src-tauri/src/claude_cli.rs
@@ -45,7 +45,11 @@ pub(crate) fn probe_known_paths(name: &str) -> Option<PathBuf> {
 }
 
 fn known_path_candidates(home: PathBuf, name: &str) -> Vec<PathBuf> {
-    vec![
+    known_path_candidates_for_platform(home, name, cfg!(windows))
+}
+
+fn known_path_candidates_for_platform(home: PathBuf, name: &str, windows: bool) -> Vec<PathBuf> {
+    let base = vec![
         // The official installer (`curl -fsSL https://claude.ai/install.sh | bash`,
         // which our own "Install the Claude Code CLI" banner suggests) drops the
         // binary here. GUI launches inherit launchd's bare PATH so `find_on_path`
@@ -60,7 +64,19 @@ fn known_path_candidates(home: PathBuf, name: &str) -> Vec<PathBuf> {
         home.join(".volta").join("bin").join(name),
         home.join(".bun").join("bin").join(name),
         PathBuf::from(format!("/usr/bin/{name}")),
-    ]
+    ];
+    if !windows {
+        return base;
+    }
+
+    let mut candidates = Vec::with_capacity(base.len() * 5);
+    for path in base {
+        for extension in ["exe", "cmd", "bat", "com"] {
+            candidates.push(path.with_extension(extension));
+        }
+        candidates.push(path);
+    }
+    candidates
 }
 
 fn first_runnable<I: Iterator<Item = PathBuf>>(candidates: I) -> Option<PathBuf> {
@@ -538,6 +554,19 @@ mod tests {
             candidates.first().map(PathBuf::as_path),
             Some(Path::new("/Users/test/.local/bin/claude")),
         );
+    }
+
+    #[test]
+    fn known_windows_paths_probe_executable_extensions() {
+        let candidates =
+            known_path_candidates_for_platform(PathBuf::from("/Users/test"), "headroom", true);
+        assert_eq!(
+            candidates.first().map(PathBuf::as_path),
+            Some(Path::new("/Users/test/.local/bin/headroom.exe")),
+        );
+        assert!(candidates
+            .iter()
+            .any(|path| path == Path::new("/Users/test/.local/bin/headroom.cmd")));
     }
 
     #[test]

--- a/src-tauri/src/claude_cli.rs
+++ b/src-tauri/src/claude_cli.rs
@@ -29,15 +29,18 @@ fn detect_cli(name: &str) -> Option<PathBuf> {
     // Context7 and plugin addons reported "not found on PATH" on every Windows
     // box regardless of what was installed. On Unix it is a cheap extra hit
     // ahead of the 2s interactive-shell probe.
-    if let Some(path) = crate::client_adapters::find_on_path(&[name]) {
-        if is_runnable(&path) {
-            return Some(path);
-        }
+    if let Some(path) = probe_on_path(name) {
+        return Some(path);
     }
     probe_via_login_shell(name)
 }
 
-fn probe_known_paths(name: &str) -> Option<PathBuf> {
+pub(crate) fn probe_on_path(name: &str) -> Option<PathBuf> {
+    let path = crate::client_adapters::find_on_path(&[name])?;
+    is_runnable(&path).then_some(path)
+}
+
+pub(crate) fn probe_known_paths(name: &str) -> Option<PathBuf> {
     first_runnable(known_path_candidates(home_dir(), name).into_iter())
 }
 
@@ -345,6 +348,26 @@ mod tests {
         fs::write(&path, "#!/bin/sh\nexit 0\n").unwrap();
         // Exec bit not set — must short-circuit without spawning.
         assert!(!is_runnable(&path));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn probe_on_path_rejects_an_existing_but_broken_entry() {
+        let _env_lock = crate::test_env_lock::HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let tmp = ScopedTempDir::new("path_broken");
+        fs::write(tmp.path().join("headroom"), "not executable\n").unwrap();
+        let saved_path = std::env::var_os("PATH");
+        std::env::set_var("PATH", tmp.path());
+
+        let found = probe_on_path("headroom");
+
+        match saved_path {
+            Some(path) => std::env::set_var("PATH", path),
+            None => std::env::remove_var("PATH"),
+        }
+        assert!(found.is_none());
     }
 
     #[test]

--- a/src-tauri/src/claude_cli.rs
+++ b/src-tauri/src/claude_cli.rs
@@ -369,9 +369,7 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn probe_on_path_rejects_an_existing_but_broken_entry() {
-        let _env_lock = crate::test_env_lock::HOME_ENV_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _env_lock = crate::test_env_lock::lock_home();
         let tmp = ScopedTempDir::new("path_broken");
         fs::write(tmp.path().join("headroom"), "not executable\n").unwrap();
         let saved_path = std::env::var_os("PATH");
@@ -549,10 +547,13 @@ mod tests {
         // ~/.local/bin, which GUI-launched processes cannot see (launchd hands us
         // PATH=/usr/bin:/bin:/usr/sbin:/sbin). Absent from this list, a stock
         // install was invisible whenever the login-shell probe also failed.
+        // Assert the directory, not the filename: on Windows the first
+        // candidate is `claude.exe` in that same directory (the extension
+        // sweep is pinned by known_windows_paths_probe_executable_extensions).
         let candidates = known_path_candidates(PathBuf::from("/Users/test"), "claude");
         assert_eq!(
-            candidates.first().map(PathBuf::as_path),
-            Some(Path::new("/Users/test/.local/bin/claude")),
+            candidates.first().and_then(|path| path.parent()),
+            Some(Path::new("/Users/test/.local/bin")),
         );
     }
 

--- a/src-tauri/src/claude_cli.rs
+++ b/src-tauri/src/claude_cli.rs
@@ -43,6 +43,13 @@ fn probe_known_paths(name: &str) -> Option<PathBuf> {
 
 fn known_path_candidates(home: PathBuf, name: &str) -> Vec<PathBuf> {
     vec![
+        // The official installer (`curl -fsSL https://claude.ai/install.sh | bash`,
+        // which our own "Install the Claude Code CLI" banner suggests) drops the
+        // binary here. GUI launches inherit launchd's bare PATH so `find_on_path`
+        // cannot see it, and the login-shell probe is a coin flip against a noisy
+        // or slow `.zshrc` -- so a stock install was undetectable (issue #59).
+        // First, because that is the order the user's own shell resolves it in.
+        home.join(".local").join("bin").join(name),
         home.join(".claude").join("local").join(name),
         PathBuf::from(format!("/opt/homebrew/bin/{name}")),
         PathBuf::from(format!("/usr/local/bin/{name}")),
@@ -75,7 +82,7 @@ fn probe_via_login_shell(name: &str) -> Option<PathBuf> {
     read_path_from_shell(command, SHELL_LOOKUP_TIMEOUT)
 }
 
-/// Spawns `command`, reads the first non-empty line from its stdout, kills
+/// Spawns `command`, reads the first stdout line naming an existing file, kills
 /// the child, and returns the line as a validated `PathBuf`. The timeout
 /// bounds how long we wait for that first line — NOT how long we wait for
 /// the child to exit. Interactive shells (`-ilc`) print the `command -v`
@@ -95,7 +102,11 @@ fn read_path_from_shell(mut command: Command, timeout: Duration) -> Option<PathB
         let reader = BufReader::new(stdout);
         for line in reader.lines().map_while(Result::ok) {
             let trimmed = line.trim().to_string();
-            if trimmed.is_empty() {
+            // Interactive shells source the user's rc files *before* running
+            // our `command -v`, so the first line on the pipe is frequently an
+            // rc-file banner. Skip anything that does not name a real file
+            // instead of handing the caller the banner and giving up.
+            if trimmed.is_empty() || !Path::new(&trimmed).is_file() {
                 continue;
             }
             let _ = tx.send(trimmed);
@@ -490,6 +501,40 @@ mod tests {
         assert!(
             elapsed < Duration::from_secs(2),
             "should return as soon as the first line arrives, not wait for the sleep; took {elapsed:?}",
+        );
+    }
+
+    #[test]
+    fn known_path_candidates_probe_the_official_installer_target_first() {
+        // Issue #59: `curl -fsSL https://claude.ai/install.sh | bash` installs to
+        // ~/.local/bin, which GUI-launched processes cannot see (launchd hands us
+        // PATH=/usr/bin:/bin:/usr/sbin:/sbin). Absent from this list, a stock
+        // install was invisible whenever the login-shell probe also failed.
+        let candidates = known_path_candidates(PathBuf::from("/Users/test"), "claude");
+        assert_eq!(
+            candidates.first().map(PathBuf::as_path),
+            Some(Path::new("/Users/test/.local/bin/claude")),
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn read_path_from_shell_skips_rc_file_banner_lines() {
+        // Regression: `zsh -ilc` sources .zshrc before running `command -v`, so
+        // anything the user's rc file prints lands on the pipe first. Taking the
+        // first non-empty line handed us the banner and reported "not installed".
+        let tmp = ScopedTempDir::new("probe_noisy_rc");
+        let fake_claude = tmp.path().join("claude");
+        make_executable(&fake_claude);
+        let claude_str = fake_claude.display().to_string();
+
+        let mut cmd = crate::proc::command("/bin/sh");
+        cmd.arg("-c")
+            .arg(format!("echo 'Welcome back!'; echo ''; echo {claude_str}"));
+
+        assert_eq!(
+            read_path_from_shell(cmd, Duration::from_secs(2)).as_deref(),
+            Some(fake_claude.as_path()),
         );
     }
 

--- a/src-tauri/src/client_adapters.rs
+++ b/src-tauri/src/client_adapters.rs
@@ -1015,7 +1015,7 @@ fn clear_readonly(path: &Path, perms: std::fs::Permissions) {
 /// stanza without destroying user data that belongs to `zap` — see
 /// docs/macos-release.md. Idempotent: safe to run when the app is not running,
 /// and safe to run twice.
-pub fn revert_external_mutations() -> Vec<String> {
+fn revert_external_mutations_with_status() -> (Vec<String>, bool) {
     let mut removed: Vec<String> = Vec::new();
 
     // Reverse settings.json mutations and shell blocks for every known client.
@@ -1061,6 +1061,10 @@ pub fn revert_external_mutations() -> Vec<String> {
         log::warn!("cleanup: removing Claude guard hook failed: {err}");
     }
 
+    // Restore the open-source Claude Code plugin hook if we neutralized it.
+    let (oss_hooks_pending, restored_oss_hooks) = restore_oss_plugin_hooks();
+    removed.extend(restored_oss_hooks);
+
     for hook_path in [headroom_rtk_hook_path(), headroom_markitdown_hook_path()] {
         if hook_path.exists() {
             match std::fs::remove_file(&hook_path) {
@@ -1105,7 +1109,11 @@ pub fn revert_external_mutations() -> Vec<String> {
     #[cfg(target_os = "linux")]
     removed.extend(remove_linux_autostart_entries());
 
-    removed
+    (removed, oss_hooks_pending)
+}
+
+pub fn revert_external_mutations() -> Vec<String> {
+    revert_external_mutations_with_status().0
 }
 
 /// Full uninstall: everything `revert_external_mutations` undoes, plus every
@@ -1116,7 +1124,7 @@ pub fn revert_external_mutations() -> Vec<String> {
 /// a Homebrew cask's `uninstall` must not delete user data, which is what `zap`
 /// is for.
 pub fn perform_full_cleanup() -> Vec<String> {
-    let mut removed = revert_external_mutations();
+    let (mut removed, oss_hooks_pending) = revert_external_mutations_with_status();
 
     // Also wipe the per-client setup-state file so a reinstall starts clean.
     let setup_state = setup_state_path();
@@ -1126,9 +1134,16 @@ pub fn perform_full_cleanup() -> Vec<String> {
 
     let app_dir = app_data_dir();
     if app_dir.exists() {
-        match remove_dir_all_retry(&app_dir) {
-            Ok(_) => removed.push(app_dir.display().to_string()),
-            Err(err) => log::warn!("cleanup: removing {} failed: {err}", app_dir.display()),
+        if oss_hooks_pending {
+            log::warn!(
+                "cleanup: preserving {} because an OSS Claude plugin hook still needs restoration",
+                app_dir.display()
+            );
+        } else {
+            match remove_dir_all_retry(&app_dir) {
+                Ok(_) => removed.push(app_dir.display().to_string()),
+                Err(err) => log::warn!("cleanup: removing {} failed: {err}", app_dir.display()),
+            }
         }
     }
 
@@ -5161,6 +5176,278 @@ fn port_listening(port: u16) -> bool {
     TcpStream::connect_timeout(&addr, Duration::from_millis(300)).is_ok()
 }
 
+/// The open-source Claude Code plugin runs this bare command at SessionStart
+/// and before Bash/PowerShell calls, where it exits 127 because the app ships
+/// no `headroom` on PATH. Replace only that exact command: no global PATH
+/// mutation, and the same rewrite works on Windows, macOS, and Linux.
+const OSS_PLUGIN_HOOK_COMMAND: &str = "headroom init hook ensure";
+/// What we put in its place: a builtin every hook host we can be launched
+/// under (sh, cmd.exe, PowerShell) understands. Deliberately not a path to a
+/// file we ship -- an absolute path goes dead if our app data is ever removed
+/// or relocated, stranding the plugin with a hook that fails on every Bash
+/// call and a restore string we can no longer match.
+const OSS_PLUGIN_MANAGED_COMMAND: &str = "exit 0";
+static OSS_PLUGIN_HOOK_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Escape hatch. `HEADROOM_ABSORB_OSS_PLUGIN=0` restores anything we already
+/// rewrote and then leaves the plugin alone.
+fn oss_absorb_disabled() -> bool {
+    std::env::var_os("HEADROOM_ABSORB_OSS_PLUGIN").is_some_and(|v| v == "0")
+}
+
+/// True when Claude Code has the open-source `headroom` plugin installed, from
+/// any marketplace. It is mirrored under several marketplace names, so match the
+/// plugin half of the `<plugin>@<marketplace>` key rather than a fixed ref.
+fn oss_headroom_plugin_installed() -> bool {
+    let Some(plugins) = crate::tool_manager::claude_installed_plugins() else {
+        return false;
+    };
+    let Some(map) = plugins.get("plugins").and_then(Value::as_object) else {
+        return false;
+    };
+    map.iter().any(|(key, installs)| {
+        key.split('@').next() == Some("headroom")
+            && installs.as_array().is_some_and(|list| !list.is_empty())
+    })
+}
+
+/// Installed plugin records carry their cache directory. Resolve the hooks file
+/// from there instead of guessing where Claude or its shell looks for commands.
+fn oss_headroom_plugin_hook_paths() -> Vec<PathBuf> {
+    let Some(plugins) = crate::tool_manager::claude_installed_plugins() else {
+        return Vec::new();
+    };
+    let Some(map) = plugins.get("plugins").and_then(Value::as_object) else {
+        return Vec::new();
+    };
+    let mut hooks = Vec::new();
+    for (key, installs) in map {
+        if key.split('@').next() != Some("headroom") {
+            continue;
+        }
+        let Some(installs) = installs.as_array() else {
+            continue;
+        };
+        for install in installs {
+            let Some(root) = install.get("installPath").and_then(Value::as_str) else {
+                continue;
+            };
+            let root = PathBuf::from(root);
+            hooks.push(root.join("hooks").join("hooks.json"));
+            hooks.push(root.join("hooks.json"));
+        }
+    }
+    hooks.retain(|path| path.is_file());
+    dedupe_paths(hooks)
+}
+
+fn oss_plugin_hook_receipt_path() -> PathBuf {
+    config_file(&app_data_dir(), "oss-plugin-hooks.json")
+}
+
+fn load_oss_plugin_hook_receipt() -> Vec<PathBuf> {
+    let path = oss_plugin_hook_receipt_path();
+    let Ok(bytes) = std::fs::read(&path) else {
+        return Vec::new();
+    };
+    match serde_json::from_slice(&bytes) {
+        Ok(paths) => paths,
+        Err(err) => {
+            // This file is the only record of which third-party hooks we
+            // rewrote. Silently overwriting an unreadable one strands them
+            // neutralized with nothing left pointing at them, so keep a copy.
+            log::warn!(
+                "oss plugin hook: unreadable receipt {}: {err}",
+                path.display()
+            );
+            let _ = backup_if_exists(&path);
+            Vec::new()
+        }
+    }
+}
+
+fn save_oss_plugin_hook_receipt(paths: &[PathBuf]) -> Result<()> {
+    let path = oss_plugin_hook_receipt_path();
+    if paths.is_empty() {
+        if path.exists() {
+            std::fs::remove_file(&path).with_context(|| format!("removing {}", path.display()))?;
+        }
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+    atomic_write(&path, &serde_json::to_vec_pretty(paths)?)
+}
+
+fn hook_file_contains_command(path: &Path, command: &str) -> Result<bool> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("reading OSS plugin hooks {}", path.display()))?;
+    Ok(raw.contains(&serde_json::to_string(command)?))
+}
+
+/// Exact JSON-string replacement preserves the plugin's formatting and becomes
+/// a no-op if upstream changes the command or schema.
+fn replace_oss_plugin_hook_command(path: &Path, from: &str, to: &str) -> Result<bool> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("reading OSS plugin hooks {}", path.display()))?;
+    serde_json::from_str::<Value>(&raw)
+        .with_context(|| format!("parsing OSS plugin hooks {}", path.display()))?;
+    let from = serde_json::to_string(from)?;
+    if !raw.contains(&from) {
+        return Ok(false);
+    }
+    let updated = raw.replace(&from, &serde_json::to_string(to)?);
+    atomic_write(path, updated.as_bytes())?;
+    Ok(true)
+}
+
+/// What the open-source plugin/CLI look like on this machine right now.
+pub struct OssPluginStatus {
+    pub plugin_installed: bool,
+    pub hook_absorbed: bool,
+    pub cli_on_path: bool,
+    /// An open-source proxy is serving on :8787 (the OSS default port).
+    pub oss_proxy_8787: bool,
+    /// Claude Code's `ANTHROPIC_BASE_URL` still points at our proxy.
+    pub base_url_ours: bool,
+}
+
+/// True when Claude Code's `ANTHROPIC_BASE_URL` still points at our proxy.
+fn claude_base_url_is_ours() -> bool {
+    std::fs::read_to_string(claude_settings_path())
+        .ok()
+        .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+        .and_then(|v| {
+            v.get("env")?
+                .get("ANTHROPIC_BASE_URL")?
+                .as_str()
+                .map(|url| url == HEADROOM_ANTHROPIC_BASE_URL)
+        })
+        .unwrap_or(false)
+}
+
+/// True when a real open-source `headroom` CLI exists for the plugin hook to
+/// run. `find_on_path` alone is not enough: a GUI launch inherits launchd's
+/// bare PATH, which never contains `~/.local/bin` -- exactly where the OSS
+/// installer puts the binary. Probing the known install locations too is what
+/// keeps us from neutralizing a plugin hook that works. Same helper Claude/
+/// Codex detection uses, so a broken binary counts as absent and gets absorbed.
+fn oss_cli_present() -> bool {
+    crate::claude_cli::probe_on_path("headroom").is_some()
+        || crate::claude_cli::probe_known_paths("headroom").is_some()
+}
+
+pub fn absorb_oss_plugin() -> OssPluginStatus {
+    // Probing runs `headroom --version` against every known install location,
+    // so it execs whatever binary of that name happens to be on disk. Nobody
+    // without the plugin needs that at every launch: the answer only decides
+    // whether to leave a plugin hook alone.
+    let probe = !oss_absorb_disabled() && oss_headroom_plugin_installed();
+    absorb_oss_plugin_with_cli_on_path(probe && oss_cli_present())
+}
+
+fn absorb_oss_plugin_with_cli_on_path(cli_on_path: bool) -> OssPluginStatus {
+    let plugin_installed = oss_headroom_plugin_installed();
+    let hooks = oss_headroom_plugin_hook_paths();
+    let absorb = plugin_installed && !cli_on_path && !oss_absorb_disabled();
+    let hook_absorbed = {
+        let _guard = OSS_PLUGIN_HOOK_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if crate::SHUTTING_DOWN.load(std::sync::atomic::Ordering::Acquire) {
+            false
+        } else {
+            reconcile_oss_plugin_hooks(&hooks, absorb).0
+        }
+    };
+
+    OssPluginStatus {
+        plugin_installed,
+        hook_absorbed,
+        cli_on_path,
+        oss_proxy_8787: port_listening(8787),
+        base_url_ours: claude_base_url_is_ours(),
+    }
+}
+
+/// Neutralize or restore the exact OSS hook command. The receipt retains cache
+/// paths after plugin removal, so uninstall can still restore inactive caches.
+fn reconcile_oss_plugin_hooks(current_hooks: &[PathBuf], absorb: bool) -> (bool, Vec<String>) {
+    let managed = OSS_PLUGIN_MANAGED_COMMAND;
+    let mut hooks = load_oss_plugin_hook_receipt();
+    hooks.extend_from_slice(current_hooks);
+    hooks = dedupe_paths(hooks);
+
+    // Persist targets before touching third-party files. If the app crashes
+    // after the rewrite, the next launch or uninstall can still restore them.
+    if absorb {
+        if let Err(err) = save_oss_plugin_hook_receipt(&hooks) {
+            log::warn!("oss plugin hook: preparing receipt failed: {err:#}");
+            return (false, Vec::new());
+        }
+    }
+
+    let mut changed = Vec::new();
+    let mut still_managed = Vec::new();
+    for path in hooks {
+        // The receipt outlives the files it names: a plugin update re-clones
+        // into a new version dir and the old one goes away. That is the normal
+        // end of an entry, not a failure -- skipping it here keeps the read
+        // error out of the log (and out of Sentry) and lets the entry fall off
+        // the receipt below.
+        match std::fs::metadata(&path) {
+            Ok(metadata) if metadata.is_file() => {}
+            Ok(_) => continue,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(err) => {
+                log::warn!(
+                    "oss plugin hook: inspecting {} failed: {err}",
+                    path.display()
+                );
+                if !absorb {
+                    still_managed.push(path);
+                }
+                continue;
+            }
+        }
+        let result = if absorb {
+            replace_oss_plugin_hook_command(&path, OSS_PLUGIN_HOOK_COMMAND, managed)
+        } else {
+            replace_oss_plugin_hook_command(&path, managed, OSS_PLUGIN_HOOK_COMMAND)
+        };
+        match result {
+            Ok(true) => changed.push(path.display().to_string()),
+            Ok(false) => {}
+            Err(err) => log::warn!("oss plugin hook: {err:#}"),
+        }
+        match hook_file_contains_command(&path, managed) {
+            Ok(true) => still_managed.push(path),
+            Ok(false) => {}
+            Err(err) => {
+                log::warn!("oss plugin hook: {err:#}");
+                if !absorb {
+                    still_managed.push(path);
+                }
+            }
+        }
+    }
+
+    if let Err(err) = save_oss_plugin_hook_receipt(&still_managed) {
+        log::warn!("oss plugin hook: saving receipt failed: {err:#}");
+    }
+    (!still_managed.is_empty(), changed)
+}
+
+fn restore_oss_plugin_hooks() -> (bool, Vec<String>) {
+    let _guard = OSS_PLUGIN_HOOK_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let hooks = oss_headroom_plugin_hook_paths();
+    reconcile_oss_plugin_hooks(&hooks, false)
+}
+
 fn resolve_default_shell_targets() -> Vec<PathBuf> {
     let mut targets =
         discover_managed_shell_targets(&["managed_rtk", "claude_code"]).unwrap_or_default();
@@ -6054,6 +6341,12 @@ mod tests {
 
     #[test]
     fn strip_headroom_mcp_toml_removes_owned_tables_keeps_user_tables() {
+        // Same straddled-HOME race as the JSON twin below: this reads
+        // app_data_dir() to build the fixture and strip_headroom_mcp_toml
+        // reads it again to match, while sibling tests flip HOME to a tempdir.
+        let _env_lock = crate::test_env_lock::HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let app_dir = crate::storage::app_data_dir().display().to_string();
         let content = format!(
             "model = \"gpt-5\"\n\
@@ -10194,5 +10487,319 @@ export ANTHROPIC_BASE_URL=http://127.0.0.1:6767
         assert!(script.contains("(expected \" + BASE_URL + \")"));
         assert!(script.contains("DEBOUNCE_PATH.touch()"));
         assert!(script.contains("time.sleep(2)\n    return probe()"));
+    }
+
+    // --- Open-source plugin coexistence -------------------------------------
+    //
+    // The four states from the investigation. `headroom init hook ensure` (the
+    // plugin's only command) never writes ANTHROPIC_BASE_URL and never picks a
+    // port, so the whole surface we own is: does a `headroom` exist on PATH for
+    // the hook to run, and did we avoid touching anyone who already had one.
+
+    fn seed_oss_plugin(home: &Path, plugin_ref: &str) -> PathBuf {
+        let dir = home.join(".claude").join("plugins");
+        fs::create_dir_all(&dir).unwrap();
+        let install = dir
+            .join("cache")
+            .join(plugin_ref.replace('@', "-"))
+            .join("0.36.5");
+        let hooks = install.join("hooks").join("hooks.json");
+        fs::create_dir_all(hooks.parent().unwrap()).unwrap();
+        fs::write(
+            &hooks,
+            json!({
+                "hooks": {
+                    "SessionStart": [{
+                        "hooks": [{ "type": "command", "command": super::OSS_PLUGIN_HOOK_COMMAND }]
+                    }],
+                    "PreToolUse": [{
+                        "matcher": "Bash|PowerShell",
+                        "hooks": [{ "type": "command", "command": super::OSS_PLUGIN_HOOK_COMMAND }]
+                    }]
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+        fs::write(
+            dir.join("installed_plugins.json"),
+            json!({
+                "version": 2,
+                "plugins": { plugin_ref: [{
+                    "scope": "user",
+                    "version": "0.36.5",
+                    "installPath": install
+                }] }
+            })
+            .to_string(),
+        )
+        .unwrap();
+        hooks
+    }
+
+    /// Every file under `root`, with its bytes, for before/after comparison.
+    fn snapshot_tree(root: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
+        let mut out = BTreeMap::new();
+        let mut stack = vec![root.to_path_buf()];
+        while let Some(dir) = stack.pop() {
+            let Ok(entries) = fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else if let Ok(bytes) = fs::read(&path) {
+                    out.insert(path, bytes);
+                }
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn state_1_app_alone_touches_nothing_on_disk() {
+        // The guarantee for the majority of users: someone running the desktop
+        // app without the open-source plugin must come out of this byte-for-byte
+        // unchanged. Not "no shim" — nothing at all.
+        let home = TestHome::new();
+        fs::create_dir_all(home.path().join(".claude")).unwrap();
+        fs::write(
+            home.path().join(".claude/settings.json"),
+            json!({ "env": { "ANTHROPIC_BASE_URL": "http://127.0.0.1:6767" } }).to_string(),
+        )
+        .unwrap();
+        fs::create_dir_all(home.path().join(".local/bin")).unwrap();
+
+        let before = snapshot_tree(home.path());
+        let status = super::absorb_oss_plugin_with_cli_on_path(false);
+        let after = snapshot_tree(home.path());
+
+        assert_eq!(before, after, "no-plugin users must see zero writes");
+        assert!(!status.plugin_installed);
+        assert!(!status.hook_absorbed);
+        assert!(
+            status.base_url_ours,
+            "our routing is left exactly as it was"
+        );
+    }
+
+    #[test]
+    fn state_1_app_alone_stays_inert() {
+        let _home = TestHome::new();
+
+        let status = super::absorb_oss_plugin_with_cli_on_path(false);
+
+        assert!(!status.plugin_installed);
+        assert!(!status.hook_absorbed);
+        assert!(!super::oss_plugin_hook_receipt_path().exists());
+    }
+
+    #[test]
+    fn state_2_plugin_without_cli_gets_a_noop_hook() {
+        let home = TestHome::new();
+        let hooks = seed_oss_plugin(home.path(), "headroom@headroom-marketplace");
+
+        let status = super::absorb_oss_plugin_with_cli_on_path(false);
+
+        assert!(status.plugin_installed);
+        assert!(status.hook_absorbed);
+        let raw = fs::read_to_string(&hooks).unwrap();
+        assert_eq!(
+            raw.matches(&serde_json::to_string(super::OSS_PLUGIN_MANAGED_COMMAND).unwrap())
+                .count(),
+            2
+        );
+        assert!(!raw.contains(super::OSS_PLUGIN_HOOK_COMMAND));
+    }
+
+    #[test]
+    fn plugin_is_recognised_from_any_marketplace_mirror() {
+        // The same plugin is listed under several marketplaces (sleetish,
+        // burgebj, oll4com) whose hooks.json are byte-identical.
+        for plugin_ref in ["headroom@headroom-marketplace", "headroom@sleetish"] {
+            let home = TestHome::new();
+            seed_oss_plugin(home.path(), plugin_ref);
+
+            assert!(
+                super::absorb_oss_plugin_with_cli_on_path(false).hook_absorbed,
+                "{plugin_ref} should be recognised"
+            );
+        }
+    }
+
+    #[test]
+    fn unrelated_plugins_do_not_trigger_the_hook_rewrite() {
+        let home = TestHome::new();
+        seed_oss_plugin(home.path(), "ponytail@ponytail");
+
+        assert!(!super::absorb_oss_plugin_with_cli_on_path(false).hook_absorbed);
+        assert!(!super::oss_plugin_hook_receipt_path().exists());
+    }
+
+    #[test]
+    fn state_3_real_cli_on_path_is_never_shadowed() {
+        let home = TestHome::new();
+        let hooks = seed_oss_plugin(home.path(), "headroom@headroom-marketplace");
+        assert!(super::absorb_oss_plugin_with_cli_on_path(false).hook_absorbed);
+
+        let status = super::absorb_oss_plugin_with_cli_on_path(true);
+
+        assert!(status.cli_on_path);
+        assert!(!status.hook_absorbed);
+        assert_eq!(
+            fs::read_to_string(hooks)
+                .unwrap()
+                .matches(super::OSS_PLUGIN_HOOK_COMMAND)
+                .count(),
+            2
+        );
+    }
+
+    /// Regression: `state_3` proves the bool is honoured, but the bool itself
+    /// came from `find_on_path` alone, and a GUI launch inherits launchd's bare
+    /// PATH -- no `~/.local/bin`, which is where the OSS installer puts
+    /// `headroom`. Every such user read as "no CLI" and had a working plugin
+    /// hook neutralized. Asserts only the positive direction: a machine that
+    /// really does have a `headroom` elsewhere cannot make this pass wrongly.
+    #[test]
+    #[cfg(unix)]
+    fn an_oss_cli_in_local_bin_counts_even_when_path_cannot_see_it() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let home = TestHome::new();
+        let cli = home.path().join(".local/bin/headroom");
+        fs::create_dir_all(cli.parent().unwrap()).unwrap();
+        fs::write(&cli, "#!/bin/sh\nexit 0\n").unwrap();
+        let mut perms = fs::metadata(&cli).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&cli, perms).unwrap();
+
+        assert!(super::oss_cli_present());
+    }
+
+    /// The replacement must stay a shell builtin, not a path to anything we
+    /// ship. A path goes dead the moment our app data is removed or moved,
+    /// and takes the restore string -- our only way back -- with it.
+    #[test]
+    fn the_managed_hook_command_is_not_a_path() {
+        assert_eq!(super::OSS_PLUGIN_MANAGED_COMMAND, "exit 0");
+    }
+
+    #[test]
+    fn removing_the_plugin_restores_its_hook_and_clears_the_receipt() {
+        let home = TestHome::new();
+        let hooks = seed_oss_plugin(home.path(), "headroom@headroom-marketplace");
+        assert!(super::absorb_oss_plugin_with_cli_on_path(false).hook_absorbed);
+
+        seed_oss_plugin(home.path(), "ponytail@ponytail");
+        let status = super::absorb_oss_plugin_with_cli_on_path(false);
+        assert!(!status.plugin_installed);
+        assert!(!status.hook_absorbed);
+        assert!(!super::oss_plugin_hook_receipt_path().exists());
+        assert_eq!(
+            fs::read_to_string(&hooks)
+                .unwrap()
+                .matches(super::OSS_PLUGIN_HOOK_COMMAND)
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn a_foreign_headroom_binary_is_never_clobbered() {
+        let home = TestHome::new();
+        let shim = home.path().join(".local/bin/headroom");
+        fs::create_dir_all(shim.parent().unwrap()).unwrap();
+        fs::write(&shim, "#!/bin/sh\necho not ours\n").unwrap();
+        seed_oss_plugin(home.path(), "headroom@headroom-marketplace");
+
+        assert!(super::absorb_oss_plugin_with_cli_on_path(false).hook_absorbed);
+        assert_eq!(
+            fs::read_to_string(&shim).unwrap(),
+            "#!/bin/sh\necho not ours\n"
+        );
+    }
+
+    #[test]
+    fn failed_restore_preserves_the_receipt_for_a_later_retry() {
+        let home = TestHome::new();
+        let hooks = seed_oss_plugin(home.path(), "headroom@headroom-marketplace");
+        assert!(super::absorb_oss_plugin_with_cli_on_path(false).hook_absorbed);
+
+        let managed = serde_json::to_string(super::OSS_PLUGIN_MANAGED_COMMAND).unwrap();
+        let corrupt = format!("{} trailing", fs::read_to_string(&hooks).unwrap());
+        fs::write(&hooks, corrupt).unwrap();
+
+        super::perform_full_cleanup();
+
+        assert!(super::app_data_dir().exists());
+        assert!(super::oss_plugin_hook_receipt_path().exists());
+        assert!(fs::read_to_string(hooks).unwrap().contains(&managed));
+    }
+
+    #[test]
+    fn state_4_oss_proxy_bypass_is_measured_not_fought() {
+        // The user ran `headroom init` themselves, so their ANTHROPIC_BASE_URL
+        // points at the open-source proxy. We report it and change nothing.
+        let home = TestHome::new();
+        fs::create_dir_all(home.path().join(".claude")).unwrap();
+        let settings = home.path().join(".claude/settings.json");
+        let original = json!({ "env": { "ANTHROPIC_BASE_URL": "http://127.0.0.1:8787" } });
+        fs::write(&settings, original.to_string()).unwrap();
+        seed_oss_plugin(home.path(), "headroom@headroom-marketplace");
+
+        let status = super::absorb_oss_plugin_with_cli_on_path(false);
+
+        assert!(status.plugin_installed);
+        assert!(
+            !status.base_url_ours,
+            "the bypass must be visible to telemetry"
+        );
+        assert_eq!(
+            fs::read_to_string(&settings).unwrap(),
+            original.to_string(),
+            "we never rewrite a base URL the user set on purpose"
+        );
+    }
+
+    #[test]
+    fn the_kill_switch_absorbs_nothing_and_restores_what_it_finds() {
+        let home = TestHome::new();
+        let hooks = seed_oss_plugin(home.path(), "headroom@headroom-marketplace");
+        assert!(super::absorb_oss_plugin_with_cli_on_path(false).hook_absorbed);
+
+        std::env::set_var("HEADROOM_ABSORB_OSS_PLUGIN", "0");
+        let status = super::absorb_oss_plugin_with_cli_on_path(false);
+        std::env::remove_var("HEADROOM_ABSORB_OSS_PLUGIN");
+
+        assert!(status.plugin_installed);
+        assert!(!status.hook_absorbed);
+        assert_eq!(
+            fs::read_to_string(&hooks)
+                .unwrap()
+                .matches(super::OSS_PLUGIN_HOOK_COMMAND)
+                .count(),
+            2,
+            "the opt-out must hand the hook back, not just stop touching it"
+        );
+    }
+
+    #[test]
+    fn absorbing_the_hook_does_not_hide_a_real_oss_remnant() {
+        let home = TestHome::new();
+        seed_oss_plugin(home.path(), "headroom@headroom-marketplace");
+        assert!(super::absorb_oss_plugin_with_cli_on_path(false).hook_absorbed);
+
+        let foreign = home.path().join(".local/bin/headroom");
+        fs::create_dir_all(foreign.parent().unwrap()).unwrap();
+        fs::write(&foreign, "#!/bin/sh\necho real OSS CLI\n").unwrap();
+
+        assert!(
+            super::detect_oss_remnants()
+                .iter()
+                .any(|w| w.contains("~/.local/bin/headroom")),
+            "absorbing the plugin hook must not hide a real OSS CLI"
+        );
     }
 }

--- a/src-tauri/src/client_adapters.rs
+++ b/src-tauri/src/client_adapters.rs
@@ -5348,6 +5348,33 @@ pub fn absorb_oss_plugin() -> OssPluginStatus {
     absorb_oss_plugin_with_cli_on_path(probe && oss_cli_present())
 }
 
+/// Cheap poll for the one state a single startup pass cannot cover: Claude Code
+/// updated the plugin, which re-clones into a fresh version directory that never
+/// saw our rewrite, so the bare command is back and failing on every Bash call.
+/// A tray app can sit for weeks between launches, so waiting for the next start
+/// means weeks of 127s.
+///
+/// Deliberately narrow. It fires only for users we are already managing (a
+/// non-empty receipt) and only for a hook path we have not rewritten, so a user
+/// with a real OSS CLI -- whose receipt is empty because we restored theirs --
+/// never sends us back through the exec probe on a timer.
+pub fn oss_plugin_hook_needs_absorbing() -> bool {
+    if oss_absorb_disabled() {
+        return false;
+    }
+    let receipt = load_oss_plugin_hook_receipt();
+    if receipt.is_empty() {
+        return false;
+    }
+    oss_headroom_plugin_hook_paths().iter().any(|path| {
+        !receipt.contains(path)
+            && matches!(
+                hook_file_contains_command(path, OSS_PLUGIN_HOOK_COMMAND),
+                Ok(true)
+            )
+    })
+}
+
 fn absorb_oss_plugin_with_cli_on_path(cli_on_path: bool) -> OssPluginStatus {
     let plugin_installed = oss_headroom_plugin_installed();
     let hooks = oss_headroom_plugin_hook_paths();
@@ -10761,6 +10788,57 @@ export ANTHROPIC_BASE_URL=http://127.0.0.1:6767
             original.to_string(),
             "we never rewrite a base URL the user set on purpose"
         );
+    }
+
+    /// A plugin update re-clones into a fresh version dir carrying the bare
+    /// command, which one startup pass can never see. The poll must catch that
+    /// and nothing else: a user we do not manage must not be dragged back
+    /// through the exec probe every five minutes forever.
+    #[test]
+    fn the_recheck_fires_only_for_a_fresh_hook_we_are_already_managing() {
+        let home = TestHome::new();
+        seed_oss_plugin(home.path(), "headroom@headroom-marketplace");
+
+        // Nobody managed yet: an untouched plugin is not the recheck's job.
+        assert!(!super::oss_plugin_hook_needs_absorbing());
+
+        assert!(super::absorb_oss_plugin_with_cli_on_path(false).hook_absorbed);
+        assert!(
+            !super::oss_plugin_hook_needs_absorbing(),
+            "steady state must stay quiet"
+        );
+
+        // Claude Code updates the plugin: a new version dir, bare command back.
+        let updated = seed_oss_plugin(home.path(), "headroom@headroom-marketplace-v2");
+        assert!(super::oss_plugin_hook_needs_absorbing());
+        assert!(super::absorb_oss_plugin_with_cli_on_path(false).hook_absorbed);
+        assert!(!fs::read_to_string(&updated)
+            .unwrap()
+            .contains(super::OSS_PLUGIN_HOOK_COMMAND));
+        assert!(!super::oss_plugin_hook_needs_absorbing());
+
+        // A real CLI appears, we hand the hook back, and the poll must not
+        // immediately claim it again.
+        assert!(!super::absorb_oss_plugin_with_cli_on_path(true).hook_absorbed);
+        assert!(
+            !super::oss_plugin_hook_needs_absorbing(),
+            "a restored user must not be re-absorbed on a timer"
+        );
+    }
+
+    #[test]
+    fn the_recheck_respects_the_kill_switch() {
+        let home = TestHome::new();
+        seed_oss_plugin(home.path(), "headroom@headroom-marketplace");
+        assert!(super::absorb_oss_plugin_with_cli_on_path(false).hook_absorbed);
+        seed_oss_plugin(home.path(), "headroom@headroom-marketplace-v2");
+        assert!(super::oss_plugin_hook_needs_absorbing());
+
+        std::env::set_var("HEADROOM_ABSORB_OSS_PLUGIN", "0");
+        let needs = super::oss_plugin_hook_needs_absorbing();
+        std::env::remove_var("HEADROOM_ABSORB_OSS_PLUGIN");
+
+        assert!(!needs);
     }
 
     #[test]

--- a/src-tauri/src/client_adapters.rs
+++ b/src-tauri/src/client_adapters.rs
@@ -5914,7 +5914,7 @@ json.dump({{"hookSpecificOutput": {{"hookEventName": "PreToolUse", "permissionDe
 /// env override (TestHome in tests, Git Bash parity in production) would be
 /// silently bypassed and writes would land in the real profile. On Unix the
 /// two sources agree, so the order change is a no-op there.
-fn home_dir() -> PathBuf {
+pub(crate) fn home_dir() -> PathBuf {
     std::env::var_os("HOME")
         .filter(|v| !v.is_empty())
         .map(PathBuf::from)
@@ -6371,9 +6371,7 @@ mod tests {
         // Same straddled-HOME race as the JSON twin below: this reads
         // app_data_dir() to build the fixture and strip_headroom_mcp_toml
         // reads it again to match, while sibling tests flip HOME to a tempdir.
-        let _env_lock = crate::test_env_lock::HOME_ENV_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _env_lock = crate::test_env_lock::lock_home();
         let app_dir = crate::storage::app_data_dir().display().to_string();
         let content = format!(
             "model = \"gpt-5\"\n\
@@ -6422,9 +6420,7 @@ mod tests {
         // again to match. Sibling tests repoint HOME at a tempdir, so without
         // the lock the two reads can straddle a flip and disagree (~1 run in 6
         // of the full suite).
-        let _env_lock = crate::test_env_lock::HOME_ENV_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _env_lock = crate::test_env_lock::lock_home();
         let app_dir = crate::storage::app_data_dir().display().to_string();
         let mut servers = json!({
             "headroom": { "command": "python3", "args": ["mcp", "serve"] },
@@ -7134,9 +7130,7 @@ export ANTHROPIC_BASE_URL=http://127.0.0.1:6767
     fn zdotdir_unresolved_env_var_falls_back_to_none() {
         // TestHome sets XDG_CONFIG_HOME under this lock, so without it the
         // remove_var below races those tests (~1 run in 6 of the full suite).
-        let _env_lock = crate::test_env_lock::HOME_ENV_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _env_lock = crate::test_env_lock::lock_home();
         // Reproduces os error 30: `$XDG_CONFIG_HOME` unset under a Finder launch
         // must NOT yield a relative `$XDG_CONFIG_HOME/zsh` path.
         std::env::remove_var("XDG_CONFIG_HOME");
@@ -7729,9 +7723,7 @@ export ANTHROPIC_BASE_URL=http://127.0.0.1:6767
 
     impl TestHome {
         fn new() -> Self {
-            let env_lock = crate::test_env_lock::HOME_ENV_LOCK
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let env_lock = crate::test_env_lock::lock_home();
             let tmp = tempfile::tempdir().expect("create temp home");
             let home = tmp.path().to_path_buf();
             let prev_home = std::env::var_os("HOME");

--- a/src-tauri/src/client_adapters.rs
+++ b/src-tauri/src/client_adapters.rs
@@ -2847,11 +2847,32 @@ fn codex_uses_chatgpt_auth() -> bool {
     }
     // Older auth.json files predate `auth_mode`: infer ChatGPT mode from the
     // presence of an OAuth account id.
-    obj.get("tokens")
-        .and_then(Value::as_object)
-        .and_then(|tokens| tokens.get("account_id"))
+    let Some(tokens) = obj.get("tokens").and_then(Value::as_object) else {
+        return false;
+    };
+    if tokens
+        .get("account_id")
         .and_then(Value::as_str)
-        .is_some_and(|id| !id.is_empty())
+        .is_some_and(|id| !id.trim().is_empty())
+    {
+        return true;
+    }
+    // Newer Codex writes an auth.json with neither `auth_mode` nor a
+    // top-level `tokens.account_id`: the account identity lives only in the
+    // `id_token` claims (upstream #3206 / #3212). Those configs read as
+    // API-key mode, so `requires_openai_auth` is omitted, Codex attaches no
+    // Authorization header, and every request 401s with "Missing bearer".
+    // The payload is decoded, not verified: it is a local file the user
+    // already owns, and the result only picks which key we write into their
+    // own config.toml. An API-key user has no ChatGPT id_token, so this
+    // cannot resurrect the forced-OAuth-login regression in #406.
+    tokens
+        .get("id_token")
+        .and_then(Value::as_str)
+        .and_then(|token| {
+            crate::proxy_intercept::decode_codex_auth_claim(token, "chatgpt_account_id")
+        })
+        .is_some_and(|id| !id.trim().is_empty())
 }
 
 fn codex_provider_table_body(requires_openai_auth: bool) -> String {
@@ -9205,6 +9226,94 @@ export ANTHROPIC_BASE_URL=http://127.0.0.1:6767
         assert!(
             !toml.contains("requires_openai_auth"),
             "API-key users must not be forced into an OpenAI OAuth login (#406), got:\n{toml}"
+        );
+    }
+
+    /// Build an unsigned JWT whose payload carries `claims`. Only the payload
+    /// segment is read, so header and signature are placeholders.
+    fn fake_id_token(claims: &str) -> String {
+        use base64::Engine;
+        let b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        format!(
+            "{}.{}.sig",
+            b64.encode(b"{\"alg\":\"none\"}"),
+            b64.encode(claims.as_bytes())
+        )
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn apply_codex_emits_requires_openai_auth_from_id_token_claim() {
+        // Newer Codex writes neither `auth_mode` nor `tokens.account_id`; the
+        // account id lives only in the id_token claims (upstream #3206). Read
+        // as API-key mode, Codex sends no Authorization header and every
+        // request 401s.
+        let home = TestHome::new();
+        fs::write(home.path().join(".zshrc"), "# user zshrc\n").unwrap();
+        let codex_dir = home.path().join(".codex");
+        fs::create_dir_all(&codex_dir).unwrap();
+        let token = fake_id_token(
+            "{\"https://api.openai.com/auth\":{\"chatgpt_account_id\":\"acct_123\"}}",
+        );
+        fs::write(
+            codex_dir.join("auth.json"),
+            format!("{{\"tokens\":{{\"id_token\":\"{token}\"}}}}"),
+        )
+        .unwrap();
+
+        super::apply_client_setup("codex").expect("apply_client_setup succeeds");
+        let toml = fs::read_to_string(codex_dir.join("config.toml")).unwrap();
+        assert!(
+            toml.contains("requires_openai_auth = true"),
+            "id_token-only ChatGPT auth still needs the flag, got:\n{toml}"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn apply_codex_omits_requires_openai_auth_when_apikey_mode_is_explicit() {
+        // An explicit `auth_mode` wins outright: a stale ChatGPT id_token
+        // alongside it must not force an OAuth login (#406).
+        let home = TestHome::new();
+        fs::write(home.path().join(".zshrc"), "# user zshrc\n").unwrap();
+        let codex_dir = home.path().join(".codex");
+        fs::create_dir_all(&codex_dir).unwrap();
+        let token = fake_id_token(
+            "{\"https://api.openai.com/auth\":{\"chatgpt_account_id\":\"acct_123\"}}",
+        );
+        fs::write(
+            codex_dir.join("auth.json"),
+            format!("{{\"auth_mode\":\"apikey\",\"tokens\":{{\"id_token\":\"{token}\"}}}}"),
+        )
+        .unwrap();
+
+        super::apply_client_setup("codex").expect("apply_client_setup succeeds");
+        let toml = fs::read_to_string(codex_dir.join("config.toml")).unwrap();
+        assert!(
+            !toml.contains("requires_openai_auth"),
+            "explicit apikey mode must win over a ChatGPT id_token (#406), got:\n{toml}"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn apply_codex_omits_requires_openai_auth_for_id_token_without_claim() {
+        let home = TestHome::new();
+        fs::write(home.path().join(".zshrc"), "# user zshrc\n").unwrap();
+        let codex_dir = home.path().join(".codex");
+        fs::create_dir_all(&codex_dir).unwrap();
+        let token = fake_id_token("{\"sub\":\"user_1\"}");
+        fs::write(
+            codex_dir.join("auth.json"),
+            format!("{{\"tokens\":{{\"id_token\":\"{token}\"}}}}"),
+        )
+        .unwrap();
+
+        super::apply_client_setup("codex").expect("apply_client_setup succeeds");
+        let toml = fs::read_to_string(codex_dir.join("config.toml")).unwrap();
+        assert!(
+            !toml.contains("requires_openai_auth"),
+            "an id_token without the ChatGPT claim is not ChatGPT auth, got:\n{toml}"
         );
     }
 

--- a/src-tauri/src/device.rs
+++ b/src-tauri/src/device.rs
@@ -230,6 +230,9 @@ mod tests {
 
     #[test]
     fn chopratejas_instance_id_is_none_when_home_missing() {
+        // This one does not swap $HOME, it deletes it. Anything reading the
+        // home dir concurrently gets None.
+        let _home_lock = crate::test_env_lock::lock_home();
         let previous = std::env::var_os("HOME");
         std::env::remove_var("HOME");
         let result = read_chopratejas_instance_id();

--- a/src-tauri/src/keychain.rs
+++ b/src-tauri/src/keychain.rs
@@ -441,10 +441,13 @@ mod tests {
         _tmp: tempfile::TempDir,
         prev_home: Option<OsString>,
         prev_xdg: Option<OsString>,
+        // Held for the guard's lifetime: see test_env_lock::lock_home.
+        _env_lock: std::sync::MutexGuard<'static, ()>,
     }
 
     impl TestHome {
         fn new() -> Self {
+            let env_lock = crate::test_env_lock::lock_home();
             let tmp = tempfile::tempdir().expect("create temp home");
             let home: PathBuf = tmp.path().to_path_buf();
             let prev_home = std::env::var_os("HOME");
@@ -457,6 +460,7 @@ mod tests {
                 _tmp: tmp,
                 prev_home,
                 prev_xdg,
+                _env_lock: env_lock,
             }
         }
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3124,12 +3124,20 @@ async fn verify_headroom_auth_code(
         "auth_verified",
         Some(json!({ "invite_code_used": used_invite_code })),
     );
+    // Pricing status is per-window UI state, so the window that did not run
+    // the sign-in keeps rendering the signed-out code form until its own poll
+    // ticks. Broadcast so every window re-reads it now.
+    let _ = app.emit("pricing-refreshed", &status);
     Ok(status)
 }
 
 #[tauri::command]
-async fn sign_out_headroom_account() -> Result<(), String> {
-    pricing::sign_out()
+async fn sign_out_headroom_account(app: AppHandle) -> Result<(), String> {
+    pricing::sign_out()?;
+    // Same broadcast as verify: the other window must not keep showing the
+    // account as signed in.
+    let _ = app.emit("pricing-refreshed", ());
+    Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3018,6 +3018,63 @@ fn report_funnel_step(state: State<'_, AppState>, step: String) {
     pricing::report_funnel_step(&state, &step);
 }
 
+/// Credentials handed over by a `headroom://auth` magic link, waiting for the
+/// UI to claim them.
+///
+/// A cold start races the frontend: macOS delivers the URL before React has
+/// mounted a listener, so an event alone is lost exactly when the app was
+/// launched *by* the link. The slot is the source of truth and the event is
+/// only a nudge for the already-running case; both paths drain it through
+/// `take_pending_magic_link`.
+static PENDING_MAGIC_LINK: std::sync::Mutex<Option<(String, String)>> = std::sync::Mutex::new(None);
+
+/// Parks the email/code from `headroom://auth?email=..&code=..` and nudges the UI.
+///
+/// The browser never signs the user in (it cannot supply the device
+/// fingerprints `verify_code` needs), so this is the ordinary typed-code flow
+/// with the typing removed.
+fn capture_magic_link_auth(app: &AppHandle, url: &tauri::Url) {
+    let Some(credentials) = parse_magic_link_auth(url) else {
+        return;
+    };
+    if let Ok(mut slot) = PENDING_MAGIC_LINK.lock() {
+        *slot = Some(credentials);
+    }
+    let _ = app.emit("magic-link-auth", ());
+}
+
+/// `headroom://auth?email=..&code=..` -> `(email, code)`.
+///
+/// Every other `headroom://` URL is the post-checkout return and must fall
+/// through to the pricing refresh untouched.
+fn parse_magic_link_auth(url: &tauri::Url) -> Option<(String, String)> {
+    if url.host_str() != Some("auth") {
+        return None;
+    }
+    let mut email = None;
+    let mut code = None;
+    for (key, value) in url.query_pairs() {
+        match key.as_ref() {
+            "email" => email = Some(value.into_owned()),
+            "code" => code = Some(value.into_owned()),
+            _ => {}
+        }
+    }
+    let email = email?;
+    let code = code?;
+    (!email.is_empty() && !code.is_empty()).then_some((email, code))
+}
+
+/// Drains the pending magic-link credentials. Returns `None` on a normal
+/// launch; one-shot so a reload cannot replay a spent code.
+#[tauri::command]
+fn take_pending_magic_link() -> Option<(String, String)> {
+    PENDING_MAGIC_LINK
+        .lock()
+        .ok()
+        .and_then(|mut slot| slot.take())
+}
+
 #[tauri::command]
 async fn request_headroom_auth_code(
     app: AppHandle,
@@ -4495,6 +4552,7 @@ pub fn run() {
                         if url.scheme() == "headroom" {
                             let app_handle = deep_link_app.clone();
                             let _ = show_launcher_window(&app_handle);
+                            capture_magic_link_auth(&app_handle, &url);
                             // Run the reconciliation on a worker thread — the
                             // deep-link callback is on the main thread and we
                             // don't want pricing's blocking HTTP call there.
@@ -4565,6 +4623,7 @@ pub fn run() {
             get_claude_profile,
             get_headroom_pricing_status,
             report_funnel_step,
+            take_pending_magic_link,
             request_headroom_auth_code,
             verify_headroom_auth_code,
             sign_out_headroom_account,
@@ -6977,17 +7036,17 @@ mod tests {
         install_pending_update, is_disk_full_signal, is_endpoint_protection_signal,
         is_network_download_signal, is_port_conflict_failure, is_prerelease_version,
         learn_step_label, lifetime_token_milestone_kind, noop_app_update_progress_emitter,
-        onboarding_recovery_copy, parse_live_learnings, parse_request_count_from_stats_body,
-        parse_request_counts_by_agent, parse_updater_endpoint_list, pattern_matches_project,
-        persistent_zero_spend, physical_rect_from_rect, read_applied_patterns_for_project,
-        readyz_failed_checks_csv, readyz_failure_has_core_unhealthy,
-        readyz_failure_is_upstream_only, readyz_outcome_fingerprint_key, recent_savings_days,
-        resolve_release_updater_config, select_updater_endpoints, store_checked_update,
-        user_message_for, watchdog_should_be_up, zero_spend_affected_days, AppUpdateProgress,
-        AppUpdateProgressEmitter, AvailableAppUpdate, BootstrapFailureKind, DailySavingsPoint,
-        HeadroomLearnPrereqStatus, InstallPendingUpdateFuture, InstallableAppUpdate, LearnAgent,
-        MonitorBounds, PhysicalRect, QuitSource, TrayRuntimeVisual, DEFAULT_UPDATER_ENDPOINT,
-        DEFAULT_UPDATER_PUBLIC_KEY,
+        onboarding_recovery_copy, parse_live_learnings, parse_magic_link_auth,
+        parse_request_count_from_stats_body, parse_request_counts_by_agent,
+        parse_updater_endpoint_list, pattern_matches_project, persistent_zero_spend,
+        physical_rect_from_rect, read_applied_patterns_for_project, readyz_failed_checks_csv,
+        readyz_failure_has_core_unhealthy, readyz_failure_is_upstream_only,
+        readyz_outcome_fingerprint_key, recent_savings_days, resolve_release_updater_config,
+        select_updater_endpoints, store_checked_update, user_message_for, watchdog_should_be_up,
+        zero_spend_affected_days, AppUpdateProgress, AppUpdateProgressEmitter, AvailableAppUpdate,
+        BootstrapFailureKind, DailySavingsPoint, HeadroomLearnPrereqStatus,
+        InstallPendingUpdateFuture, InstallableAppUpdate, LearnAgent, MonitorBounds, PhysicalRect,
+        QuitSource, TrayRuntimeVisual, DEFAULT_UPDATER_ENDPOINT, DEFAULT_UPDATER_PUBLIC_KEY,
     };
     use parking_lot::Mutex;
     use serde_json::json;
@@ -9631,6 +9690,41 @@ Some unrelated content.
                 .status()
                 .expect("run sh -n");
             assert!(status.success(), "sh rejected the script: {script}");
+        }
+    }
+
+    #[test]
+    fn magic_link_auth_extracts_email_and_code() {
+        let url = tauri::Url::parse("headroom://auth?email=a%40b.com&code=123456").unwrap();
+        assert_eq!(
+            parse_magic_link_auth(&url),
+            Some(("a@b.com".to_string(), "123456".to_string()))
+        );
+    }
+
+    #[test]
+    fn magic_link_auth_ignores_the_checkout_return_url() {
+        // Every other headroom:// URL must fall through to the pricing refresh.
+        for raw in [
+            "headroom://checkout-complete",
+            "headroom://",
+            "headroom://auth",
+        ] {
+            let url = tauri::Url::parse(raw).unwrap();
+            assert_eq!(parse_magic_link_auth(&url), None, "{raw}");
+        }
+    }
+
+    #[test]
+    fn magic_link_auth_rejects_half_filled_links() {
+        for raw in [
+            "headroom://auth?email=a%40b.com",
+            "headroom://auth?code=123456",
+            "headroom://auth?email=&code=123456",
+            "headroom://auth?email=a%40b.com&code=",
+        ] {
+            let url = tauri::Url::parse(raw).unwrap();
+            assert_eq!(parse_magic_link_auth(&url), None, "{raw}");
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5237,6 +5237,16 @@ fn execute_headroom_learn_run(
 
     let mut command = crate::proc::command(&entrypoint);
     command.arg("learn").arg("--apply");
+    // The analysis CLI is killed after this long with no stream event. Upstream
+    // defaults to 60s, which kills a healthy run: the digest is large, it is
+    // routed through our own proxy, and the model can think past a minute
+    // before the first token (RUST-6W: 14 kills across 8 unrelated machines,
+    // every release from 0.8.2 to 0.8.6). Same failure the /stats probe had at
+    // 500ms -- a cap tight enough to turn "slow" into "broken".
+    //
+    // Only the IDLE cap moves. Upstream's 300s hard cap still bounds a genuine
+    // hang, so this trades a slower failure for runs that now finish.
+    command.env("HEADROOM_LEARN_CLI_IDLE_TIMEOUT_SECS", "180");
     match agent {
         LearnAgent::Claude => {
             // Per-project Claude scan; writes CLAUDE.md / MEMORY.md for the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4643,7 +4643,12 @@ pub fn run() {
                                         );
                                         state
                                             .apply_codex_pricing_gate_status(status.codex.as_ref());
-                                        let _ = app_handle.emit("pricing-refreshed", &status);
+                                        // Payload-less on purpose: this status
+                                        // was fetched before any magic link in
+                                        // the same URL was redeemed, so it is
+                                        // stale by the time it lands. The
+                                        // frontend refetches instead.
+                                        let _ = app_handle.emit("pricing-refreshed", ());
                                     }
                                     Err(err) => {
                                         sentry::capture_message(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ mod port_conflict;
 mod pricing;
 mod proc;
 mod proxy_intercept;
+mod savings_canary;
 mod state;
 mod storage;
 mod tool_manager;
@@ -3235,6 +3236,9 @@ fn run_activity_observation(app: &AppHandle) {
 
     if let Ok(feed) = fetch_transformations_feed(ACTIVITY_OBSERVER_LIMIT) {
         let _ = state.observe_activity_from_transformations(&feed.transformations);
+        // Same batch, second reader: flags a client whose requests all stopped
+        // compressing (see savings_canary for why the server cannot see this).
+        savings_canary::observe(&feed.transformations);
     }
 
     let projects = state.list_claude_code_projects().unwrap_or_default();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4116,6 +4116,9 @@ async fn set_auto_learn_enabled(app: AppHandle, enabled: bool) -> Result<bool, S
 
 #[tauri::command]
 async fn uninstall_and_quit(app: AppHandle) -> Result<Vec<String>, String> {
+    // Prevent the launch-time OSS-plugin worker from mutating Claude's hook
+    // cache after cleanup has restored it.
+    SHUTTING_DOWN.store(true, Ordering::Release);
     {
         let state: tauri::State<'_, AppState> = app.state();
         state.stop_headroom();
@@ -4416,6 +4419,42 @@ pub fn run() {
                     "autostart_launch": launched_from_autostart
                 })),
             );
+
+            // Absorb the open-source `headroom` Claude Code plugin. Its hooks
+            // run a bare `headroom init hook ensure`, which exits 127 here
+            // because the app ships no `headroom` on PATH. When the plugin is
+            // present and no real CLI is visible, replace only that exact hook
+            // command with `exit 0`. No global PATH changes, nothing pointing
+            // at a file of ours that could later go missing, and the same
+            // rewrite works on Windows, macOS, and Linux.
+            // `HEADROOM_ABSORB_OSS_PLUGIN=0` opts out and restores.
+            //
+            // Off the setup closure: nothing downstream waits on the result,
+            // and the status probe opens a TCP connection to :8787. That must
+            // never sit on the main thread's launch path, least of all for the
+            // majority of users who do not have the plugin at all.
+            let oss_handle = app_handle.clone();
+            std::thread::spawn(move || {
+                let oss = client_adapters::absorb_oss_plugin();
+                // Only worth an event when there is something to report; every
+                // launch already counts in `app_started`. `base_url_ours: false`
+                // alongside `oss_proxy_8787: true` is the state where the user
+                // ran `headroom init` themselves and their traffic bypasses us,
+                // so our savings under-report — measured, not fought.
+                if oss.plugin_installed || oss.oss_proxy_8787 {
+                    analytics::track_event(
+                        &oss_handle,
+                        "oss_plugin_detected",
+                        Some(json!({
+                            "plugin_installed": oss.plugin_installed,
+                            "hook_absorbed": oss.hook_absorbed,
+                            "cli_on_path": oss.cli_on_path,
+                            "oss_proxy_8787": oss.oss_proxy_8787,
+                            "base_url_ours": oss.base_url_ours
+                        })),
+                    );
+                }
+            });
             // Wire up the bearer-triggered identity-pusher worker. The
             // intercept thread sends a signal here every time it captures a
             // bearer whose value differs from what was previously in the
@@ -7042,11 +7081,12 @@ mod tests {
         physical_rect_from_rect, read_applied_patterns_for_project, readyz_failed_checks_csv,
         readyz_failure_has_core_unhealthy, readyz_failure_is_upstream_only,
         readyz_outcome_fingerprint_key, recent_savings_days, resolve_release_updater_config,
-        select_updater_endpoints, store_checked_update, user_message_for, watchdog_should_be_up,
-        zero_spend_affected_days, AppUpdateProgress, AppUpdateProgressEmitter, AvailableAppUpdate,
-        BootstrapFailureKind, DailySavingsPoint, HeadroomLearnPrereqStatus,
-        InstallPendingUpdateFuture, InstallableAppUpdate, LearnAgent, MonitorBounds, PhysicalRect,
-        QuitSource, TrayRuntimeVisual, DEFAULT_UPDATER_ENDPOINT, DEFAULT_UPDATER_PUBLIC_KEY,
+        select_updater_endpoints, store_checked_update, take_pending_magic_link, user_message_for,
+        watchdog_should_be_up, zero_spend_affected_days, AppUpdateProgress,
+        AppUpdateProgressEmitter, AvailableAppUpdate, BootstrapFailureKind, DailySavingsPoint,
+        HeadroomLearnPrereqStatus, InstallPendingUpdateFuture, InstallableAppUpdate, LearnAgent,
+        MonitorBounds, PhysicalRect, QuitSource, TrayRuntimeVisual, DEFAULT_UPDATER_ENDPOINT,
+        DEFAULT_UPDATER_PUBLIC_KEY, PENDING_MAGIC_LINK,
     };
     use parking_lot::Mutex;
     use serde_json::json;
@@ -9726,5 +9766,25 @@ Some unrelated content.
             let url = tauri::Url::parse(raw).unwrap();
             assert_eq!(parse_magic_link_auth(&url), None, "{raw}");
         }
+    }
+
+    /// The slot is one-shot: a window reload re-runs the claim on mount, and a
+    /// second hand-out would replay a code the server has already spent. Sole
+    /// owner of PENDING_MAGIC_LINK in the suite, so no serialisation needed.
+    #[test]
+    fn pending_magic_link_is_handed_out_exactly_once() {
+        assert_eq!(take_pending_magic_link(), None, "slot starts empty");
+
+        *PENDING_MAGIC_LINK.lock().unwrap() = Some(("a@b.com".to_string(), "123456".to_string()));
+
+        assert_eq!(
+            take_pending_magic_link(),
+            Some(("a@b.com".to_string(), "123456".to_string()))
+        );
+        assert_eq!(
+            take_pending_magic_link(),
+            None,
+            "a reload must not replay a spent code"
+        );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4433,6 +4433,13 @@ pub fn run() {
             // and the status probe opens a TCP connection to :8787. That must
             // never sit on the main thread's launch path, least of all for the
             // majority of users who do not have the plugin at all.
+            // A plugin update lands a fresh version dir with the bare command
+            // back, so one pass at startup is not enough for a tray app that
+            // stays up for weeks. Re-check on a slow timer; the check itself is
+            // a receipt read that returns immediately for everyone we are not
+            // already managing.
+            const OSS_PLUGIN_RECHECK_INTERVAL: std::time::Duration =
+                std::time::Duration::from_secs(300);
             let oss_handle = app_handle.clone();
             std::thread::spawn(move || {
                 let oss = client_adapters::absorb_oss_plugin();
@@ -4453,6 +4460,16 @@ pub fn run() {
                             "base_url_ours": oss.base_url_ours
                         })),
                     );
+                }
+                // Startup cadence for the event, not for the repair.
+                loop {
+                    std::thread::sleep(OSS_PLUGIN_RECHECK_INTERVAL);
+                    if SHUTTING_DOWN.load(Ordering::Acquire) {
+                        return;
+                    }
+                    if client_adapters::oss_plugin_hook_needs_absorbing() {
+                        client_adapters::absorb_oss_plugin();
+                    }
                 }
             });
             // Wire up the bearer-triggered identity-pusher worker. The

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,6 +29,18 @@ mod usage_counters;
 #[cfg(test)]
 pub(crate) mod test_env_lock {
     pub(crate) static HOME_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Hold this for the whole time `$HOME` is swapped. Tests that only READ
+    /// the home dir need it too: `logging::scrub_home` and everything behind
+    /// `dirs::home_dir()` resolve it at call time, so an unlocked swapper in
+    /// another module makes their assertion silently vacuous -- and
+    /// `device.rs` removes `$HOME` outright, which turns the scrub into a
+    /// no-op and fails the test outright.
+    pub(crate) fn lock_home() -> std::sync::MutexGuard<'static, ()> {
+        HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
 }
 
 use std::future::Future;

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -934,9 +934,7 @@ mod tests {
     fn scrub_home_replaces_home_dir_with_tilde() {
         // scrub_home reads $HOME again internally, so a TestHome elsewhere
         // swapping it between our read and theirs makes the scrub a no-op.
-        let _home_lock = crate::test_env_lock::HOME_ENV_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _home_lock = crate::test_env_lock::lock_home();
 
         let home = dirs::home_dir().unwrap();
         let msg = format!(
@@ -955,9 +953,7 @@ mod tests {
     fn scrub_event_covers_message_tags_and_extras() {
         // scrub_home reads $HOME again internally, so a TestHome elsewhere
         // swapping it between our read and theirs makes the scrub a no-op.
-        let _home_lock = crate::test_env_lock::HOME_ENV_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _home_lock = crate::test_env_lock::lock_home();
 
         let home = dirs::home_dir().unwrap();
         let home = home.display().to_string();

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -932,6 +932,12 @@ mod tests {
 
     #[test]
     fn scrub_home_replaces_home_dir_with_tilde() {
+        // scrub_home reads $HOME again internally, so a TestHome elsewhere
+        // swapping it between our read and theirs makes the scrub a no-op.
+        let _home_lock = crate::test_env_lock::HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
         let home = dirs::home_dir().unwrap();
         let msg = format!(
             "cleanup: removing {}/Library/Application Support/x",
@@ -947,6 +953,12 @@ mod tests {
 
     #[test]
     fn scrub_event_covers_message_tags_and_extras() {
+        // scrub_home reads $HOME again internally, so a TestHome elsewhere
+        // swapping it between our read and theirs makes the scrub a no-op.
+        let _home_lock = crate::test_env_lock::HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
         let home = dirs::home_dir().unwrap();
         let home = home.display().to_string();
         let mut event = sentry::protocol::Event::new();

--- a/src-tauri/src/output_savings.rs
+++ b/src-tauri/src/output_savings.rs
@@ -37,6 +37,13 @@ const MEASURED_MIN_COVERAGE: f64 = 0.5;
 /// the correct outcome -- they keep the synthetic-control number.
 const MEASURED_MAX_CI_HALF_WIDTH_PCT: f64 = 10.0;
 
+/// A baseline stratum speaks for a treatment stratum only with this many
+/// observations behind it. Below it, one long pre-install reply becomes the
+/// "mean" an entire request class is scored against (a real ledger held
+/// `opus|new_user_ask|m|notools` at n=1, mean 849 — and 3,022 quota pings
+/// averaging 40 tokens each booked ~809 "saved" against it).
+const MIN_BASELINE_N: u64 = 10;
+
 /// Running count / sum / sum-of-squares, mirroring the backend's `_Accum` so
 /// mean and variance come out bit-comparable.
 #[derive(Debug, Clone, Copy, Default, Deserialize)]
@@ -84,34 +91,24 @@ struct Baseline {
 }
 
 impl Baseline {
-    /// `(mean, var, n)` for *key*: the exact stratum, else every stratum
-    /// sharing its longest matching prefix, merged.
+    /// `(mean, var, n)` for *key*: the exact stratum only, and only with
+    /// [`MIN_BASELINE_N`] observations behind it.
     ///
-    /// Upstream trims trailing fields the same way but takes the first hash
-    /// order match, so a re-serialized ledger can change its answer. Merging
-    /// every match is order-independent and uses more evidence. Returns `None`
-    /// rather than falling back to the global mean.
+    /// This used to back off to the longest matching key prefix, merged.
+    /// That readmitted the global-mean overcount one level down: an
+    /// `opus|new_user_ask|xs|notools` ping (a ~24-token quota check) has no
+    /// exact stratum, so it borrowed the merged `opus|new_user_ask|` mean of
+    /// 1,611 tokens and booked a 98.7% "reduction" per ping — 49% of one real
+    /// ledger's claimed savings, and a permanent "Output −99%" day chip once
+    /// pings were the only scored traffic. A verbosity baseline is only
+    /// evidence for the stratum it observed; anything else returns `None` and
+    /// the request stays out of the estimate.
     fn lookup(&self, key: &str) -> Option<(f64, f64, u64)> {
-        if let Some(acc) = self.strata.get(key) {
-            if acc.n > 0 {
-                return Some((acc.mean(), acc.var(), acc.n));
-            }
+        let acc = self.strata.get(key)?;
+        if acc.n < MIN_BASELINE_N {
+            return None;
         }
-        let mut parts: Vec<&str> = key.split('|').collect();
-        while parts.len() > 1 {
-            parts.pop();
-            let prefix = format!("{}|", parts.join("|"));
-            let mut merged = Accum::default();
-            for (k, acc) in &self.strata {
-                if acc.n > 0 && k.starts_with(&prefix) {
-                    merged.merge(acc);
-                }
-            }
-            if merged.n > 0 {
-                return Some((merged.mean(), merged.var(), merged.n));
-            }
-        }
-        None
+        Some((acc.mean(), acc.var(), acc.n))
     }
 }
 
@@ -255,10 +252,17 @@ fn measured_if_ready(
     Some(measured)
 }
 
-/// Percent + 95% normal-approximation band, or `None` when the result is not a
-/// reduction we can honestly display. A reduction is definitionally within
-/// [0, 100]: a freshly seeded baseline divides by near-zero and blows up, and
-/// the dashboard used to render that as "Output --6,130.7%".
+/// Percent + 95% normal-approximation band, or `None` when the result is not
+/// one we can honestly display (no covered requests, a degenerate baseline, or
+/// a >100% blowup from a near-zero one — the dashboard once rendered such a
+/// blowup as "Output --6,130.7%").
+///
+/// A NEGATIVE result floors to 0% instead of returning `None`. "No reduction"
+/// is an answer, not an error: discarding it meant a holdout measuring ~0
+/// could never replace the estimate, and a `None` from this module lets the
+/// caller fall back to the backend's global-mean-credited number — strictly
+/// worse than an honest zero. The CI is left unclamped so the gate in
+/// [`measured_if_ready`] still sees the real band.
 fn finalize(
     method: &'static str,
     saved: f64,
@@ -270,13 +274,13 @@ fn finalize(
         return None;
     }
     let pct = saved / baseline_tokens * 100.0;
-    if !pct.is_finite() || !(0.0..=100.0).contains(&pct) {
+    if !pct.is_finite() || pct > 100.0 {
         return None;
     }
     let se = var.max(0.0).sqrt();
     Some(OutputEstimate {
         method,
-        reduction_percent: pct,
+        reduction_percent: pct.max(0.0),
         ci_low_percent: (saved - 1.96 * se) / baseline_tokens * 100.0,
         ci_high_percent: (saved + 1.96 * se) / baseline_tokens * 100.0,
         requests,
@@ -332,26 +336,32 @@ mod tests {
     fn excludes_strata_the_baseline_never_saw() {
         let e = estimate(MIXED);
         assert_eq!(e.method, "estimated");
-        // 4 opus|ask|l|tools + 2 opus|ask|l|notools; the 3 fable requests have
-        // no baseline evidence and must not be credited against the global mean.
-        assert_eq!(e.requests, 6);
-        assert_eq!(e.tokens_saved, 1300);
-        assert_eq!(e.baseline_tokens, 6000);
-        assert!((e.reduction_percent - 21.666_667).abs() < 1e-5);
-        assert!((e.ci_low_percent - 12.363_196).abs() < 1e-5);
-        assert!((e.ci_high_percent - 30.970_137).abs() < 1e-5);
+        // Only the 4 opus|ask|l|tools requests have an exact, well-fed
+        // baseline stratum. The 2 opus|ask|l|notools (no exact stratum) and
+        // the 3 fable requests (no evidence at all) stay out.
+        assert_eq!(e.requests, 4);
+        assert_eq!(e.tokens_saved, 800);
+        assert_eq!(e.baseline_tokens, 4000);
+        assert!((e.reduction_percent - 20.0).abs() < 1e-9);
+        assert!((e.ci_low_percent - 7.777_253).abs() < 1e-5);
+        assert!((e.ci_high_percent - 32.222_747).abs() < 1e-5);
     }
 
     #[test]
-    fn prefix_backoff_supplies_a_near_neighbour() {
-        // opus|ask|l|notools has no exact stratum but shares the opus|ask|l|
-        // prefix with one, so it is scored -- against 1000, not the 1333 global.
+    fn lookup_is_exact_stratum_only_with_enough_evidence() {
         let ledger: Ledger = serde_json::from_str(MIXED).expect("parse");
+        // Exact stratum with n >= MIN_BASELINE_N qualifies.
         let (mu, _var, n) = ledger
             .baseline
-            .lookup("opus|ask|l|notools")
-            .expect("prefix hit");
+            .lookup("opus|ask|l|tools")
+            .expect("exact hit");
         assert_eq!((mu, n), (1000.0, 10));
+        // No prefix backoff: an xs ping must not borrow the merged opus|ask|
+        // mean (the "Output -99%" day-chip artifact).
+        assert!(ledger.baseline.lookup("opus|ask|l|notools").is_none());
+        assert!(ledger.baseline.lookup("opus|ask|xs|notools").is_none());
+        // Exact stratum below MIN_BASELINE_N is not evidence either.
+        assert!(ledger.baseline.lookup("opus|ask|xl|tools").is_none());
         assert!(ledger.baseline.lookup("fable|ask|l|tools").is_none());
     }
 
@@ -407,13 +417,33 @@ mod tests {
     }
 
     #[test]
-    fn a_shaper_that_made_replies_longer_is_not_shown_as_a_reduction() {
+    fn a_shaper_that_made_replies_longer_floors_at_zero() {
         // Treatment above baseline gives a negative percent, which the tile
-        // used to render as "Output --6,130.7%".
+        // used to render as "Output --6,130.7%". It floors to an honest 0%
+        // rather than vanishing: a None here makes the dashboard fall back to
+        // the backend's global-mean-credited number, which is worse than zero.
         let json = r#"{
           "baseline": {"strata": {"opus|ask|l|tools": {"n": 10, "sum": 1000, "sumsq": 110000}}, "glob": {"n": 0, "sum": 0, "sumsq": 0}},
           "treatment": {"opus|ask|l|tools": {"n": 4, "sum": 3200, "sumsq": 2580000}}
         }"#;
-        assert!(estimate_from_bytes(json.as_bytes()).is_none());
+        let e = estimate_from_bytes(json.as_bytes()).expect("floored estimate");
+        assert_eq!(e.method, "estimated");
+        assert_eq!(e.reduction_percent, 0.0);
+        assert_eq!(e.tokens_saved, 0);
+    }
+
+    #[test]
+    fn a_solid_holdout_measuring_no_reduction_still_takes_over() {
+        // Control replies come out SHORTER than treatment: the true effect is
+        // ~zero-or-negative. Once the holdout is solid (full coverage, tight
+        // band) that honest zero must replace the synthetic estimate -- the
+        // old [0,100] validity check discarded it, so a shaper that saved
+        // nothing kept its estimated percentage forever.
+        let e = estimate(&with_control(
+            r#""control": {"opus|ask|l|tools": {"n": 100, "sum": 70000, "sumsq": 49010000}}"#,
+        ));
+        assert_eq!(e.method, "measured");
+        assert_eq!(e.reduction_percent, 0.0);
+        assert!(e.ci_high_percent < 0.0, "band stays unclamped for the gate");
     }
 }

--- a/src-tauri/src/output_savings.rs
+++ b/src-tauri/src/output_savings.rs
@@ -120,6 +120,34 @@ struct Ledger {
     control: HashMap<String, Accum>,
 }
 
+impl Ledger {
+    /// What to score *key* against: the seeded verbosity baseline where it has
+    /// evidence, otherwise this stratum's own control arm.
+    ///
+    /// The verbosity baseline is learned once, at install, and never relearned
+    /// -- every transcript written since is already shaped. So it speaks only
+    /// for the strata that machine happened to run beforehand, and no amount
+    /// of waiting widens that. On one real ledger it covered 11 opus strata
+    /// and 42% of requests, with nothing at all for fable, sonnet or haiku:
+    /// more than half the traffic permanently unscoreable, and a day spent
+    /// entirely on those models produced no sample at all.
+    ///
+    /// A control-arm request is unshaped by construction, so it observes the
+    /// same counterfactual the baseline was seeded to capture -- in the same
+    /// period, from the same client, in exactly this stratum. It is the only
+    /// evidence that can ever arrive for a stratum the seeding missed.
+    ///
+    /// Baseline first and control only where it is silent, so filling the
+    /// holdout adds coverage without moving the number for strata that
+    /// already had some.
+    fn baseline_for(&self, key: &str) -> Option<(f64, f64, u64)> {
+        self.baseline.lookup(key).or_else(|| {
+            let c = self.control.get(key)?;
+            (c.n >= MIN_BASELINE_N).then(|| (c.mean(), c.var(), c.n))
+        })
+    }
+}
+
 /// One side of the counterfactual, ready for the dashboard.
 #[derive(Debug, Clone, PartialEq)]
 pub struct OutputEstimate {
@@ -166,8 +194,8 @@ fn estimate_from_bytes(bytes: &[u8]) -> Option<OutputEstimate> {
     }
 }
 
-/// Synthetic control: treatment output against the learned baseline, over the
-/// strata the baseline can actually speak to.
+/// Synthetic control: treatment output against the best counterfactual each
+/// stratum has (see [`Ledger::baseline_for`]), over the strata that have one.
 ///
 /// `Σ n·(μ − ȳ)` with `Var ≈ Σ [ n·σ²_y + n²·σ²_μ/m ]`, matching the backend's
 /// derivation so the only difference is which strata qualify.
@@ -181,7 +209,7 @@ fn estimate_from_baseline(ledger: &Ledger) -> Option<OutputEstimate> {
         if acc.n == 0 {
             continue;
         }
-        let Some((mu, mu_var, m)) = ledger.baseline.lookup(key) else {
+        let Some((mu, mu_var, m)) = ledger.baseline_for(key) else {
             continue;
         };
         let n = acc.n as f64;
@@ -321,6 +349,11 @@ mod tests {
       "control":   {"opus|ask|l|tools": {"n": 100,  "sum": 100000, "sumsq": 100990000}}
     }"#;
 
+    /// `MIXED` with a control arm swapped in.
+    fn mixed_with_control(control: &str) -> String {
+        MIXED.replace("\"control\": {}", &format!("\"control\": {control}"))
+    }
+
     fn with_control(control: &str) -> String {
         let idx = HOLDOUT
             .find("\"control\"")
@@ -345,6 +378,29 @@ mod tests {
         assert!((e.reduction_percent - 20.0).abs() < 1e-9);
         assert!((e.ci_low_percent - 7.777_253).abs() < 1e-5);
         assert!((e.ci_high_percent - 32.222_747).abs() < 1e-5);
+    }
+
+    #[test]
+    fn a_stratum_the_baseline_missed_is_scored_against_its_own_control_arm() {
+        // fable has no baseline stratum and never can -- the verbosity
+        // baseline was seeded once, before Headroom shaped anything. Its own
+        // control arm is unshaped by construction, so it is the counterfactual.
+        let e = estimate(&mixed_with_control(
+            r#"{"fable|ask|l|tools": {"n": 10, "sum": 10000, "sumsq": 10200000}}"#,
+        ));
+        assert_eq!(e.method, "estimated");
+        // 4 opus (seeded baseline, mu 1000 vs 800) + 3 fable (control mean
+        // 1000 vs 700). The 2 opus|ask|l|notools still have neither.
+        assert_eq!(e.requests, 7);
+        assert_eq!(e.tokens_saved, 1_700);
+        assert_eq!(e.baseline_tokens, 7_000);
+
+        // A thin control arm is not evidence: same floor as the baseline.
+        let thin = estimate(&mixed_with_control(
+            r#"{"fable|ask|l|tools": {"n": 9, "sum": 9000, "sumsq": 9180000}}"#,
+        ));
+        assert_eq!(thin.requests, 4);
+        assert_eq!(thin.tokens_saved, 800);
     }
 
     #[test]

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -4179,7 +4179,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial(unauth_sync_counter)]
+    #[serial_test::serial]
     fn unauthorized_background_sync_tolerates_blips_then_escalates() {
         CONSECUTIVE_UNAUTHORIZED_SYNCS.store(0, std::sync::atomic::Ordering::Relaxed);
 
@@ -4228,7 +4228,7 @@ mod tests {
     #[test]
     // Ok resets the unauthorized counter, so keep it off the escalation
     // test's timeline.
-    #[serial_test::serial(unauth_sync_counter)]
+    #[serial_test::serial]
     fn successful_background_sync_returns_remote_account_profile() {
         let (authenticated, account, error) =
             merge_background_account_sync(Some("session-token"), Ok(sample_remote_account()));

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -5684,6 +5684,7 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn verify_auth_code_decodes_and_writes_session_token() {
+        let _home_lock = crate::test_env_lock::lock_home();
         // Override HOME / XDG_DATA_HOME so the keychain debug store and
         // app_data_dir live in a fresh tempdir, not the dev's real profile.
         let prev_home = std::env::var_os("HOME");
@@ -5767,6 +5768,7 @@ mod tests {
     /// what to do, and must not leak the endpoint.
     #[test]
     fn verify_auth_code_reports_an_unreachable_server_in_plain_language() {
+        let _home_lock = crate::test_env_lock::lock_home();
         let (state, dir) = temp_app_state();
         let err = super::verify_auth_code_with_base_url(
             &state,
@@ -5949,6 +5951,7 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn activate_account_requires_session_token() {
+        let _home_lock = crate::test_env_lock::lock_home();
         // No AuthedTestEnv → no token in keychain. Override HOME so any
         // keychain read still goes to a tempdir, not the dev profile.
         let scratch = tempfile::tempdir().expect("scratch");

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -131,6 +131,39 @@ fn is_transient_transport_error(err: &reqwest::Error) -> bool {
     err.is_connect() || err.is_timeout() || err.is_request()
 }
 
+/// Describe a round trip that never produced a response.
+///
+/// reqwest's `Display` is only "error sending request for url (https://...)":
+/// the cause lives in the source chain and is dropped, so the user gets an
+/// unactionable URL dump. That is what issue #58 reported, hit during a
+/// headroom-web deploy switchover. Classify into three stable phrases rather
+/// than interpolating the cause - the user gets something to act on, and
+/// Sentry gets a message that groups instead of splintering on `os error 61`.
+fn transport_failure(action: &str, err: &reqwest::Error) -> String {
+    let kind = if err.is_timeout() {
+        "the request timed out"
+    } else if err.is_connect() {
+        "the server could not be reached"
+    } else {
+        "the request failed"
+    };
+    format!("Could not {action}: {kind}. Check your connection and try again in a moment.")
+}
+
+/// Report transport failures, but rank them. Before issue #58 the auth path
+/// dropped transient ones entirely, so we could not answer "how many users hit
+/// this" from the client at all - the whole investigation had to be done from
+/// headroom-web's deploy log. Sign-in runs ~15x/day fleet-wide, so capturing
+/// every failure at Warning costs little; only a non-transport failure (which
+/// implies something wrong on our side) is worth an Error.
+fn transport_level(err: &reqwest::Error) -> sentry::Level {
+    if is_transient_transport_error(err) {
+        sentry::Level::Warning
+    } else {
+        sentry::Level::Error
+    }
+}
+
 fn plan_tier_header_value(tier: &ClaudePlanTier) -> &'static str {
     match tier {
         ClaudePlanTier::Free => "free",
@@ -1149,10 +1182,8 @@ pub(crate) fn request_auth_code_with_base_url(
         })
         .send()
         .map_err(|err| {
-            let msg = format!("Could not request sign-in code: {err}");
-            if !is_transient_transport_error(&err) {
-                sentry::capture_message(&msg, sentry::Level::Warning);
-            }
+            let msg = transport_failure("request a sign-in code", &err);
+            sentry::capture_message(&msg, transport_level(&err));
             msg
         })?;
 
@@ -1213,7 +1244,11 @@ pub(crate) fn verify_auth_code_with_base_url(
             identity: IdentityPayload::for_state(state),
         })
         .send()
-        .map_err(|err| format!("Could not verify sign-in code: {err}"))?;
+        .map_err(|err| {
+            let msg = transport_failure("verify your sign-in code", &err);
+            sentry::capture_message(&msg, transport_level(&err));
+            msg
+        })?;
 
     if !response.status().is_success() {
         return Err(format!(
@@ -1290,10 +1325,8 @@ pub(crate) fn activate_account_with_base_url(
         .json(&serde_json::json!({ "lifetime_tokens_saved": lifetime_tokens_saved }))
         .send()
         .map_err(|err| {
-            let msg = format!("Could not activate Headroom desktop access: {err}");
-            if !is_transient_transport_error(&err) {
-                sentry::capture_message(&msg, sentry::Level::Warning);
-            }
+            let msg = transport_failure("activate Headroom desktop access", &err);
+            sentry::capture_message(&msg, transport_level(&err));
             msg
         })?;
 
@@ -1575,7 +1608,7 @@ pub(crate) fn create_checkout_session_with_base_url(
             pricing_model: "intro",
         })
         .send()
-        .map_err(|err| format!("Could not create checkout session: {err}"))?;
+        .map_err(|err| transport_failure("start checkout", &err))?;
 
     if response.status().as_u16() == 401 {
         clear_session_token()?;
@@ -1623,7 +1656,7 @@ pub(crate) fn change_subscription_plan_with_base_url(
             pricing_model: "intro",
         })
         .send()
-        .map_err(|err| format!("Could not change subscription plan: {err}"))?;
+        .map_err(|err| transport_failure("change your plan", &err))?;
 
     if response.status().as_u16() == 401 {
         clear_session_token()?;
@@ -1655,7 +1688,7 @@ pub(crate) fn reactivate_subscription_with_base_url(base_url: &str) -> Result<()
         .post(join_url(base_url, "desktop/subscriptions/reactivate"))
         .header("Authorization", format!("Bearer {token}"))
         .send()
-        .map_err(|err| format!("Could not reactivate subscription: {err}"))?;
+        .map_err(|err| transport_failure("reactivate your subscription", &err))?;
 
     if response.status().as_u16() == 401 {
         clear_session_token()?;
@@ -1695,7 +1728,7 @@ pub(crate) fn get_billing_portal_url_with_base_url(
     }
     let response = request
         .send()
-        .map_err(|err| format!("Could not reach billing portal: {err}"))?;
+        .map_err(|err| transport_failure("open the billing portal", &err))?;
 
     if response.status().as_u16() == 401 {
         clear_session_token()?;
@@ -1733,7 +1766,7 @@ pub(crate) fn get_save_offer_with_base_url(base_url: &str) -> Result<Option<Save
         .get(join_url(base_url, "desktop/save_offer"))
         .header("Authorization", format!("Bearer {token}"))
         .send()
-        .map_err(|err| format!("Could not check for an offer: {err}"))?;
+        .map_err(|err| transport_failure("check for an offer", &err))?;
 
     if response.status().as_u16() == 401 {
         clear_session_token()?;
@@ -1777,7 +1810,7 @@ pub(crate) fn submit_cancellation_intent_with_base_url(
         .header("Authorization", format!("Bearer {token}"))
         .json(&serde_json::json!({ "reason": reason, "note": note }))
         .send()
-        .map_err(|err| format!("Could not reach Headroom: {err}"))?;
+        .map_err(|err| transport_failure("send your note", &err))?;
 
     if response.status().as_u16() == 401 {
         clear_session_token()?;
@@ -1812,7 +1845,7 @@ pub(crate) fn redeem_save_offer_with_base_url(base_url: &str) -> Result<(), Stri
         .post(join_url(base_url, "desktop/save_offer"))
         .header("Authorization", format!("Bearer {token}"))
         .send()
-        .map_err(|err| format!("Could not apply the offer: {err}"))?;
+        .map_err(|err| transport_failure("apply the offer", &err))?;
 
     if response.status().as_u16() == 401 {
         clear_session_token()?;
@@ -5725,6 +5758,33 @@ mod tests {
         )
         .expect_err("blank code rejected");
         assert!(err.contains("authentication code"));
+        drop_state(dir);
+    }
+
+    /// Issue #58: a headroom-web deploy switchover left the API unreachable for
+    /// ~75s and the user was shown reqwest's raw
+    /// "error sending request for url (https://...)". The message has to say
+    /// what to do, and must not leak the endpoint.
+    #[test]
+    fn verify_auth_code_reports_an_unreachable_server_in_plain_language() {
+        let (state, dir) = temp_app_state();
+        let err = super::verify_auth_code_with_base_url(
+            &state,
+            "user@example.com",
+            "123456",
+            None,
+            "http://127.0.0.1:1", // nothing listens here
+        )
+        .expect_err("unreachable server surfaces as error");
+
+        assert!(
+            err.contains("Check your connection"),
+            "not actionable: {err}"
+        );
+        assert!(
+            !err.contains("error sending request") && !err.contains("127.0.0.1"),
+            "leaked reqwest internals: {err}"
+        );
         drop_state(dir);
     }
 

--- a/src-tauri/src/proxy_intercept.rs
+++ b/src-tauri/src/proxy_intercept.rs
@@ -1764,7 +1764,7 @@ fn maybe_spawn_codex_usage_poll(buf: &[u8], codex_slot: &CodexRateLimitSlot) {
 /// Best-effort decode of one claim from the nested OpenAI auth object in a
 /// Codex OAuth bearer JWT. No signature verification: callers use this only
 /// to classify routing or show a local plan hint, never to grant access.
-fn decode_codex_auth_claim(token: &str, claim: &str) -> Option<String> {
+pub(crate) fn decode_codex_auth_claim(token: &str, claim: &str) -> Option<String> {
     let payload_b64 = token.split('.').nth(1)?;
     // JWT payloads are base64url without padding; tolerate either form.
     let trimmed = payload_b64.trim_end_matches('=');

--- a/src-tauri/src/proxy_intercept.rs
+++ b/src-tauri/src/proxy_intercept.rs
@@ -2899,7 +2899,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial(backend_port)]
+    #[serial]
     async fn intercept_captures_bearer_and_forwards_headers_to_backend() {
         // Fake backend: accept one connection, read its header block, hold the
         // connection open long enough for the test to inspect what arrived.
@@ -2916,8 +2916,12 @@ mod tests {
         });
 
         // Point the intercept's per-connection backend lookup at our fake
-        // backend's ephemeral port. Serialized via #[serial(backend_port)] so
-        // tests that mutate the global don't race.
+        // backend's ephemeral port. Serialized via #[serial] so tests that
+        // mutate the global don't race. Deliberately the unnamed key: every
+        // serial test in this crate shares it. A named group (#[serial(foo)])
+        // is an INDEPENDENT lock, so it would let a backend-port test run
+        // alongside an unnamed one and hand the loser a port pointing at
+        // someone else's fixture. Do not reintroduce named groups here.
         backend_port::set(backend_addr.port());
 
         // Run the intercept on its own ephemeral port.
@@ -3016,7 +3020,7 @@ mod tests {
     /// Only the negative case is asserted: letting the beacon fire would spawn a
     /// thread POSTing to the real headroom-web.
     #[tokio::test]
-    #[serial(backend_port)]
+    #[serial]
     async fn local_backend_path_does_not_fire_first_optimized_request() {
         use std::sync::atomic::Ordering;
 
@@ -3087,7 +3091,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial(backend_port)]
+    #[serial]
     async fn intercept_falls_back_direct_when_backend_is_unreachable() {
         // Pick a backend port that nothing is listening on. Bind+immediately
         // drop a listener to grab a free port, then connect attempts will fail.
@@ -3638,7 +3642,7 @@ mod tests {
     /// forwards a request to a fake upstream, then streams the upstream's
     /// response back to the client as HTTP/1.1 chunked transfer.
     #[tokio::test]
-    #[serial(backend_port)]
+    #[serial]
     async fn bypass_forwards_request_to_upstream_and_streams_response_back() {
         let (upstream_listener, upstream_addr) = bind_ephemeral().await;
         let upstream_base = format!("http://127.0.0.1:{}", upstream_addr.port());
@@ -3828,7 +3832,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial(backend_port)]
+    #[serial]
     async fn bypass_returns_502_when_upstream_unreachable() {
         // Bind+drop to grab a free port nothing is listening on.
         let (probe, dead_addr) = bind_ephemeral().await;
@@ -3908,7 +3912,7 @@ mod tests {
     /// when `tool_manager` selects a fallback port mid-launch, in-flight
     /// clients get routed to the new backend without a thread restart.
     #[tokio::test]
-    #[serial(backend_port)]
+    #[serial]
     async fn intercept_picks_up_backend_port_changes_between_connections() {
         let (first_listener, first_addr) = bind_ephemeral().await;
         let (second_listener, second_addr) = bind_ephemeral().await;
@@ -4254,7 +4258,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial(backend_port)]
+    #[serial]
     async fn intercept_rewrites_use_responses_lite_in_models_response() {
         let models_json = br#"{"models":[{"slug":"gpt-5.5","use_responses_lite":true}]}"#.to_vec();
         let (backend_listener, backend_addr) = bind_ephemeral().await;
@@ -4366,7 +4370,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial(backend_port)]
+    #[serial]
     async fn intercept_skips_models_rewrite_for_anthropic_fetch() {
         // Same catalog shape, but the request carries Anthropic markers —
         // the Codex-only lite-flag rewrite must leave it untouched.

--- a/src-tauri/src/savings_canary.rs
+++ b/src-tauri/src/savings_canary.rs
@@ -1,0 +1,251 @@
+//! Zero-savings canary.
+//!
+//! The 2026-08-21 Codex CLI 0.149.0 regression (tools moved out of the
+//! top-level `tools` array into `additional_tools` input items) ran 7+ peak
+//! hours before a human spotted it on the admin page. Nothing errored:
+//! requests forwarded and streamed normally, they just compressed to exactly
+//! zero. Every alarm we had was error-based or fleet-aggregated, and the
+//! server-side per-client rate canary that looks like the obvious answer
+//! cannot see it - codex is almost never a user's only client, so its
+//! dominant-client cohort was n=1 on the day of the incident.
+//!
+//! The signature is local and per-request: a large request that ran through
+//! the compression pipeline and saved nothing. This module reads it off the
+//! `/transformations/feed` batch `run_activity_observation` already polls, and
+//! reports once per process to Sentry, where events aggregate across the
+//! fleet on a fixed fingerprint. One machine reporting is a lead; a hundred
+//! is a graph.
+
+use std::collections::BTreeSet;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::models::TransformationFeedEvent;
+
+/// Requests below this are too small to draw a conclusion from - a short turn
+/// with nothing compressible legitimately saves zero.
+const MIN_INPUT_TOKENS: u64 = 10_000;
+/// Qualifying requests needed before the ratio means anything. The observer
+/// pulls 150 events per pass, so a busy machine clears this easily and a
+/// barely-used one stays quiet instead of paging on three samples.
+const MIN_SAMPLE: usize = 20;
+/// Healthy traffic scatters; a wire-format change zeroes essentially all of
+/// it. Anything short of near-total is noise, not a regression.
+const ZERO_RATIO: f64 = 0.9;
+
+/// One report per process. A wedged client produces the same finding on every
+/// observer pass, and the point is to learn that it happened, not how often.
+static REPORTED: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug, PartialEq)]
+pub struct Anomaly {
+    /// Large, compression-eligible requests examined.
+    pub sample: usize,
+    /// How many of those saved nothing.
+    pub zero: usize,
+    /// Distinct output-shaper strata seen on the zero-saved requests. The
+    /// `|notools` suffix is what named the Codex regression.
+    pub strata: Vec<String>,
+    /// Distinct `provider/model` pairs, to point at which client broke.
+    pub models: Vec<String>,
+}
+
+/// Pick out the anomaly, or `None` when the batch looks healthy or is too
+/// thin to judge. Pure: `observe` owns the reporting side effects.
+pub fn detect(events: &[TransformationFeedEvent]) -> Option<Anomaly> {
+    // An empty transform list means the pipeline never ran (bypass header,
+    // optimize disabled, unlicensed). Those save zero by design and must not
+    // page - only requests that were actually compressed count.
+    let considered: Vec<&TransformationFeedEvent> = events
+        .iter()
+        .filter(|e| {
+            !e.transforms_applied.is_empty()
+                && e.input_tokens_original.unwrap_or(0) >= MIN_INPUT_TOKENS
+        })
+        .collect();
+
+    if considered.len() < MIN_SAMPLE {
+        return None;
+    }
+
+    let zeroed: Vec<&&TransformationFeedEvent> = considered
+        .iter()
+        .filter(|e| e.tokens_saved.unwrap_or(0) <= 0)
+        .collect();
+
+    if (zeroed.len() as f64) < considered.len() as f64 * ZERO_RATIO {
+        return None;
+    }
+
+    // BTreeSet: deduped and ordered, so the Sentry extras are stable across
+    // machines instead of reshuffling per batch.
+    let mut strata = BTreeSet::new();
+    let mut models = BTreeSet::new();
+    for event in &zeroed {
+        for transform in &event.transforms_applied {
+            if let Some(stratum) = transform.strip_prefix("output_shaper:stratum:") {
+                strata.insert(stratum.to_string());
+            }
+        }
+        let provider = event.provider.as_deref().unwrap_or("?");
+        let model = event.model.as_deref().unwrap_or("?");
+        models.insert(format!("{provider}/{model}"));
+    }
+
+    Some(Anomaly {
+        sample: considered.len(),
+        zero: zeroed.len(),
+        strata: strata.into_iter().take(5).collect(),
+        models: models.into_iter().take(5).collect(),
+    })
+}
+
+/// Report a detected anomaly to Sentry, at most once per process.
+pub fn observe(events: &[TransformationFeedEvent]) {
+    let Some(anomaly) = detect(events) else {
+        return;
+    };
+    if REPORTED.swap(true, Ordering::AcqRel) {
+        return;
+    }
+
+    let strata = anomaly.strata.join(", ");
+    let models = anomaly.models.join(", ");
+    // Fixed fingerprint: every affected machine lands in one issue, so the
+    // event count is the blast radius. Counts stay out of it deliberately.
+    let fingerprint: [&str; 1] = ["zero_savings_canary"];
+    sentry::with_scope(
+        |scope| {
+            scope.set_tag("flow", "zero_savings_canary");
+            scope.set_extra("sample", (anomaly.sample as u64).into());
+            scope.set_extra("zero_saved", (anomaly.zero as u64).into());
+            scope.set_extra("min_input_tokens", MIN_INPUT_TOKENS.into());
+            scope.set_extra("strata", strata.clone().into());
+            scope.set_extra("models", models.clone().into());
+            scope.set_fingerprint(Some(fingerprint.as_slice()));
+        },
+        || {
+            sentry::capture_message(
+                &format!(
+                    "zero_savings_canary: {}/{} large requests compressed to nothing \
+                     (models: {models}; strata: {strata})",
+                    anomaly.zero, anomaly.sample
+                ),
+                sentry::Level::Warning,
+            );
+        },
+    );
+    log::warn!(
+        "zero-savings canary: {}/{} requests over {MIN_INPUT_TOKENS} tokens saved nothing \
+         (models: {models}; strata: {strata})",
+        anomaly.zero,
+        anomaly.sample
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event(input_tokens: u64, saved: i64, transforms: &[&str]) -> TransformationFeedEvent {
+        TransformationFeedEvent {
+            request_id: None,
+            timestamp: None,
+            provider: Some("openai".to_string()),
+            model: Some("gpt-5.6-sol".to_string()),
+            input_tokens_original: Some(input_tokens),
+            input_tokens_optimized: Some(input_tokens.saturating_sub(saved.max(0) as u64)),
+            tokens_saved: Some(saved),
+            savings_percent: None,
+            transforms_applied: transforms.iter().map(|t| t.to_string()).collect(),
+            workspace: None,
+            turn_id: None,
+            request_messages: None,
+            compressed_messages: None,
+        }
+    }
+
+    /// The Codex 0.149.0 shape: compression ran, classified `notools`, saved 0.
+    fn zeroed_codex_batch(count: usize) -> Vec<TransformationFeedEvent> {
+        (0..count)
+            .map(|_| {
+                event(
+                    40_000,
+                    0,
+                    &[
+                        "output_shaper:stratum:gpt|new_user_ask|m|notools",
+                        "output_shaper:verbosity:L2",
+                    ],
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn detects_a_fleet_of_large_requests_saving_nothing() {
+        let anomaly = detect(&zeroed_codex_batch(MIN_SAMPLE)).expect("anomaly");
+        assert_eq!(anomaly.sample, MIN_SAMPLE);
+        assert_eq!(anomaly.zero, MIN_SAMPLE);
+        assert_eq!(anomaly.strata, vec!["gpt|new_user_ask|m|notools"]);
+        assert_eq!(anomaly.models, vec!["openai/gpt-5.6-sol"]);
+    }
+
+    #[test]
+    fn stays_quiet_below_the_sample_floor() {
+        assert!(detect(&zeroed_codex_batch(MIN_SAMPLE - 1)).is_none());
+    }
+
+    #[test]
+    fn stays_quiet_when_compression_is_working() {
+        let healthy: Vec<_> = (0..MIN_SAMPLE * 2)
+            .map(|_| event(40_000, 608, &["openai:responses:tool_schema_compaction"]))
+            .collect();
+        assert!(detect(&healthy).is_none());
+    }
+
+    /// Passthrough (bypass header, optimize off, unlicensed) saves zero by
+    /// design and must never page: the pipeline never ran, so no transforms.
+    #[test]
+    fn ignores_passthrough_requests() {
+        let passthrough: Vec<_> = (0..MIN_SAMPLE * 2).map(|_| event(40_000, 0, &[])).collect();
+        assert!(detect(&passthrough).is_none());
+    }
+
+    /// Small turns legitimately have nothing to compress.
+    #[test]
+    fn ignores_small_requests() {
+        let small: Vec<_> = (0..MIN_SAMPLE * 2)
+            .map(|_| event(MIN_INPUT_TOKENS - 1, 0, &["output_shaper:verbosity:L2"]))
+            .collect();
+        assert!(detect(&small).is_none());
+    }
+
+    /// A minority of zero-saved requests is ordinary scatter, not a break.
+    #[test]
+    fn tolerates_a_minority_of_zero_saved_requests() {
+        let mut mixed = zeroed_codex_batch(4);
+        mixed.extend(
+            (0..16).map(|_| event(40_000, 900, &["openai:responses:tool_schema_compaction"])),
+        );
+        assert!(detect(&mixed).is_none());
+    }
+
+    /// Missing `tokens_saved` (older proxy, or an outcome that never recorded
+    /// one) reads as zero rather than being silently dropped from the count.
+    #[test]
+    fn treats_absent_tokens_saved_as_zero() {
+        let mut batch = zeroed_codex_batch(MIN_SAMPLE);
+        for entry in &mut batch {
+            entry.tokens_saved = None;
+        }
+        assert_eq!(detect(&batch).expect("anomaly").zero, MIN_SAMPLE);
+    }
+
+    #[test]
+    fn observe_reports_at_most_once_per_process() {
+        // The static is process-wide, so this asserts the swap contract
+        // directly rather than fighting the other tests over Sentry state.
+        assert!(!REPORTED.swap(true, Ordering::AcqRel));
+        assert!(REPORTED.swap(true, Ordering::AcqRel));
+        REPORTED.store(false, Ordering::Release);
+    }
+}

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -3509,7 +3509,17 @@ impl AppState {
                 self.proxy_bypass.store(false, Release);
                 self.claude_only_bypass.store(false, Release);
             }
-            Err(_) => {}
+            // Leave the flags on their last known value: a pricing lookup that
+            // failed is not evidence the user became gated, and flipping
+            // bypass on a transient error would drop them to unoptimized
+            // traffic. Deliberately fail-open, but NOT silent -- if this
+            // starts failing persistently the gate freezes on whatever it last
+            // decided and nothing else in the app would ever say so. warn!
+            // bridges to Sentry, so a sustained outage surfaces instead of
+            // looking like a healthy ungated fleet.
+            Err(err) => {
+                log::warn!("enforce_pricing_gate: pricing status unavailable, leaving gate flags unchanged: {err}");
+            }
         }
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -5627,10 +5627,26 @@ impl HeadroomSavingsHistoryResponse {
 /// timeout eat three days of output-shaping samples unnoticed, but the
 /// dashboard retries every 12s and `log::warn!` bridges to Sentry, so an
 /// unthrottled warn would flood it.
-/// ponytail: in-memory, resets on restart (one warn per launch while broken)
-/// and never resets on recovery, so a flap inside the window stays quiet.
+/// The window DOUBLES per consecutive warn up to `STATS_FETCH_WARN_MAX_INTERVAL`,
+/// because some causes are permanent and unfixable by any release we ship:
+/// RUST-87 is a single mac whose 6767 belongs to another app, and the flat
+/// 15-minute window sent 96 identical events a day from that one host with no
+/// end state. A first failure still speaks immediately; only the repeats decay.
+/// A successful fetch clears the streak, so a condition that heals and comes
+/// back is loud again.
+/// ponytail: one global slot, not per-category -- a host has one cause at a
+/// time in practice; key it by category if that stops being true.
 const STATS_FETCH_WARN_INTERVAL: Duration = Duration::from_secs(900);
-static STATS_FETCH_WARNED_AT: Mutex<Option<Instant>> = Mutex::new(None);
+const STATS_FETCH_WARN_MAX_INTERVAL: Duration = Duration::from_secs(6 * 3600);
+static STATS_FETCH_WARNED_AT: Mutex<Option<(Instant, u32)>> = Mutex::new(None);
+
+/// Window a warn must clear before the `streak`-th consecutive one may speak:
+/// 15m, 30m, 1h, 2h, 4h, then capped. `streak` is 1-based.
+fn stats_fetch_warn_interval(streak: u32) -> Duration {
+    STATS_FETCH_WARN_INTERVAL
+        .saturating_mul(1u32 << streak.clamp(1, 6).saturating_sub(1))
+        .min(STATS_FETCH_WARN_MAX_INTERVAL)
+}
 
 /// Coarse cause class for a `/stats` failure, used as the Sentry fingerprint.
 ///
@@ -5659,10 +5675,17 @@ fn stats_fetch_failure_category(reason: &str) -> String {
 
 fn warn_stats_fetch_failed(reason: &str) {
     let mut last = STATS_FETCH_WARNED_AT.lock();
-    if last.is_some_and(|at| at.elapsed() < STATS_FETCH_WARN_INTERVAL) {
-        return;
-    }
-    *last = Some(Instant::now());
+    let streak = match *last {
+        Some((at, streak)) => {
+            if at.elapsed() < stats_fetch_warn_interval(streak) {
+                return;
+            }
+            streak.saturating_add(1)
+        }
+        None => 1,
+    };
+    *last = Some((Instant::now(), streak));
+    drop(last);
     let category = stats_fetch_failure_category(reason);
     // A 4xx means SOMETHING answered 6767 without the backend's routes, and
     // the readyz gate cannot tell it from an ancient-but-ours proxy (a 404
@@ -5747,6 +5770,8 @@ fn fetch_headroom_dashboard_stats() -> Option<HeadroomDashboardStats> {
         };
 
         if let Some(parsed) = parse_headroom_stats_from_json(&body) {
+            // Recovery resets the backoff: the next outage warns immediately.
+            *STATS_FETCH_WARNED_AT.lock() = None;
             return Some(parsed);
         }
         last_failure = Some("payload had no recognised savings fields".to_string());
@@ -7599,12 +7624,13 @@ mod tests {
         parse_headroom_stats_history_from_json, parse_ps_cpu_time,
         proxy_readyz_503_body_is_upstream_only, proxy_readyz_status_is_reachable,
         rebuild_persisted_savings_from_records, savings_rate_implausible,
-        support_tier_for_platform, tcp_port_accepts_connection, tool_schema_savings_usd,
-        total_dir_size_bytes, warn_stats_fetch_failed, AppState, BootValidationOutcome,
-        ClaudeProjectScan, DailySavingsBucket, Duration, HeadroomDashboardStats,
-        HeadroomSavingsHistoryPoint, Instant, OutputSampleBucket, PersistedSavingsState,
-        SavingsObservation, SavingsRecord, SavingsTracker, OUTPUT_SAMPLE_SERIES_VERSION,
-        STATS_FETCH_WARNED_AT, STATS_FETCH_WARN_INTERVAL,
+        stats_fetch_warn_interval, support_tier_for_platform, tcp_port_accepts_connection,
+        tool_schema_savings_usd, total_dir_size_bytes, warn_stats_fetch_failed, AppState,
+        BootValidationOutcome, ClaudeProjectScan, DailySavingsBucket, Duration,
+        HeadroomDashboardStats, HeadroomSavingsHistoryPoint, Instant, OutputSampleBucket,
+        PersistedSavingsState, SavingsObservation, SavingsRecord, SavingsTracker,
+        OUTPUT_SAMPLE_SERIES_VERSION, STATS_FETCH_WARNED_AT, STATS_FETCH_WARN_INTERVAL,
+        STATS_FETCH_WARN_MAX_INTERVAL,
     };
 
     #[test]
@@ -10000,11 +10026,12 @@ mod tests {
         *STATS_FETCH_WARNED_AT.lock() = None;
 
         warn_stats_fetch_failed("timed out after 5s");
-        let first = (*STATS_FETCH_WARNED_AT.lock()).expect("first failure warns");
+        let (first, streak) = (*STATS_FETCH_WARNED_AT.lock()).expect("first failure warns");
+        assert_eq!(streak, 1);
 
         warn_stats_fetch_failed("timed out after 5s");
         assert_eq!(
-            (*STATS_FETCH_WARNED_AT.lock()).expect("still stamped"),
+            (*STATS_FETCH_WARNED_AT.lock()).expect("still stamped").0,
             first,
             "a repeat inside the window must not warn again"
         );
@@ -10013,15 +10040,54 @@ mod tests {
         if let Some(stale) =
             Instant::now().checked_sub(STATS_FETCH_WARN_INTERVAL + Duration::from_secs(1))
         {
-            *STATS_FETCH_WARNED_AT.lock() = Some(stale);
+            *STATS_FETCH_WARNED_AT.lock() = Some((stale, 1));
             warn_stats_fetch_failed("timed out after 5s");
+            let (at, streak) = (*STATS_FETCH_WARNED_AT.lock()).expect("re-stamped");
             assert!(
-                (*STATS_FETCH_WARNED_AT.lock()).expect("re-stamped") > stale,
+                at > stale,
                 "a failure after the window elapsed must warn again"
+            );
+            assert_eq!(
+                streak, 2,
+                "the streak advances so the next window is longer"
+            );
+
+            // The window that just elapsed no longer clears the new one.
+            *STATS_FETCH_WARNED_AT.lock() = Some((stale, 2));
+            warn_stats_fetch_failed("timed out after 5s");
+            assert_eq!(
+                (*STATS_FETCH_WARNED_AT.lock()).expect("unchanged").0,
+                stale,
+                "a permanent cause must back off instead of warning every window"
             );
         }
 
         *STATS_FETCH_WARNED_AT.lock() = None;
+    }
+
+    #[test]
+    fn stats_fetch_warn_interval_backs_off_and_caps() {
+        // RUST-87: one host whose 6767 is owned by another app warned 96x/day
+        // under a flat window. Backoff turns an unfixable cause into ~8/day.
+        assert_eq!(stats_fetch_warn_interval(1), STATS_FETCH_WARN_INTERVAL);
+        assert_eq!(stats_fetch_warn_interval(2), STATS_FETCH_WARN_INTERVAL * 2);
+        assert_eq!(stats_fetch_warn_interval(5), STATS_FETCH_WARN_INTERVAL * 16);
+        assert_eq!(stats_fetch_warn_interval(6), STATS_FETCH_WARN_MAX_INTERVAL);
+        assert_eq!(
+            stats_fetch_warn_interval(u32::MAX),
+            STATS_FETCH_WARN_MAX_INTERVAL
+        );
+        // A streak of 0 is unreachable, but must not shift by -1.
+        assert_eq!(stats_fetch_warn_interval(0), STATS_FETCH_WARN_INTERVAL);
+
+        // 24h of continuous failure, first warn at t=0.
+        let mut elapsed = Duration::ZERO;
+        let mut warns = 1u32;
+        while elapsed < Duration::from_secs(24 * 3600) {
+            elapsed += stats_fetch_warn_interval(warns);
+            warns += 1;
+        }
+        assert!(warns <= 10, "expected <=10 warns/day, got {warns}");
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -4183,6 +4183,17 @@ struct OutputSampleBucket {
     baseline_tokens: u64,
 }
 
+/// Semantics version of the sampled output series. The samples are deltas of
+/// `crate::output_savings::estimate()`, so they are only comparable to other
+/// samples taken under the same estimator rules. Bump this when those rules
+/// change and the persisted series + watermark pair are dropped once on load:
+/// mixing units keeps stale artifacts on the chart (the 98.7% ping buckets of
+/// 2026-08) and parks the seed watermark above the new, smaller cumulative,
+/// which silences the sampler until it re-climbs the difference.
+/// Version history: 0 = pre-field (prefix-fallback lookup), 1 = exact-stratum
+/// lookup with MIN_BASELINE_N (2026-08-22).
+const OUTPUT_SAMPLE_SERIES_VERSION: u8 = 1;
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 struct PersistedSavingsState {
@@ -4221,6 +4232,9 @@ struct PersistedSavingsState {
     /// local (`local_hour_key`, joining the local-keyed hourly points).
     output_daily_samples: BTreeMap<String, OutputSampleBucket>,
     output_hourly_samples: BTreeMap<String, OutputSampleBucket>,
+    /// See [`OUTPUT_SAMPLE_SERIES_VERSION`]. Container default (0) marks a
+    /// file written before the field existed, whose series is in old units.
+    output_sample_series_version: u8,
     /// Last reading of the output shaper's durable estimator total. Cached so
     /// the lifetime headline can price this layer while the backend is still
     /// starting: without it, cold start falls back to the (understating)
@@ -4337,6 +4351,19 @@ impl SavingsTracker {
                 })
             });
 
+        // Old-units sampled series (see OUTPUT_SAMPLE_SERIES_VERSION) is
+        // dropped wholesale: buckets, plus the watermark seed pair -- keeping
+        // the pair would floor the first-poll seed at the OLD estimator's
+        // larger cumulative and silence the sampler until it re-climbs there.
+        let output_series_current = persisted_state.as_ref().is_some_and(|state| {
+            state.output_sample_series_version >= OUTPUT_SAMPLE_SERIES_VERSION
+        });
+        if persisted_state.is_some() && !output_series_current {
+            log::info!(
+                "sampled output series predates estimator semantics v{OUTPUT_SAMPLE_SERIES_VERSION}; dropping it"
+            );
+        }
+
         let mut tracker = Self {
             records_path,
             state_path,
@@ -4375,16 +4402,20 @@ impl SavingsTracker {
                 .map_or_else(BTreeMap::new, |state| state.hourly_savings.clone()),
             output_daily_samples: persisted_state
                 .as_ref()
+                .filter(|_| output_series_current)
                 .map_or_else(BTreeMap::new, |state| state.output_daily_samples.clone()),
             output_hourly_samples: persisted_state
                 .as_ref()
+                .filter(|_| output_series_current)
                 .map_or_else(BTreeMap::new, |state| state.output_hourly_samples.clone()),
             output_sample_watermark: None,
             last_output_estimator_tokens_saved: persisted_state
                 .as_ref()
+                .filter(|_| output_series_current)
                 .and_then(|state| state.last_output_estimator_tokens_saved),
             last_output_estimator_baseline_tokens: persisted_state
                 .as_ref()
+                .filter(|_| output_series_current)
                 .and_then(|state| state.last_output_estimator_baseline_tokens),
             last_written_at: None,
         };
@@ -5173,6 +5204,7 @@ impl SavingsTracker {
             output_hourly_samples: self.output_hourly_samples.clone(),
             last_output_estimator_tokens_saved: self.last_output_estimator_tokens_saved,
             last_output_estimator_baseline_tokens: self.last_output_estimator_baseline_tokens,
+            output_sample_series_version: OUTPUT_SAMPLE_SERIES_VERSION,
         }
     }
 
@@ -7543,8 +7575,9 @@ mod tests {
         support_tier_for_platform, tcp_port_accepts_connection, tool_schema_savings_usd,
         total_dir_size_bytes, warn_stats_fetch_failed, AppState, BootValidationOutcome,
         ClaudeProjectScan, DailySavingsBucket, Duration, HeadroomDashboardStats,
-        HeadroomSavingsHistoryPoint, Instant, PersistedSavingsState, SavingsObservation,
-        SavingsRecord, SavingsTracker, STATS_FETCH_WARNED_AT, STATS_FETCH_WARN_INTERVAL,
+        HeadroomSavingsHistoryPoint, Instant, OutputSampleBucket, PersistedSavingsState,
+        SavingsObservation, SavingsRecord, SavingsTracker, OUTPUT_SAMPLE_SERIES_VERSION,
+        STATS_FETCH_WARNED_AT, STATS_FETCH_WARN_INTERVAL,
     };
 
     #[test]
@@ -8508,6 +8541,70 @@ mod tests {
         assert_eq!(
             reloaded.last_output_estimator_tokens_saved,
             Some(22_000_000)
+        );
+    }
+
+    #[test]
+    fn old_units_sampled_output_series_is_dropped_once_on_load() {
+        // A file written before OUTPUT_SAMPLE_SERIES_VERSION existed carries
+        // sampled buckets in the old estimator's units (the 98.7% ping
+        // artifacts) and a watermark pair far above the new cumulative, which
+        // would silence the sampler for weeks. Both go; everything else stays.
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join("config")).expect("config dir");
+        let mut old = PersistedSavingsState {
+            schema_version: 3,
+            lifetime_requests: 12,
+            last_output_estimator_tokens_saved: Some(11_644_822),
+            last_output_estimator_baseline_tokens: Some(36_147_591),
+            output_sample_series_version: 0,
+            ..Default::default()
+        };
+        old.output_daily_samples.insert(
+            "2026-08-21".into(),
+            OutputSampleBucket {
+                saved_tokens: 6_360,
+                baseline_tokens: 6_444,
+            },
+        );
+        old.output_hourly_samples.insert(
+            "2026-08-21T09:00".into(),
+            OutputSampleBucket {
+                saved_tokens: 1_586,
+                baseline_tokens: 1_611,
+            },
+        );
+        std::fs::write(
+            config_file(dir.path(), "savings-state.json"),
+            serde_json::to_vec(&old).expect("serialize"),
+        )
+        .expect("write old state");
+
+        let tracker = SavingsTracker::load_or_create(dir.path()).expect("load");
+        assert!(tracker.output_daily_samples.is_empty());
+        assert!(tracker.output_hourly_samples.is_empty());
+        assert_eq!(tracker.last_output_estimator_tokens_saved, None);
+        assert_eq!(tracker.last_output_estimator_baseline_tokens, None);
+        assert_eq!(tracker.lifetime_requests, 12, "unrelated fields survive");
+
+        // The initial persist in load_or_create stamps the current version,
+        // so the drop happens exactly once: new-units samples then survive.
+        let mut tracker = tracker;
+        tracker.output_daily_samples.insert(
+            "2026-08-22".into(),
+            OutputSampleBucket {
+                saved_tokens: 100,
+                baseline_tokens: 400,
+            },
+        );
+        tracker.persist_state().expect("persist");
+        let reloaded = SavingsTracker::load_or_create(dir.path()).expect("reload");
+        assert_eq!(
+            reloaded.output_daily_samples.get("2026-08-22"),
+            Some(&OutputSampleBucket {
+                saved_tokens: 100,
+                baseline_tokens: 400,
+            })
         );
     }
 
@@ -10986,6 +11083,7 @@ mod tests {
             output_hourly_samples: std::collections::BTreeMap::new(),
             last_output_estimator_tokens_saved: None,
             last_output_estimator_baseline_tokens: None,
+            output_sample_series_version: OUTPUT_SAMPLE_SERIES_VERSION,
         };
         std::fs::write(
             config_file(&base_dir, "savings-state.json"),

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -4184,12 +4184,17 @@ struct OutputSampleBucket {
 }
 
 /// Semantics version of the sampled output series. The samples are deltas of
-/// `crate::output_savings::estimate()`, so they are only comparable to other
-/// samples taken under the same estimator rules. Bump this when those rules
-/// change and the persisted series + watermark pair are dropped once on load:
-/// mixing units keeps stale artifacts on the chart (the 98.7% ping buckets of
-/// 2026-08) and parks the seed watermark above the new, smaller cumulative,
-/// which silences the sampler until it re-climbs the difference.
+/// `crate::output_savings::estimate()`, so a sample is only comparable to
+/// others taken under the same estimator rules. Bump this when those rules
+/// change: the persisted *watermark pair* is then dropped once on load, so the
+/// next poll reseeds against the new cumulative instead of parking above it
+/// (the new number is smaller, and a mark left at the old one silences the
+/// sampler until it re-climbs the difference — weeks, on a real ledger).
+///
+/// Recorded BUCKETS are deliberately kept across a bump. They are the history
+/// the chart draws, and a percentage measured honestly under the rules of its
+/// day is worth more than a gap: v1 dropped them and simply erased two weeks
+/// of a user's output history. Only the seed pair is unit-sensitive.
 /// Version history: 0 = pre-field (prefix-fallback lookup), 1 = exact-stratum
 /// lookup with MIN_BASELINE_N (2026-08-22).
 const OUTPUT_SAMPLE_SERIES_VERSION: u8 = 1;
@@ -4351,16 +4356,16 @@ impl SavingsTracker {
                 })
             });
 
-        // Old-units sampled series (see OUTPUT_SAMPLE_SERIES_VERSION) is
-        // dropped wholesale: buckets, plus the watermark seed pair -- keeping
-        // the pair would floor the first-poll seed at the OLD estimator's
-        // larger cumulative and silence the sampler until it re-climbs there.
+        // Sampled series recorded under older estimator semantics (see
+        // OUTPUT_SAMPLE_SERIES_VERSION): the buckets stay -- they are the
+        // user's history -- but the watermark seed pair is dropped so the
+        // first poll reseeds against the new, smaller cumulative.
         let output_series_current = persisted_state.as_ref().is_some_and(|state| {
             state.output_sample_series_version >= OUTPUT_SAMPLE_SERIES_VERSION
         });
         if persisted_state.is_some() && !output_series_current {
             log::info!(
-                "sampled output series predates estimator semantics v{OUTPUT_SAMPLE_SERIES_VERSION}; dropping it"
+                "sampled output series predates estimator semantics v{OUTPUT_SAMPLE_SERIES_VERSION}; reseeding the watermark, keeping recorded buckets"
             );
         }
 
@@ -4402,11 +4407,9 @@ impl SavingsTracker {
                 .map_or_else(BTreeMap::new, |state| state.hourly_savings.clone()),
             output_daily_samples: persisted_state
                 .as_ref()
-                .filter(|_| output_series_current)
                 .map_or_else(BTreeMap::new, |state| state.output_daily_samples.clone()),
             output_hourly_samples: persisted_state
                 .as_ref()
-                .filter(|_| output_series_current)
                 .map_or_else(BTreeMap::new, |state| state.output_hourly_samples.clone()),
             output_sample_watermark: None,
             last_output_estimator_tokens_saved: persisted_state
@@ -8545,11 +8548,12 @@ mod tests {
     }
 
     #[test]
-    fn old_units_sampled_output_series_is_dropped_once_on_load() {
+    fn old_units_sampled_output_series_keeps_history_and_reseeds_the_watermark() {
         // A file written before OUTPUT_SAMPLE_SERIES_VERSION existed carries
-        // sampled buckets in the old estimator's units (the 98.7% ping
-        // artifacts) and a watermark pair far above the new cumulative, which
-        // would silence the sampler for weeks. Both go; everything else stays.
+        // sampled buckets recorded under the old estimator plus a watermark
+        // pair far above the new cumulative. The watermark must go (it would
+        // silence the sampler for weeks); the buckets must NOT -- dropping
+        // them erased two weeks of a real user's output history.
         let dir = tempfile::tempdir().expect("tempdir");
         std::fs::create_dir_all(dir.path().join("config")).expect("config dir");
         let mut old = PersistedSavingsState {
@@ -8581,14 +8585,21 @@ mod tests {
         .expect("write old state");
 
         let tracker = SavingsTracker::load_or_create(dir.path()).expect("load");
-        assert!(tracker.output_daily_samples.is_empty());
-        assert!(tracker.output_hourly_samples.is_empty());
+        assert_eq!(
+            tracker.output_daily_samples.get("2026-08-21"),
+            Some(&OutputSampleBucket {
+                saved_tokens: 6_360,
+                baseline_tokens: 6_444,
+            }),
+            "recorded history survives an estimator-semantics bump"
+        );
+        assert_eq!(tracker.output_hourly_samples.len(), 1);
         assert_eq!(tracker.last_output_estimator_tokens_saved, None);
         assert_eq!(tracker.last_output_estimator_baseline_tokens, None);
         assert_eq!(tracker.lifetime_requests, 12, "unrelated fields survive");
 
-        // The initial persist in load_or_create stamps the current version,
-        // so the drop happens exactly once: new-units samples then survive.
+        // The initial persist in load_or_create stamps the current version, so
+        // the reseed happens exactly once and later buckets accumulate on top.
         let mut tracker = tracker;
         tracker.output_daily_samples.insert(
             "2026-08-22".into(),
@@ -8597,14 +8608,14 @@ mod tests {
                 baseline_tokens: 400,
             },
         );
+        tracker.last_output_estimator_tokens_saved = Some(5_308_371);
         tracker.persist_state().expect("persist");
         let reloaded = SavingsTracker::load_or_create(dir.path()).expect("reload");
+        assert_eq!(reloaded.output_daily_samples.len(), 2);
         assert_eq!(
-            reloaded.output_daily_samples.get("2026-08-22"),
-            Some(&OutputSampleBucket {
-                saved_tokens: 100,
-                baseline_tokens: 400,
-            })
+            reloaded.last_output_estimator_tokens_saved,
+            Some(5_308_371),
+            "watermark survives once the series is current"
         );
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -4357,15 +4357,27 @@ impl SavingsTracker {
             });
 
         // Sampled series recorded under older estimator semantics (see
-        // OUTPUT_SAMPLE_SERIES_VERSION): the buckets stay -- they are the
+        // OUTPUT_SAMPLE_SERIES_VERSION): completed days stay -- they are the
         // user's history -- but the watermark seed pair is dropped so the
         // first poll reseeds against the new, smaller cumulative.
+        //
+        // The bucket covering the moment of the bump is the exception. It is a
+        // part-day of OLD-units samples that new-units samples are about to be
+        // added to, so it represents nothing: on 2026-08-22 it left the day
+        // chip reading 93% (pure pre-bump ping artifacts) while every other
+        // number had moved to the new estimator. Dropping just that bucket
+        // costs the current day's partial figure -- which the all-time
+        // fallback covers -- and keeps every completed day.
         let output_series_current = persisted_state.as_ref().is_some_and(|state| {
             state.output_sample_series_version >= OUTPUT_SAMPLE_SERIES_VERSION
         });
+        // Daily keys are UTC dates, hourly keys are local (see the field docs),
+        // so the seam has to be named in each series' own timezone.
+        let seam_day_utc = Utc::now().format("%Y-%m-%d").to_string();
+        let seam_day_local = local_day_key(Local::now());
         if persisted_state.is_some() && !output_series_current {
             log::info!(
-                "sampled output series predates estimator semantics v{OUTPUT_SAMPLE_SERIES_VERSION}; reseeding the watermark, keeping recorded buckets"
+                "sampled output series predates estimator semantics v{OUTPUT_SAMPLE_SERIES_VERSION}; reseeding the watermark, dropping the {seam_day_utc} seam bucket, keeping completed days"
             );
         }
 
@@ -4407,10 +4419,22 @@ impl SavingsTracker {
                 .map_or_else(BTreeMap::new, |state| state.hourly_savings.clone()),
             output_daily_samples: persisted_state
                 .as_ref()
-                .map_or_else(BTreeMap::new, |state| state.output_daily_samples.clone()),
+                .map_or_else(BTreeMap::new, |state| {
+                    let mut samples = state.output_daily_samples.clone();
+                    if !output_series_current {
+                        samples.remove(&seam_day_utc);
+                    }
+                    samples
+                }),
             output_hourly_samples: persisted_state
                 .as_ref()
-                .map_or_else(BTreeMap::new, |state| state.output_hourly_samples.clone()),
+                .map_or_else(BTreeMap::new, |state| {
+                    let mut samples = state.output_hourly_samples.clone();
+                    if !output_series_current {
+                        samples.retain(|key, _| !key.starts_with(&seam_day_local));
+                    }
+                    samples
+                }),
             output_sample_watermark: None,
             last_output_estimator_tokens_saved: persisted_state
                 .as_ref()
@@ -8578,6 +8602,25 @@ mod tests {
                 baseline_tokens: 1_611,
             },
         );
+        // The seam: a part-day of old-units samples that new-units samples
+        // would be added to. Kept, it reads as the day's figure (93% of pure
+        // ping artifacts, 2026-08-22) long after everything else has moved on.
+        let seam_day_utc = Utc::now().format("%Y-%m-%d").to_string();
+        let seam_hour_local = super::local_hour_key(Local::now());
+        old.output_daily_samples.insert(
+            seam_day_utc.clone(),
+            OutputSampleBucket {
+                saved_tokens: 17_995,
+                baseline_tokens: 19_332,
+            },
+        );
+        old.output_hourly_samples.insert(
+            seam_hour_local.clone(),
+            OutputSampleBucket {
+                saved_tokens: 1_590,
+                baseline_tokens: 1_611,
+            },
+        );
         std::fs::write(
             config_file(dir.path(), "savings-state.json"),
             serde_json::to_vec(&old).expect("serialize"),
@@ -8585,6 +8628,11 @@ mod tests {
         .expect("write old state");
 
         let tracker = SavingsTracker::load_or_create(dir.path()).expect("load");
+        assert!(
+            !tracker.output_daily_samples.contains_key(&seam_day_utc),
+            "the mixed-units seam bucket is dropped"
+        );
+        assert!(!tracker.output_hourly_samples.contains_key(&seam_hour_local));
         assert_eq!(
             tracker.output_daily_samples.get("2026-08-21"),
             Some(&OutputSampleBucket {

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -11300,7 +11300,7 @@ S(('127.0.0.1', int(sys.argv[1])), H).serve_forever()
     }
 
     #[test]
-    #[serial_test::serial(backend_port)]
+    #[serial_test::serial]
     fn managed_headroom_startup_uses_supported_proxy_args() {
         backend_port::reset_for_tests();
         let default_port = backend_port::DEFAULT_BACKEND_PORT.to_string();
@@ -11344,7 +11344,7 @@ S(('127.0.0.1', int(sys.argv[1])), H).serve_forever()
     /// validation attempt exit 2 and the upgrade time out. The flag must be
     /// gated on runtime >= 0.28.0; unknown versions assume the pinned runtime.
     #[test]
-    #[serial_test::serial(backend_port)]
+    #[serial_test::serial]
     fn entrypoint_args_gate_no_http2_on_runtime_version() {
         backend_port::reset_for_tests();
 
@@ -11374,7 +11374,7 @@ S(('127.0.0.1', int(sys.argv[1])), H).serve_forever()
     /// `--no-ccr` flag only exists from 0.31.0; on the 0.28.0 fallback runtime
     /// click would exit 2 and boot validation would fail like RUST-4A.
     #[test]
-    #[serial_test::serial(backend_port)]
+    #[serial_test::serial]
     fn entrypoint_args_gate_no_ccr_on_runtime_version() {
         backend_port::reset_for_tests();
 
@@ -11408,7 +11408,7 @@ S(('127.0.0.1', int(sys.argv[1])), H).serve_forever()
     /// the proxy raise on startup and exit before opening the port. Must gate on
     /// runtime >= 0.30.0; unknown versions assume the pinned (current) runtime.
     #[test]
-    #[serial_test::serial(backend_port)]
+    #[serial_test::serial]
     fn savings_profile_gated_on_runtime_version() {
         assert_eq!(savings_profile_for_runtime(Some("0.28.0")), "agent-90");
         assert_eq!(savings_profile_for_runtime(Some("0.29.9")), "agent-90");
@@ -11426,7 +11426,7 @@ S(('127.0.0.1', int(sys.argv[1])), H).serve_forever()
     /// old provider. Unlike the savings persona, an unreadable version fails
     /// CLOSED: the flag is an opt-in, and off is always the safe answer.
     #[test]
-    #[serial_test::serial(backend_port)]
+    #[serial_test::serial]
     fn cc_switch_reconcile_gated_on_runtime_version() {
         assert_eq!(cc_switch_reconcile_for_runtime(Some("0.35.0")), "0");
         assert_eq!(cc_switch_reconcile_for_runtime(Some("0.36.2")), "0");
@@ -11451,7 +11451,7 @@ S(('127.0.0.1', int(sys.argv[1])), H).serve_forever()
     /// the helpers are invoked AFTER fallback has updated the atomic, the
     /// chosen fallback port flows through.
     #[test]
-    #[serial_test::serial(backend_port)]
+    #[serial_test::serial]
     fn startup_args_reflect_fallback_port_set_after_default() {
         backend_port::reset_for_tests();
         backend_port::set(6770);

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -6442,7 +6442,7 @@ impl PluginHost {
     }
 }
 
-fn claude_installed_plugins() -> Option<Value> {
+pub(crate) fn claude_installed_plugins() -> Option<Value> {
     let path = dirs::home_dir()?
         .join(".claude")
         .join("plugins")

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -1621,7 +1621,16 @@ fn classify_kompress_prefetch_failure(tail: &str) -> &'static str {
     // (notably Server 2022) does not ship. Nothing retriable and nothing the
     // app can repair, but it must not sit in the "other" grab-bag: that bucket
     // is what made RUST-3C/RUST-45 unresolvable.
-    } else if t.contains("winerror 126") || t.contains("importerror: dll load failed") {
+    //
+    // 126 is "the DLL is absent", 1114 is "it is there and its init routine
+    // failed" (RUST-75, c10.dll) -- different Windows errnos, same broken
+    // native stack, same non-answer for us, so one bucket. Match the number,
+    // not the sentence after it: Windows localizes that text, and 1114 landed
+    // in the grab-bag as Korean.
+    } else if t.contains("winerror 126")
+        || t.contains("winerror 1114")
+        || t.contains("importerror: dll load failed")
+    {
         "missing native dep"
     } else {
         "other"
@@ -3487,6 +3496,40 @@ impl ToolManager {
         )
     }
 
+    /// Run a directory operation that Windows can transiently deny.
+    ///
+    /// `DeleteFile`/`RemoveDirectory` only MARK a name for deletion: it stays
+    /// on disk until the last handle closes, and a rename onto it meanwhile
+    /// returns ACCESS_DENIED. Defender opens every file we just unpacked for
+    /// the same second or two. RUST-8K is that race hitting `rename` on a
+    /// fresh 0.8.6 install (os error 5, localized so the text is not even
+    /// greppable) -- and it dead-ends the bootstrap, so the user never gets a
+    /// runtime at all.
+    ///
+    /// Retries every error, not a classified subset: on a genuinely broken
+    /// install this costs ~2.5s on a path that already failed, and the alt is
+    /// a per-platform errno table (5/32/33 mean something else entirely on
+    /// Unix) guarding a branch no test on a Mac can reach.
+    /// ponytail: linear backoff, no jitter -- one process, no contention.
+    fn retry_fs<T>(what: &str, mut op: impl FnMut() -> std::io::Result<T>) -> std::io::Result<T> {
+        const ATTEMPTS: u32 = 5;
+        let mut attempt = 1;
+        loop {
+            match op() {
+                Ok(value) => return Ok(value),
+                Err(err) if attempt < ATTEMPTS => {
+                    // info, not warn: a retry that then succeeds is a
+                    // non-event, and warn bridges to Sentry. The caller
+                    // reports the final failure as bootstrap_failed.
+                    log::info!("{what} failed ({err}), retry {attempt}/{ATTEMPTS}");
+                    std::thread::sleep(std::time::Duration::from_millis(250 * u64::from(attempt)));
+                    attempt += 1;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+    }
+
     fn install_python_distribution<F>(&self, mut emit_step: F) -> Result<()>
     where
         F: FnMut(BootstrapStepUpdate),
@@ -3552,8 +3595,10 @@ impl ToolManager {
         // deletion.
         let staging_dir = self.runtime.runtime_dir.join("python.extracting");
         if staging_dir.exists() {
-            std::fs::remove_dir_all(&staging_dir)
-                .with_context(|| format!("clearing stale {}", staging_dir.display()))?;
+            Self::retry_fs("clearing stale staging dir", || {
+                std::fs::remove_dir_all(&staging_dir)
+            })
+            .with_context(|| format!("clearing stale {}", staging_dir.display()))?;
         }
         std::fs::create_dir_all(&staging_dir)
             .with_context(|| format!("creating {}", staging_dir.display()))?;
@@ -3576,11 +3621,15 @@ impl ToolManager {
             );
         }
         if self.runtime.python_dir.exists() {
-            std::fs::remove_dir_all(&self.runtime.python_dir).with_context(|| {
-                format!("removing partial {}", self.runtime.python_dir.display())
-            })?;
+            Self::retry_fs("removing partial python dir", || {
+                std::fs::remove_dir_all(&self.runtime.python_dir)
+            })
+            .with_context(|| format!("removing partial {}", self.runtime.python_dir.display()))?;
         }
-        std::fs::rename(&extracted_root, &self.runtime.python_dir).with_context(|| {
+        Self::retry_fs("publishing extracted python", || {
+            std::fs::rename(&extracted_root, &self.runtime.python_dir)
+        })
+        .with_context(|| {
             format!(
                 "publishing extracted python into {}",
                 self.runtime.python_dir.display()
@@ -8921,6 +8970,14 @@ pub(crate) fn pip_failure_category(compact: &str) -> &'static str {
         || lower.contains("check the permissions")
         || lower.contains("access is denied")
         || lower.contains("errno 13")
+        // Windows LOCALIZES its error text: RUST-8K arrived as
+        // "액세스가 거부되었습니다. (os error 5)" and fell through to the
+        // grab-bag this function exists to prevent. The numeric code is the
+        // one locale-independent handle. Not gated to Windows: errno 5 is EIO
+        // on Unix, but a mislabelled bucket on an all-but-unseen pip EIO is a
+        // cheaper bug than a Windows-only branch no test here can reach. Keep
+        // the closing paren -- os error 50/51 are macOS network errors.
+        || lower.contains("(os error 5)")
     {
         "permission"
     } else if lower.contains("no such file or directory") || lower.contains("errno 2") {
@@ -9364,6 +9421,7 @@ impl std::error::Error for HeadroomStartupFailure {}
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
     use std::fs;
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
@@ -9927,6 +9985,14 @@ asyncio.run(verify())
             classify_kompress_prefetch_failure(
                 "OSError: [WinError 126] The specified module could not be found. \
                  Error loading \"...\\torch\\lib\\c10.dll\" or one of its dependencies"
+            ),
+            "missing native dep"
+        );
+        // RUST-75, verbatim from the event: only the errno survives the locale.
+        assert_eq!(
+            classify_kompress_prefetch_failure(
+                "OSError: [WinError 1114] DLL 초기화 루틴을 실행할 수 없습니다. \
+                 Error loading \"...\\torch\\lib\\c10.dll\" or one of its dependencies."
             ),
             "missing native dep"
         );
@@ -13604,6 +13670,19 @@ exit 0
                 "network",
             ),
             ("exit=1; stderr tail: something new", "other"),
+            // RUST-8K, verbatim: Windows access-denied on a Korean install.
+            // Only the numeric code survives translation.
+            (
+                "publishing extracted python into ~\\AppData\\Local\\Headroom: \
+                 액세스가 거부되었습니다. (os error 5)",
+                "permission",
+            ),
+            // The macOS network errnos must not read as a denial: the
+            // closing paren in the needle is what keeps 51 out of "permission".
+            (
+                "exit=1; stderr tail: error sending request (os error 51)",
+                "other",
+            ),
         ];
         for (compact, expected) in cases {
             assert_eq!(pip_failure_category(compact), expected, "for: {compact}");
@@ -13655,5 +13734,43 @@ exit 0
             seen.len() >= 5,
             "the five RUST-6K shapes must land in distinct buckets, got: {seen:?}"
         );
+    }
+
+    #[test]
+    fn retry_fs_survives_a_transient_denial() {
+        // RUST-8K: Windows kept the old python dir alive after remove_dir_all
+        // and denied the rename onto it. The op succeeds once the handle
+        // closes, so the bootstrap must not dead-end on the first refusal.
+        let attempts = Cell::new(0u32);
+        let result = ToolManager::retry_fs("unit", || {
+            attempts.set(attempts.get() + 1);
+            if attempts.get() < 3 {
+                Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied))
+            } else {
+                Ok(attempts.get())
+            }
+        });
+        assert_eq!(result.expect("third attempt succeeds"), 3);
+        assert_eq!(
+            attempts.get(),
+            3,
+            "must retry, not give up on the first Err"
+        );
+    }
+
+    #[test]
+    fn retry_fs_gives_up_and_returns_the_last_error() {
+        // The bound matters as much as the retry: an unbounded loop would hang
+        // the bootstrap on a genuinely broken install instead of reporting it.
+        let attempts = Cell::new(0u32);
+        let result = ToolManager::retry_fs("unit", || {
+            attempts.set(attempts.get() + 1);
+            Err::<(), _>(std::io::Error::from(std::io::ErrorKind::PermissionDenied))
+        });
+        assert_eq!(
+            result.expect_err("exhausted").kind(),
+            std::io::ErrorKind::PermissionDenied
+        );
+        assert_eq!(attempts.get(), 5, "bounded at ATTEMPTS");
     }
 }

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -1941,7 +1941,19 @@ impl ToolManager {
     }
 
     pub fn python_runtime_installed(&self) -> bool {
-        self.runtime.ready_flag().exists() && self.runtime.managed_python().exists()
+        // The base interpreter counts too, not just the venv. A venv's
+        // `Scripts/python.exe` is a redirector stub that execs the interpreter
+        // recorded in `pyvenv.cfg`; deleting `runtime/python` (AV quarantine,
+        // disk cleanup) leaves the stub and the READY flag on disk, so a
+        // venv-only gate reads "installed" while every spawn dies with exit 103
+        // / `No Python at '...'` (RUST-8E). That matters because this gate is
+        // what routes a missing runtime back to setup, and bootstrap already
+        // re-downloads the distribution and rebuilds the venv from it -- the
+        // only thing standing between the user and a self-repair was this
+        // check. Same blind spot as RUST-66/6M one level down.
+        self.runtime.ready_flag().exists()
+            && self.runtime.managed_python().exists()
+            && self.runtime.standalone_python().exists()
     }
 
     pub fn logs_dir(&self) -> PathBuf {
@@ -11702,6 +11714,31 @@ after
         .expect("receipt");
         let manager = ToolManager::new(runtime.clone());
         (root, runtime, manager)
+    }
+
+    /// RUST-8E: a venv orphaned from its base interpreter keeps its redirector
+    /// stub and READY flag, so the venv-only gate reported "installed" and the
+    /// launch dead-ended in a Sentry start failure (exit 103, `No Python at`)
+    /// instead of routing to setup, which re-downloads the runtime.
+    #[test]
+    fn python_runtime_installed_requires_the_standalone_base() {
+        let (_root, runtime, manager) = seed_test_runtime("orphaned-venv-base");
+        for marker in [runtime.ready_flag(), runtime.managed_python()] {
+            fs::create_dir_all(marker.parent().expect("parent")).expect("mkdir");
+            fs::write(&marker, b"").expect("marker");
+        }
+        assert!(
+            !manager.python_runtime_installed(),
+            "a venv whose standalone base is gone must not read as installed"
+        );
+
+        let base = runtime.standalone_python();
+        fs::create_dir_all(base.parent().expect("parent")).expect("mkdir");
+        fs::write(&base, b"").expect("base");
+        assert!(
+            manager.python_runtime_installed(),
+            "all three markers present must read as installed"
+        );
     }
 
     /// RUST-82: `python -m venv` runs ensurepip through `check_output` and

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -6443,7 +6443,11 @@ impl PluginHost {
 }
 
 pub(crate) fn claude_installed_plugins() -> Option<Value> {
-    let path = dirs::home_dir()?
+    // Not `dirs::home_dir()`: on Windows that reads the profile known folder
+    // and ignores `$HOME`, so a redirected home (tests, Git Bash) resolves
+    // against the REAL profile. Every OSS-plugin test failed on Windows CI
+    // that way -- reading the runner's own ~/.claude and finding no plugin.
+    let path = crate::client_adapters::home_dir()
         .join(".claude")
         .join("plugins")
         .join("installed_plugins.json");
@@ -12938,9 +12942,7 @@ after
 
     impl HomeGuard {
         fn new(root: &Path) -> Self {
-            let env_lock = crate::test_env_lock::HOME_ENV_LOCK
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let env_lock = crate::test_env_lock::lock_home();
             let prev_home = std::env::var_os("HOME");
             let prev_codex = std::env::var_os("CODEX_HOME");
             std::env::set_var("HOME", root);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.8.7-rc.2",
+  "version": "0.8.7-rc.3",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.8.7-rc.5",
+  "version": "0.8.7-rc.6",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.8.7-rc.3",
+  "version": "0.8.7-rc.4",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.8.7-rc.6",
+  "version": "0.8.7-rc.7",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.8.7-rc.9",
+  "version": "0.8.7-rc.10",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.8.7-rc.7",
+  "version": "0.8.7-rc.8",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.8.6",
+  "version": "0.8.7-rc.1",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.8.7-rc.10",
+  "version": "0.8.7",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.8.7-rc.8",
+  "version": "0.8.7-rc.9",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.8.7-rc.4",
+  "version": "0.8.7-rc.5",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.8.7-rc.1",
+  "version": "0.8.7-rc.2",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1719,6 +1719,12 @@ export default function App() {
   const [pricingBusy, setPricingBusy] = useState(false);
   const [pricingError, setPricingError] = useState<string | null>(null);
   const pricingRefreshInFlightRef = useRef(false);
+  // When the last authoritative status (verify / sign-out) was applied. A slow
+  // pricing fetch issued before it must not land afterwards and overwrite it:
+  // on a fresh install the very first fetch is the slowest, and it was still in
+  // flight when the magic link signed the user in, so it clobbered the signed-in
+  // status with its own stale signed-out one.
+  const pricingStatusStampRef = useRef(0);
   const [authEmail, setAuthEmail] = useState("");
   const [authCode, setAuthCode] = useState("");
   const [authCodeRequestedFor, setAuthCodeRequestedFor] = useState<string | null>(null);
@@ -3240,7 +3246,15 @@ export default function App() {
   // poll tick.
   useEffect(() => {
     let unlisten: (() => void) | undefined;
-    void listen("pricing-refreshed", () => {
+    void listen<HeadroomPricingStatus | null>("pricing-refreshed", (event) => {
+      // Auth mutations ship the new status with the event. Using it beats a
+      // refetch that the in-flight guard may drop outright, leaving this window
+      // stale until the next poll tick (60s focused, 600s not).
+      if (event.payload) {
+        pricingStatusStampRef.current = Date.now();
+        setPricingStatus(event.payload);
+        return;
+      }
       void refreshPricingStatus();
     }).then((fn) => {
       unlisten = fn;
@@ -3777,8 +3791,12 @@ export default function App() {
     }
     pricingRefreshInFlightRef.current = true;
     setPricingBusy(true);
+    const issuedAt = Date.now();
     try {
       const status = await invoke<HeadroomPricingStatus>("get_headroom_pricing_status");
+      if (pricingStatusStampRef.current > issuedAt) {
+        return;
+      }
       setPricingStatus(status);
       // The code step is local UI state, so a sign-in that happened elsewhere
       // (the magic link, or the other window) leaves this one still asking for
@@ -4105,6 +4123,7 @@ export default function App() {
         code,
         inviteCode: null
       });
+      pricingStatusStampRef.current = Date.now();
       setPricingStatus(status);
       setAuthCode("");
       setAuthCodeRequestedFor(null);
@@ -4156,7 +4175,9 @@ export default function App() {
       if (cancelled) {
         return;
       }
-      setMagicLinkState(verified ? "signed_in" : "failed");
+      // Success needs no screen: clearing this drops the user straight onto the
+      // next onboarding step, already signed in.
+      setMagicLinkState(verified ? null : "failed");
     }
     void claimMagicLink();
     const unlistenPromise = listen("magic-link-auth", () => {
@@ -4173,7 +4194,9 @@ export default function App() {
     setAuthFlowSuccess(null);
     try {
       await invoke("sign_out_headroom_account");
-      setPricingStatus(await invoke<HeadroomPricingStatus>("get_headroom_pricing_status"));
+      const status = await invoke<HeadroomPricingStatus>("get_headroom_pricing_status");
+      pricingStatusStampRef.current = Date.now();
+      setPricingStatus(status);
       setAuthCode("");
       setAuthCodeRequestedFor(null);
       setAuthFlowSuccess("Signed out of Headroom.");
@@ -4672,6 +4695,39 @@ export default function App() {
     return null;
   }
 
+  // Ahead of the terms gate: redemption is already under way by the time that
+  // gate renders, and its sign-in form has no busy state of its own, so the
+  // wait read as nothing happening at all.
+  if (windowLabel === "launcher" && magicLinkState !== null) {
+    const magicLinkCopy = magicLinkScreenCopy(
+      magicLinkState,
+      pricingStatus?.account?.email ?? authEmail,
+      authFlowError
+    );
+    return (
+      <LauncherShell
+        shellClassName="intro-shell intro-shell--post-install"
+        spinnerClassName="intro-shell__spinner intro-shell__spinner--post-install"
+        copyClassName="intro-shell__copy intro-shell__copy--post-install"
+        onMouseDown={handleLauncherSurfaceMouseDown}
+        version={appSemver}
+        showSpinner={magicLinkState === "verifying"}
+      >
+        <h1>{magicLinkCopy.title}</h1>
+        <p className="launcher-install-notice">{magicLinkCopy.body}</p>
+        {magicLinkState === "verifying" ? null : (
+          <button
+            className="primary-button primary-button--large primary-button--success"
+            onClick={() => setMagicLinkState(null)}
+            type="button"
+          >
+            Continue
+          </button>
+        )}
+      </LauncherShell>
+    );
+  }
+
   // Block every window (launcher and main) until the user accepts the current
   // Terms of Service. New installs hit this in the launcher; updating users —
   // who may never see the launcher — hit it in the main window. Bumping the
@@ -4977,36 +5033,6 @@ export default function App() {
             </div>
           </>
         ) : null}
-      </LauncherShell>
-    );
-  }
-
-  if (windowLabel === "launcher" && magicLinkState !== null) {
-    const magicLinkCopy = magicLinkScreenCopy(
-      magicLinkState,
-      pricingStatus?.account?.email ?? authEmail,
-      authFlowError
-    );
-    return (
-      <LauncherShell
-        shellClassName="intro-shell intro-shell--post-install"
-        spinnerClassName="intro-shell__spinner intro-shell__spinner--post-install"
-        copyClassName="intro-shell__copy intro-shell__copy--post-install"
-        onMouseDown={handleLauncherSurfaceMouseDown}
-        version={appSemver}
-        showSpinner={magicLinkState === "verifying"}
-      >
-        <h1>{magicLinkCopy.title}</h1>
-        <p className="launcher-install-notice">{magicLinkCopy.body}</p>
-        {magicLinkState === "verifying" ? null : (
-          <button
-            className="primary-button primary-button--large primary-button--success"
-            onClick={() => setMagicLinkState(null)}
-            type="button"
-          >
-            Continue
-          </button>
-        )}
       </LauncherShell>
     );
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,6 +92,7 @@ import {
   recentDailySavingsUsd,
   setServerPlanPrices,
   tierRecommendationSourceLabel,
+  scheduledPlanChange,
   upgradePlanIntentLabel,
   type BillingPeriod,
   type PricingAudience,
@@ -113,6 +114,7 @@ import {
   buildMonthlySavingsChartData,
   buildMonthlySavingsWindow,
   compressibleInputSavingsRate,
+  allTimeCacheHitPair,
   cacheHitPair,
   outputReductionForWindow,
   compactNumber,
@@ -3728,7 +3730,7 @@ export default function App() {
       applyConnectorsIfChanged(items);
     } catch (error) {
       setConnectorsError(
-        error instanceof Error ? error.message : "Could not load connector status."
+        describeInvokeError(error, "Could not load connector status.")
       );
     }
   }
@@ -3740,7 +3742,7 @@ export default function App() {
       void maybeFireUrgentRuntimeNotification(runtime);
     } catch (error) {
       setConnectorsError(
-        error instanceof Error ? error.message : "Could not load runtime status."
+        describeInvokeError(error, "Could not load runtime status.")
       );
     }
   }
@@ -3756,7 +3758,7 @@ export default function App() {
       await refreshRuntimeStatus();
     } catch (error) {
       setResumeError(
-        error instanceof Error ? error.message : "Could not restart Headroom."
+        describeInvokeError(error, "Could not restart Headroom.")
       );
     } finally {
       setResuming(false);
@@ -3777,7 +3779,7 @@ export default function App() {
       setPricingError(null);
     } catch (error) {
       setPricingError(
-        error instanceof Error ? error.message : "Could not load pricing status."
+        describeInvokeError(error, "Could not load pricing status.")
       );
     } finally {
       pricingRefreshInFlightRef.current = false;
@@ -3793,7 +3795,7 @@ export default function App() {
       applyClaudeProjectsIfChanged(projects);
     } catch (error) {
       setClaudeProjectsError(
-        error instanceof Error ? error.message : "Could not load Claude Code projects."
+        describeInvokeError(error, "Could not load Claude Code projects.")
       );
     } finally {
       setClaudeProjectsBusy(false);
@@ -3866,7 +3868,7 @@ export default function App() {
       await beginProxyVerificationStep();
     } catch (error) {
       setConnectorsError(
-        error instanceof Error ? error.message : "Could not configure your coding tools automatically."
+        describeInvokeError(error, "Could not configure your coding tools automatically.")
       );
       setLauncherStage("client_setup");
     } finally {
@@ -3945,7 +3947,7 @@ export default function App() {
         ...current,
         running: false,
         summary: "headroom learn could not be started.",
-        error: error instanceof Error ? error.message : "Failed to start headroom learn."
+        error: describeInvokeError(error, "Failed to start headroom learn.")
       }));
     } finally {
       setHeadroomLearnBusy(false);
@@ -4023,7 +4025,7 @@ export default function App() {
       }
     } catch (error) {
       setAddonError(
-        error instanceof Error ? error.message : "The addon action could not be completed."
+        describeInvokeError(error, "The addon action could not be completed.")
       );
     } finally {
       setAddonBusyId(null);
@@ -4151,7 +4153,7 @@ export default function App() {
       setPendingUpgradePlanId(null);
     } catch (error) {
       setAuthFlowError(
-        error instanceof Error ? error.message : "Could not sign out of Headroom."
+        describeInvokeError(error, "Could not sign out of Headroom.")
       );
     }
   }
@@ -4161,7 +4163,7 @@ export default function App() {
       await openExternalLink(CLAUDE_CODE_INSTALL_DOCS_URL);
     } catch (error) {
       setLearnInstallCopyNotice(
-        error instanceof Error ? error.message : "Could not open the install guide."
+        describeInvokeError(error, "Could not open the install guide.")
       );
       window.setTimeout(() => setLearnInstallCopyNotice(null), 3000);
     }
@@ -4265,7 +4267,7 @@ export default function App() {
         setCheckoutPollingDeadline(Date.now() + 5 * 60_000);
       } catch (error) {
         setUpgradeActionError(
-          error instanceof Error ? error.message : typeof error === "string" ? error : "Could not start checkout."
+          describeInvokeError(error, "Could not start checkout.")
         );
       } finally {
         setUpgradeActionBusy(null);
@@ -4283,7 +4285,7 @@ export default function App() {
         await openBillingPortal();
       } catch (error) {
         setUpgradeActionError(
-          error instanceof Error ? error.message : typeof error === "string" ? error : "Could not open billing portal."
+          describeInvokeError(error, "Could not open billing portal.")
         );
       } finally {
         setUpgradeActionBusy(null);
@@ -4303,7 +4305,7 @@ export default function App() {
       await openExternalLink(action.url);
     } catch (error) {
       setUpgradeActionError(
-        error instanceof Error ? error.message : "Could not open the selected plan link."
+        describeInvokeError(error, "Could not open the selected plan link.")
       );
     } finally {
       setUpgradeActionBusy(null);
@@ -4380,7 +4382,7 @@ export default function App() {
       await openBillingPortal();
     } catch (error) {
       setUpgradeActionError(
-        error instanceof Error ? error.message : typeof error === "string" ? error : "Could not open billing portal."
+        describeInvokeError(error, "Could not open billing portal.")
       );
     } finally {
       setUpgradeActionBusy(null);
@@ -4416,7 +4418,7 @@ export default function App() {
       await openBillingPortal();
     } catch (error) {
       setUpgradeActionError(
-        error instanceof Error ? error.message : typeof error === "string" ? error : "Could not open billing portal."
+        describeInvokeError(error, "Could not open billing portal.")
       );
     } finally {
       setUpgradeActionBusy(null);
@@ -4470,7 +4472,7 @@ export default function App() {
       setContactSubmitSuccess("Thanks. Check your inbox for a confirmation email.");
     } catch (error) {
       setContactSubmitError(
-        error instanceof Error ? error.message : "Could not submit the contact request."
+        describeInvokeError(error, "Could not submit the contact request.")
       );
     } finally {
       setContactSubmitBusy(false);
@@ -4515,7 +4517,7 @@ export default function App() {
       await refreshConnectors();
     } catch (error) {
       setConnectorsError(
-        error instanceof Error ? error.message : "Failed to update connector."
+        describeInvokeError(error, "Failed to update connector.")
       );
     } finally {
       setConnectorsBusy(false);
@@ -4588,17 +4590,10 @@ export default function App() {
   // feeds it the lifetime breakdown as a single synthetic bucket;
   // cacheReadTokens is used only as an existence signal for coverage, never
   // ratioed against our own token counts.
-  const cachePairAllTime = (() => {
-    const b = dashboard.savingsBreakdown;
-    if (!b || b.cacheReadTokens <= 0) return null;
-    return cacheHitPair([
-      {
-        cacheSavingsUsd: b.cacheSavingsUsd,
-        actualCostUsd: b.totalInputCostUsd,
-        estimatedSavingsUsd: dashboard.lifetimeEstimatedSavingsUsd
-      }
-    ]);
-  })();
+  const cachePairAllTime = allTimeCacheHitPair(
+    dashboard.savingsBreakdown,
+    dashboard.lifetimeEstimatedSavingsUsd
+  );
   const compressionOfRestPct = cachePairAllTime?.compressedPct ?? null;
   // Same pair for the shorter windows, from the buckets that carry cache
   // coverage (backend history checkpoints; local-tracker buckets and days
@@ -5985,23 +5980,7 @@ export default function App() {
   // A downgrade waits for the end of the term already paid for, so between
   // confirming it and it landing the subscription still reports the old plan.
   // Without this the change leaves no trace anywhere in the app.
-  const pendingPlanChangeInfo = (() => {
-    const account = pricingStatus?.account;
-    const tier = account?.subscriptionPendingTier;
-    const effectiveAt = account?.subscriptionPendingEffectiveAt;
-    if (!tier || !effectiveAt) return null;
-    const period = account?.subscriptionPendingBillingPeriod === "monthly" ? "monthly" : "annual";
-    const on = new Date(effectiveAt).toLocaleDateString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric"
-    });
-    // Same tier on a shorter cycle is a billing switch, not a plan change.
-    const note = tier === account?.subscriptionTier
-      ? `Switches to ${period} billing on ${on}`
-      : `Switches to ${upgradePlanIntentLabel(tier)} (${period}) on ${on}`;
-    return { tier, billingPeriod: period, note };
-  })();
+  const pendingPlanChangeInfo = scheduledPlanChange(pricingStatus?.account);
   // The card beside the active plan: the nearest step up, since that is what
   // this view is for. Only the top tier has none, and there the tier below it
   // is the sole remaining move.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4077,13 +4077,17 @@ export default function App() {
       setAuthFlowError("Enter the authentication code from your email.");
       return;
     }
+    await verifyAuthCode(authEmail.trim(), authCode.trim());
+  }
+
+  async function verifyAuthCode(email: string, code: string) {
     setAuthVerifyBusy(true);
     setAuthFlowError(null);
     setAuthFlowSuccess(null);
     try {
       const status = await invoke<HeadroomPricingStatus>("verify_headroom_auth_code", {
-        email: authEmail.trim(),
-        code: authCode.trim(),
+        email,
+        code,
         inviteCode: null
       });
       setPricingStatus(status);
@@ -4104,6 +4108,36 @@ export default function App() {
       setAuthVerifyBusy(false);
     }
   }
+
+  // Magic sign-in link (headroom://auth). The browser deliberately cannot sign
+  // anyone in -- it has none of the device fingerprints verify_code needs -- so
+  // it only hands over the code and this is the ordinary typed-code flow with
+  // the typing removed.
+  //
+  // Drained on mount as well as on the event: a cold start launched *by* the
+  // link delivers the URL before this listener exists, so an event alone would
+  // be lost exactly when the link was the thing that opened the app. Rust hands
+  // the slot out once, so both windows can race for it harmlessly.
+  useEffect(() => {
+    let cancelled = false;
+    async function claimMagicLink() {
+      const pending = await invoke<[string, string] | null>("take_pending_magic_link");
+      if (cancelled || !pending) {
+        return;
+      }
+      const [email, code] = pending;
+      setAuthEmail(email);
+      await verifyAuthCode(email, code);
+    }
+    void claimMagicLink();
+    const unlistenPromise = listen("magic-link-auth", () => {
+      void claimMagicLink();
+    });
+    return () => {
+      cancelled = true;
+      void unlistenPromise.then((unlisten) => unlisten());
+    };
+  }, []);
 
   async function handleSignOutHeadroomAccount() {
     setAuthFlowError(null);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -148,6 +148,7 @@ import {
   getClaudeConnector,
   getContactRequestValidationError,
   getInitialLauncherStage,
+  magicLinkScreenCopy,
   getLauncherAutoConfigureDecision,
   isValidEmailAddress,
   needsTermsAcceptance,
@@ -155,6 +156,7 @@ import {
   nextAutoConfigureStepAfterApply,
   recommendedHeadroomTier,
   type LauncherStage,
+  type MagicLinkState,
   type InstallWizardStep
 } from "./lib/launcherHelpers";
 import { mockDashboard } from "./lib/mockData";
@@ -1607,6 +1609,10 @@ export default function App() {
   // through `setLauncherStage` so implicit renders from bootstrap/dashboard
   // flags cannot bypass the install step's readiness gate.
   const [launcherStage, setLauncherStage] = useState<LauncherStage>("install");
+  // Set while a headroom://auth magic link is being redeemed. The launcher is
+  // already on screen by then (the deep-link handler shows it), so without this
+  // the sign-in ran invisibly behind whatever onboarding stage it landed on.
+  const [magicLinkState, setMagicLinkState] = useState<MagicLinkState | null>(null);
   // Paywall-first experiment flag, served from the Rust-side cache (never
   // blocks). Gated flow applies only to fresh installs: an installed runtime
   // means the user is grandfathered and sees zero difference.
@@ -4082,7 +4088,7 @@ export default function App() {
     await verifyAuthCode(authEmail.trim(), authCode.trim());
   }
 
-  async function verifyAuthCode(email: string, code: string) {
+  async function verifyAuthCode(email: string, code: string): Promise<boolean> {
     setAuthVerifyBusy(true);
     setAuthFlowError(null);
     setAuthFlowSuccess(null);
@@ -4104,8 +4110,10 @@ export default function App() {
         setActiveView("upgrade");
       }
       await refreshConnectors();
+      return true;
     } catch (error) {
       setAuthFlowError(describeInvokeError(error, "Could not verify sign-in code."));
+      return false;
     } finally {
       setAuthVerifyBusy(false);
     }
@@ -4120,7 +4128,14 @@ export default function App() {
   // link delivers the URL before this listener exists, so an event alone would
   // be lost exactly when the link was the thing that opened the app. Rust hands
   // the slot out once, so both windows can race for it harmlessly.
+  // Only the launcher claims it: both windows mount this component and the slot
+  // is one-shot, so the hidden main window could win the race and sign the user
+  // in where nobody could see it. The deep-link handler shows the launcher
+  // before parking the credentials, so it is the window on screen.
   useEffect(() => {
+    if (windowLabel !== "launcher") {
+      return;
+    }
     let cancelled = false;
     async function claimMagicLink() {
       const pending = await invoke<[string, string] | null>("take_pending_magic_link");
@@ -4129,7 +4144,12 @@ export default function App() {
       }
       const [email, code] = pending;
       setAuthEmail(email);
-      await verifyAuthCode(email, code);
+      setMagicLinkState("verifying");
+      const verified = await verifyAuthCode(email, code);
+      if (cancelled) {
+        return;
+      }
+      setMagicLinkState(verified ? "signed_in" : "failed");
     }
     void claimMagicLink();
     const unlistenPromise = listen("magic-link-auth", () => {
@@ -4139,7 +4159,7 @@ export default function App() {
       cancelled = true;
       void unlistenPromise.then((unlisten) => unlisten());
     };
-  }, []);
+  }, [windowLabel]);
 
   async function handleSignOutHeadroomAccount() {
     setAuthFlowError(null);
@@ -4950,6 +4970,36 @@ export default function App() {
             </div>
           </>
         ) : null}
+      </LauncherShell>
+    );
+  }
+
+  if (windowLabel === "launcher" && magicLinkState !== null) {
+    const magicLinkCopy = magicLinkScreenCopy(
+      magicLinkState,
+      pricingStatus?.account?.email ?? authEmail,
+      authFlowError
+    );
+    return (
+      <LauncherShell
+        shellClassName="intro-shell intro-shell--post-install"
+        spinnerClassName="intro-shell__spinner intro-shell__spinner--post-install"
+        copyClassName="intro-shell__copy intro-shell__copy--post-install"
+        onMouseDown={handleLauncherSurfaceMouseDown}
+        version={appSemver}
+        showSpinner={magicLinkState === "verifying"}
+      >
+        <h1>{magicLinkCopy.title}</h1>
+        <p className="launcher-install-notice">{magicLinkCopy.body}</p>
+        {magicLinkState === "verifying" ? null : (
+          <button
+            className="primary-button primary-button--large primary-button--success"
+            onClick={() => setMagicLinkState(null)}
+            type="button"
+          >
+            Continue
+          </button>
+        )}
       </LauncherShell>
     );
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3780,6 +3780,13 @@ export default function App() {
     try {
       const status = await invoke<HeadroomPricingStatus>("get_headroom_pricing_status");
       setPricingStatus(status);
+      // The code step is local UI state, so a sign-in that happened elsewhere
+      // (the magic link, or the other window) leaves this one still asking for
+      // a code nobody needs to enter. Every refresh path lands here.
+      if (status.authenticated) {
+        setAuthCode("");
+        setAuthCodeRequestedFor(null);
+      }
       void maybeFireTrialNotifications(status);
       void maybeFireUrgentPricingNotifications(status);
       setPricingError(null);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -860,10 +860,15 @@ function WindowRateChip({
 
 function OutputReductionChip({
   reduction,
-  flip = false
+  flip = false,
+  allTimeFallback = false
 }: {
   reduction: OutputReduction;
   flip?: boolean;
+  /** Rendered because the visible window has no samples of its own, so this
+   * is the lifetime figure standing in. Says so, rather than letting an
+   * all-time number read as that period's. */
+  allTimeFallback?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -909,7 +914,9 @@ function OutputReductionChip({
           onClick={(e) => e.stopPropagation()}
         >
           <div className="output-chip__pop-head">
-            <span className="output-chip__pop-title">Output token reduction</span>
+            <span className="output-chip__pop-title">
+              Output token reduction{allTimeFallback ? " · all-time" : ""}
+            </span>
             <span className="output-chip__pop-badge">{isMeasured ? "measured" : "estimated"}</span>
           </div>
           <div className="output-chip__pop-value">{percent1(reduction.reductionPercent)}%</div>
@@ -926,6 +933,7 @@ function OutputReductionChip({
             </div>
           </dl>
           <p className="output-chip__pop-note">
+            {allTimeFallback ? "No output samples landed in this window, so this is the all-time figure, not this period's. " : ""}
             {isMeasured
               ? "Output tokens the model didn't emit because the shaper steered verbosity / routed effort down — measured against an unshaped A/B holdout."
               : "Output tokens the model didn't emit because the shaper steered verbosity / routed effort down. Output savings are counterfactual, so this is an estimate vs a learned baseline."}
@@ -983,17 +991,16 @@ function DailySavingsChart({
   const compressibleRate = compressibleInputSavingsRate(
     view === "month" ? monthlyWindow : hourlyWindow
   );
-  // Window-scoped output reduction from the locally-sampled series. Falls
-  // back to the all-time estimator chip only when the window includes now —
-  // a historical window with no samples shows no output figure rather than
-  // an all-time number masquerading as that period's.
+  // Window-scoped output reduction from the locally-sampled series, falling
+  // back to the all-time figure for any window without samples of its own.
+  // The fallback labels itself all-time (see OutputReductionChip) so it can't
+  // read as that period's number — but it does render: since the estimator
+  // only scores strata its baseline actually observed, a window of purely
+  // unscored traffic has no samples at all, and showing nothing there reads
+  // as "the shaper did nothing" rather than "this window can't be measured".
   const windowOutput = outputReductionForWindow(
     view === "month" ? monthlyWindow : hourlyWindow
   );
-  const windowIncludesToday =
-    view === "month"
-      ? visibleMonth.getTime() === currentMonth.getTime()
-      : visibleDay.getTime() === today.getTime();
   const canViewPreviousMonth = firstSavingsMonth ? visibleMonth > firstSavingsMonth : false;
   const canViewNextMonth = visibleMonth < currentMonth;
   const canViewPreviousDay = firstHourlyDay ? visibleDay > firstHourlyDay : false;
@@ -1102,9 +1109,7 @@ function DailySavingsChart({
             <span className="savings-chart__overlay-label">
               {view === "day" ? "saved today" : "saved this month"}
             </span>
-            {compressibleRate !== null ||
-            windowOutput !== null ||
-            (windowIncludesToday && outputReduction) ? (
+            {compressibleRate !== null || windowOutput !== null || outputReduction ? (
               <span className="savings-chart__overlay-chips">
                 {compressibleRate !== null && (
                   <WindowRateChip
@@ -1140,8 +1145,8 @@ function DailySavingsChart({
                     ]}
                     note="Estimate vs the shaper's learned baseline, sampled while the app runs."
                   />
-                ) : windowIncludesToday && outputReduction ? (
-                  <OutputReductionChip flip reduction={outputReduction} />
+                ) : outputReduction ? (
+                  <OutputReductionChip allTimeFallback flip reduction={outputReduction} />
                 ) : null}
               </span>
             ) : null}

--- a/src/components/ActivityFeed.test.tsx
+++ b/src/components/ActivityFeed.test.tsx
@@ -1,3 +1,5 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -343,6 +345,49 @@ describe("ActivityFeed", () => {
       />
     );
     expect(markup).toContain("activity-feed__item--clickable");
+  });
+
+  // Both diff branches live behind the expand click, so these two drive the
+  // real DOM rather than renderToStaticMarkup.
+  it("labels the diff with the token pair when both counts are known", async () => {
+    render(
+      <ActivityFeed
+        feed={feedWith({
+          transformation: transformation({
+            inputTokensOriginal: 1000,
+            inputTokensOptimized: 250,
+            requestMessages: [{ role: "user", content: "before" }],
+            compressedMessages: [{ role: "user", content: "after" }]
+          })
+        })}
+        error={null}
+      />
+    );
+    await userEvent.click(screen.getByRole("button", { name: /Recent large compression/ }));
+    expect(screen.getByText(/Compression diff \(1,000 → 250 tokens\)/)).toBeInTheDocument();
+  });
+
+  it("dumps both sides when the pair is too large to diff", async () => {
+    // Past MAX_DIFF_CELLS the LCS table would be gigabytes, so diffLines
+    // returns null and the detail view must still show the user something.
+    // 6000 x 6000 lines is ~36M cells, just over the cap.
+    const lines = (tag: string) =>
+      Array.from({ length: 6000 }, (_, i) => `${tag} ${i}`).join("\n");
+    render(
+      <ActivityFeed
+        feed={feedWith({
+          transformation: transformation({
+            requestMessages: [{ role: "user", content: lines("orig") }],
+            compressedMessages: [{ role: "user", content: lines("comp") }]
+          })
+        })}
+        error={null}
+      />
+    );
+    await userEvent.click(screen.getByRole("button", { name: /Recent large compression/ }));
+    expect(screen.getByText("Request (original)")).toBeInTheDocument();
+    expect(screen.getByText("Request (compressed)")).toBeInTheDocument();
+    expect(screen.queryByText(/Compression diff/)).not.toBeInTheDocument();
   });
 
   it("falls back to the raw transform string when unknown", () => {
@@ -937,6 +982,25 @@ describe("formatRequestMessages", () => {
     expect(formatRequestMessages([{ content: "orphan content" }])).toBe(
       "(unknown):\norphan content"
     );
+  });
+
+  it("survives block shapes the proxy log can hand it", () => {
+    // Everything here comes off the wire, so no shape is guaranteed. The rule
+    // is the same throughout: render what is legible, drop what is not, never
+    // throw -- a malformed block must not take the whole detail view down.
+    const cases: Array<[unknown, string]> = [
+      [null, ""], // content absent entirely
+      [42, ""], // neither string nor block list
+      [{ type: "text", text: "not in a list" }, ""], // a bare block, unwrapped
+      [[null, "raw string entry", { type: "text", text: "kept" }], "kept"],
+      [[{ tool_use_id: "x" }], ""], // no text, no content, no type
+      [[{ type: "tool_result", content: [] }], "[tool_result]"] // empty payload
+    ];
+    for (const [content, expected] of cases) {
+      expect(
+        formatRequestMessages([{ role: "user", content } as never])
+      ).toBe(`user:\n${expected}`);
+    }
   });
 });
 

--- a/src/components/OptimizePanel.test.tsx
+++ b/src/components/OptimizePanel.test.tsx
@@ -114,6 +114,20 @@ describe("OptimizePanel", () => {
     });
   });
 
+  it("says so when the first load fails instead of reading as an empty scan", async () => {
+    // Without this the pills stay disabled at "0 learnings" forever: the modal
+    // that holds the error cannot be opened, so an IPC failure is invisible.
+    invokeMock.mockRejectedValueOnce(new Error("list_applied_patterns: no such project"));
+
+    render(<OptimizePanel projectPath="/proj" />);
+
+    const pill = await screen.findByRole("button", { name: /could not load learnings/i });
+    expect(pill).toHaveAttribute("title", "list_applied_patterns: no such project");
+    expect(
+      screen.queryByRole("button", { name: /learnings in CLAUDE.local\.md/i })
+    ).not.toBeInTheDocument();
+  });
+
   it("surfaces a delete-pattern failure inside the open modal", async () => {
     invokeMock.mockRejectedValueOnce(new Error("write CLAUDE.local.md: permission denied"));
 

--- a/src/components/OptimizePanel.test.tsx
+++ b/src/components/OptimizePanel.test.tsx
@@ -114,18 +114,26 @@ describe("OptimizePanel", () => {
     });
   });
 
-  it("says so when the first load fails instead of reading as an empty scan", async () => {
+  it("offers a retry when the first load fails", async () => {
     // Without this the pills stay disabled at "0 learnings" forever: the modal
     // that holds the error cannot be opened, so an IPC failure is invisible.
-    invokeMock.mockRejectedValueOnce(new Error("list_applied_patterns: no such project"));
+    invokeMock
+      .mockRejectedValueOnce(new Error("list_applied_patterns: no such project"))
+      .mockResolvedValueOnce(samplePatterns);
 
     render(<OptimizePanel projectPath="/proj" />);
+    const user = userEvent.setup();
 
-    const pill = await screen.findByRole("button", { name: /could not load learnings/i });
+    const pill = await screen.findByRole("button", { name: /could not load learnings.*retry/i });
     expect(pill).toHaveAttribute("title", "list_applied_patterns: no such project");
+    expect(pill).toBeEnabled();
+
+    await user.click(pill);
+
     expect(
-      screen.queryByRole("button", { name: /learnings in CLAUDE.local\.md/i })
-    ).not.toBeInTheDocument();
+      await screen.findByRole("button", { name: /2 learnings in CLAUDE.local\.md/i })
+    ).toBeEnabled();
+    expect(invokeMock).toHaveBeenCalledTimes(2);
   });
 
   it("surfaces a delete-pattern failure inside the open modal", async () => {

--- a/src/components/OptimizePanel.tsx
+++ b/src/components/OptimizePanel.tsx
@@ -122,6 +122,25 @@ export function OptimizePanel({
     );
   }
 
+  // A failed first load leaves `applied` null, which disables both pills -- so
+  // the modal holding `loadError` can never be opened and the panel reads
+  // "0 learnings", indistinguishable from a clean empty scan. Say so instead.
+  // (A refetch failure after a good load still surfaces inside the modal.)
+  if (loadError && applied === null) {
+    return (
+      <span className="optimize-panel__pills">
+        <button
+          type="button"
+          className="optimize-panel__pill optimize-panel__pill--empty"
+          disabled
+          title={loadError}
+        >
+          could not load learnings
+        </button>
+      </span>
+    );
+  }
+
   return (
     <>
       <span className="optimize-panel__pills">

--- a/src/components/OptimizePanel.tsx
+++ b/src/components/OptimizePanel.tsx
@@ -124,7 +124,7 @@ export function OptimizePanel({
 
   // A failed first load leaves `applied` null, which disables both pills -- so
   // the modal holding `loadError` can never be opened and the panel reads
-  // "0 learnings", indistinguishable from a clean empty scan. Say so instead.
+  // "0 learnings", indistinguishable from a clean empty scan. Surface a retry.
   // (A refetch failure after a good load still surfaces inside the modal.)
   if (loadError && applied === null) {
     return (
@@ -132,10 +132,13 @@ export function OptimizePanel({
         <button
           type="button"
           className="optimize-panel__pill optimize-panel__pill--empty"
-          disabled
+          onClick={() => {
+            setLoadError(null);
+            refetch();
+          }}
           title={loadError}
         >
-          could not load learnings
+          could not load learnings — retry
         </button>
       </span>
     );

--- a/src/lib/appHelpers.test.ts
+++ b/src/lib/appHelpers.test.ts
@@ -12,11 +12,12 @@ import {
   introSaleBadgeLabel,
   isTierDowngrade,
   paybackLabel,
+  scheduledPlanChange,
   recentDailySavingsUsd,
   setServerPlanPrices,
   upgradePlanIntentLabel,
 } from "./appHelpers";
-import type { ClientConnectorStatus, RuntimeStatus } from "./types";
+import type { ClientConnectorStatus, HeadroomAccountProfile, RuntimeStatus } from "./types";
 import type { DailySavingsPoint, IntroOffer } from "./types";
 
 const daily = (usd: number): DailySavingsPoint => ({
@@ -73,6 +74,10 @@ describe("app helpers", () => {
     expect(describeInvokeError({ message: "typed message" }, "fallback")).toBe("typed message");
     expect(describeInvokeError({ error: "nested error" }, "fallback")).toBe("nested error");
     expect(describeInvokeError({ message: "   " }, "fallback")).toBe("fallback");
+    // 20 call sites in App.tsx lean on this, several on the billing path.
+    expect(describeInvokeError(new Error(""), "fallback")).toBe("fallback");
+    expect(describeInvokeError(null, "fallback")).toBe("fallback");
+    expect(describeInvokeError(undefined, "fallback")).toBe("fallback");
   });
 
   it("returns the next lower visible plan for paid subscriptions", () => {
@@ -702,5 +707,79 @@ describe("buildInstallFailureMailto", () => {
     );
     expect(decoded).toContain("unknown");
     expect(decoded).toContain("(none captured)");
+  });
+});
+
+describe("scheduledPlanChange", () => {
+  const account = (over: Partial<HeadroomAccountProfile> = {}): HeadroomAccountProfile => ({
+    email: "dev@example.com",
+    trialActive: false,
+    subscriptionActive: true,
+    subscriptionTier: "pro",
+    acceptedInvitesCount: 0,
+    inviteBonusPercent: 0,
+    ...over,
+  });
+
+  // TZ-independent: the runner's local rendering of the same instant.
+  const on = (iso: string) =>
+    new Date(iso).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+
+  it("calls a same-tier change a billing switch, not a plan change", () => {
+    const info = scheduledPlanChange(
+      account({
+        subscriptionTier: "pro",
+        subscriptionPendingTier: "pro",
+        subscriptionPendingBillingPeriod: "monthly",
+        subscriptionPendingEffectiveAt: "2026-09-01T12:00:00Z",
+      })
+    );
+    expect(info).toEqual({
+      tier: "pro",
+      billingPeriod: "monthly",
+      note: `Switches to monthly billing on ${on("2026-09-01T12:00:00Z")}`,
+    });
+  });
+
+  it("names the incoming plan when the tier actually changes", () => {
+    const info = scheduledPlanChange(
+      account({
+        subscriptionTier: "max20x",
+        subscriptionPendingTier: "max5x",
+        subscriptionPendingBillingPeriod: "annual",
+        subscriptionPendingEffectiveAt: "2026-09-01T12:00:00Z",
+      })
+    );
+    expect(info?.tier).toBe("max5x");
+    expect(info?.note).toBe(`Switches to Max x5 (annual) on ${on("2026-09-01T12:00:00Z")}`);
+  });
+
+  it("defaults an unknown billing period to annual", () => {
+    const info = scheduledPlanChange(
+      account({
+        subscriptionPendingTier: "max5x",
+        subscriptionPendingBillingPeriod: null,
+        subscriptionPendingEffectiveAt: "2026-09-01T12:00:00Z",
+      })
+    );
+    expect(info?.billingPeriod).toBe("annual");
+  });
+
+  it("reports nothing without both a tier and a usable date", () => {
+    expect(scheduledPlanChange(null)).toBeNull();
+    expect(scheduledPlanChange(undefined)).toBeNull();
+    expect(scheduledPlanChange(account())).toBeNull();
+    expect(
+      scheduledPlanChange(account({ subscriptionPendingTier: "max5x" }))
+    ).toBeNull();
+    expect(
+      scheduledPlanChange(account({ subscriptionPendingEffectiveAt: "2026-09-01T12:00:00Z" }))
+    ).toBeNull();
+    // An unparseable date must not reach the billing screen as "Invalid Date".
+    expect(
+      scheduledPlanChange(
+        account({ subscriptionPendingTier: "max5x", subscriptionPendingEffectiveAt: "soon" })
+      )
+    ).toBeNull();
   });
 });

--- a/src/lib/appHelpers.ts
+++ b/src/lib/appHelpers.ts
@@ -3,6 +3,7 @@ import type {
   ClientConnectorStatus,
   RuntimeStatus,
   DailySavingsPoint,
+  HeadroomAccountProfile,
   HeadroomPricingStatus,
   HeadroomSubscriptionTier,
   IntroOffer,
@@ -226,6 +227,39 @@ export function upgradePlanIntentLabel(planId: UpgradePlanId | null) {
     default:
       return null;
   }
+}
+
+export interface ScheduledPlanChange {
+  tier: HeadroomSubscriptionTier;
+  billingPeriod: BillingPeriod;
+  note: string;
+}
+
+/** A plan change the server has scheduled for the next cycle. Until it lands
+ * the subscription still reports the plan being paid for, so the pending
+ * fields are the only sign of it. Null unless both the tier and a usable
+ * effective date are known -- an unparseable date would otherwise reach the
+ * billing screen as "on Invalid Date". */
+export function scheduledPlanChange(
+  account: HeadroomAccountProfile | null | undefined
+): ScheduledPlanChange | null {
+  const tier = account?.subscriptionPendingTier;
+  const effectiveAt = account?.subscriptionPendingEffectiveAt;
+  if (!tier || !effectiveAt) return null;
+  const effective = new Date(effectiveAt);
+  if (Number.isNaN(effective.getTime())) return null;
+  const billingPeriod: BillingPeriod =
+    account?.subscriptionPendingBillingPeriod === "monthly" ? "monthly" : "annual";
+  const on = effective.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric"
+  });
+  // Same tier on a shorter cycle is a billing switch, not a plan change.
+  const note = tier === account?.subscriptionTier
+    ? `Switches to ${billingPeriod} billing on ${on}`
+    : `Switches to ${upgradePlanIntentLabel(tier)} (${billingPeriod}) on ${on}`;
+  return { tier, billingPeriod, note };
 }
 
 // Connector(s) whose detected plan drives a tier-mismatch recommendation, for

--- a/src/lib/dashboardHelpers.test.ts
+++ b/src/lib/dashboardHelpers.test.ts
@@ -151,12 +151,34 @@ describe("dashboard helpers", () => {
       actualCostUsd: 10,
       totalTokensSent: 1000,
       compressibleCostUsd: 9,
-      compressibleTokensSent: 400
+      // $9 compressible out of $19 of full-price input, applied to our own
+      // token count -- never `totalTokensSent - cacheReadTokens`.
+      compressibleTokensSent: 474
     });
 
     // No cache coverage: nothing to subtract, bars keep the full figure.
     const uncovered = buildHourlySavingsChartData([{ ...covered[0], cacheReadTokens: undefined, cacheSavingsUsd: undefined }]);
     expect(uncovered[0]).toMatchObject({ compressibleCostUsd: 10, compressibleTokensSent: 1000 });
+  });
+
+  it("keeps the token bar non-zero when provider cache reads exceed forwarded input", () => {
+    // Real 2026-08-21T08:00 bucket: differencing the two scales clamped this
+    // to a flat zero bar while the dollar bar showed $11.78.
+    const chartData = buildHourlySavingsChartData([
+      {
+        hour: "2026-08-21T08:00",
+        estimatedSavingsUsd: 1,
+        estimatedTokensSaved: 100,
+        actualCostUsd: 98.46,
+        totalTokensSent: 77_148_652,
+        cacheReadTokens: 102_285_108,
+        cacheSavingsUsd: 780.1,
+        byProvider: []
+      }
+    ]);
+    expect(chartData[0].compressibleCostUsd).toBeGreaterThan(0);
+    expect(chartData[0].compressibleTokensSent).toBeGreaterThan(0);
+    expect(chartData[0].compressibleTokensSent).toBeLessThan(77_148_652);
   });
 
   it("builds monthly chart data and finds earliest visible history", () => {

--- a/src/lib/dashboardHelpers.test.ts
+++ b/src/lib/dashboardHelpers.test.ts
@@ -7,6 +7,7 @@ import {
   buildMonthlySavingsChartData,
   buildMonthlySavingsWindow,
   compressibleInputSavingsRate,
+  allTimeCacheHitPair,
   cacheHitPair,
   outputReductionForWindow,
   compactNumber,
@@ -508,6 +509,40 @@ describe("cacheHitPair", () => {
     ]);
     expect(pair!.hitPct).toBe(100);
     expect(pair!.compressedPct).toBe(0);
+  });
+});
+
+describe("allTimeCacheHitPair", () => {
+  const breakdown = {
+    compressionSavingsUsd: 4,
+    outputSavingsUsd: 0,
+    cacheSavingsUsd: 9, // read discount $9 -> read cost $1
+    cacheReadTokens: 900,
+    totalInputTokens: 1000,
+    totalInputCostUsd: 3 // $1 reads + $2 billable
+  };
+
+  it("prices the lifetime breakdown as one synthetic bucket", () => {
+    const pair = allTimeCacheHitPair(breakdown, 4);
+    const direct = cacheHitPair([
+      {
+        cacheSavingsUsd: breakdown.cacheSavingsUsd,
+        actualCostUsd: breakdown.totalInputCostUsd,
+        estimatedSavingsUsd: 4
+      }
+    ]);
+    expect(pair).toEqual(direct);
+    expect(pair!.hitPct).toBeCloseTo(83.33, 2);
+    // $4 saved against $4 saved + $2 paid at full price.
+    expect(pair!.compressedPct).toBeCloseTo(66.67, 2);
+  });
+
+  it("is null without cache coverage, whatever the dollars say", () => {
+    // cacheReadTokens is the existence signal: no reads means no hit rate to
+    // report, even though cacheSavingsUsd would divide fine.
+    expect(allTimeCacheHitPair({ ...breakdown, cacheReadTokens: 0 }, 4)).toBeNull();
+    expect(allTimeCacheHitPair(null, 4)).toBeNull();
+    expect(allTimeCacheHitPair(undefined, 4)).toBeNull();
   });
 });
 

--- a/src/lib/dashboardHelpers.ts
+++ b/src/lib/dashboardHelpers.ts
@@ -309,18 +309,36 @@ export function buildHourlySavingsWindow(data: HourlySavingsPoint[], day: Date) 
  * above it (which uses the same denominator, see `compressibleInputSavingsRate`).
  * Read cost is recovered from the read discount the same way: `usd / 9`.
  *
+ * The TOKEN figure is priced the same way rather than differenced, for the
+ * reason spelled out on `compressibleInputSavingsRate`: `cacheReadTokens` is
+ * the provider's count and `totalTokensSent` is our tokenizer's count of the
+ * forwarded prompt, and on real data the reads routinely exceed the forwarded
+ * input -- `totalTokensSent - cacheReadTokens` clamped 27 of 36 live hourly
+ * buckets to a flat zero bar while the same buckets' dollar bars were fine.
+ * So we split our own token count by the compressible share the dollar pair
+ * implies (reads bill at ~0.1x, so their full-price value is `discount * 10/9`
+ * and full-price input is `actualCostUsd + cacheSavingsUsd`).
+ *
  * Falls back to the full figure on buckets with no cache coverage - local
  * tracker buckets, and days aged out of the backend's checkpoint history. */
 export function compressibleSpend(point: {
-  cacheReadTokens?: number | null;
   cacheSavingsUsd?: number | null;
   actualCostUsd: number;
   totalTokensSent: number;
 }) {
-  const readCostUsd = point.cacheSavingsUsd == null ? 0 : Math.max(0, point.cacheSavingsUsd) / 9;
+  if (point.cacheSavingsUsd == null) {
+    return {
+      compressibleCostUsd: Math.max(0, point.actualCostUsd),
+      compressibleTokensSent: Math.max(0, point.totalTokensSent)
+    };
+  }
+  const cacheSavingsUsd = Math.max(0, point.cacheSavingsUsd);
+  const compressibleCostUsd = Math.max(0, point.actualCostUsd - cacheSavingsUsd / 9);
+  const fullPriceInput = Math.max(0, point.actualCostUsd) + cacheSavingsUsd;
+  const compressibleShare = fullPriceInput > 0 ? compressibleCostUsd / fullPriceInput : 1;
   return {
-    compressibleCostUsd: Math.max(0, point.actualCostUsd - readCostUsd),
-    compressibleTokensSent: Math.max(0, point.totalTokensSent - (point.cacheReadTokens ?? 0))
+    compressibleCostUsd,
+    compressibleTokensSent: Math.round(Math.max(0, point.totalTokensSent) * compressibleShare)
   };
 }
 

--- a/src/lib/dashboardHelpers.ts
+++ b/src/lib/dashboardHelpers.ts
@@ -3,7 +3,8 @@ import type {
   ClientSetupResult,
   DailySavingsPoint,
   HourlySavingsPoint,
-  ProviderSavingsPoint
+  ProviderSavingsPoint,
+  SavingsBreakdown
 } from "./types";
 
 export interface SavingsChartDatum {
@@ -126,6 +127,24 @@ export function cacheHitPair(
   // remainder rather than hiding the (excellent) hit rate.
   const compressedPct = baseline > 0 ? Math.min(100, (saved / baseline) * 100) : 0;
   return { hitPct, compressedPct };
+}
+
+/** The all-time cache-hit pair, from the lifetime breakdown rather than a
+ * window of buckets. Null when the client has never cached anything: there is
+ * no hit rate to report, and `cacheHitPair` would be dividing into an empty
+ * window. */
+export function allTimeCacheHitPair(
+  breakdown: SavingsBreakdown | null | undefined,
+  lifetimeEstimatedSavingsUsd: number
+) {
+  if (!breakdown || breakdown.cacheReadTokens <= 0) return null;
+  return cacheHitPair([
+    {
+      cacheSavingsUsd: breakdown.cacheSavingsUsd,
+      actualCostUsd: breakdown.totalInputCostUsd,
+      estimatedSavingsUsd: lifetimeEstimatedSavingsUsd
+    }
+  ]);
 }
 
 /** Canonical input-compression rate for a window of buckets: the share of the

--- a/src/lib/launcherHelpers.test.ts
+++ b/src/lib/launcherHelpers.test.ts
@@ -148,9 +148,8 @@ describe("launcher helpers", () => {
   });
 
   describe("magicLinkScreenCopy", () => {
-    it("names the account in every terminal state", () => {
+    it("names the account while verifying", () => {
       expect(magicLinkScreenCopy("verifying", "a@b.com", null).body).toContain("a@b.com");
-      expect(magicLinkScreenCopy("signed_in", "a@b.com", null).body).toContain("a@b.com");
     });
 
     it("surfaces the verify error, falling back to a retry hint", () => {

--- a/src/lib/launcherHelpers.test.ts
+++ b/src/lib/launcherHelpers.test.ts
@@ -6,6 +6,7 @@ import {
   getClaudeConnector,
   getContactRequestValidationError,
   getInitialLauncherStage,
+  magicLinkScreenCopy,
   getLauncherAutoConfigureDecision,
   isValidEmailAddress,
   needsTermsAcceptance,
@@ -144,6 +145,22 @@ describe("launcher helpers", () => {
         message: "Waiting for a Claude Code prompt..."
       }
     ]);
+  });
+
+  describe("magicLinkScreenCopy", () => {
+    it("names the account in every terminal state", () => {
+      expect(magicLinkScreenCopy("verifying", "a@b.com", null).body).toContain("a@b.com");
+      expect(magicLinkScreenCopy("signed_in", "a@b.com", null).body).toContain("a@b.com");
+    });
+
+    it("surfaces the verify error, falling back to a retry hint", () => {
+      expect(magicLinkScreenCopy("failed", "a@b.com", "Code expired.").body).toBe(
+        "Code expired."
+      );
+      expect(magicLinkScreenCopy("failed", "a@b.com", null).body).toContain(
+        "Request a new sign-in link"
+      );
+    });
   });
 
   describe("getInitialLauncherStage", () => {

--- a/src/lib/launcherHelpers.ts
+++ b/src/lib/launcherHelpers.ts
@@ -158,6 +158,26 @@ export function getLauncherAutoConfigureDecision(
   return "begin_proxy_verification";
 }
 
+/// Copy for the launcher's magic-link screen (headroom://auth).
+export type MagicLinkState = "verifying" | "signed_in" | "failed";
+
+export function magicLinkScreenCopy(
+  state: MagicLinkState,
+  email: string,
+  error: string | null
+): { title: string; body: string } {
+  if (state === "verifying") {
+    return { title: "Signing you in…", body: `Finishing sign-in for ${email}.` };
+  }
+  if (state === "failed") {
+    return {
+      title: "That sign-in link did not work",
+      body: error ?? "Request a new sign-in link and try again.",
+    };
+  }
+  return { title: "You are signed in", body: `Signed in as ${email}.` };
+}
+
 /// Given a launcher-window startup result, return the stage the launcher
 /// should land on, or `null` to leave the current stage untouched (the caller
 /// is in a non-launcher window, or bootstrap hasn't completed yet).

--- a/src/lib/launcherHelpers.ts
+++ b/src/lib/launcherHelpers.ts
@@ -158,8 +158,9 @@ export function getLauncherAutoConfigureDecision(
   return "begin_proxy_verification";
 }
 
-/// Copy for the launcher's magic-link screen (headroom://auth).
-export type MagicLinkState = "verifying" | "signed_in" | "failed";
+/// Copy for the launcher's magic-link screen (headroom://auth). Success has no
+/// screen of its own - it drops straight through to the next onboarding step.
+export type MagicLinkState = "verifying" | "failed";
 
 export function magicLinkScreenCopy(
   state: MagicLinkState,
@@ -169,13 +170,10 @@ export function magicLinkScreenCopy(
   if (state === "verifying") {
     return { title: "Signing you in…", body: `Finishing sign-in for ${email}.` };
   }
-  if (state === "failed") {
-    return {
-      title: "That sign-in link did not work",
-      body: error ?? "Request a new sign-in link and try again.",
-    };
-  }
-  return { title: "You are signed in", body: `Signed in as ${email}.` };
+  return {
+    title: "That sign-in link did not work",
+    body: error ?? "Request a new sign-in link and try again.",
+  };
 }
 
 /// Given a launcher-window startup result, return the stage the launcher

--- a/src/styles.css
+++ b/src/styles.css
@@ -2214,6 +2214,12 @@ select {
   color: var(--text-primary);
 }
 
+/* Provisional numbers look provisional: a chip whose figure is an estimate
+   (vs measured against the A/B holdout) gets a dashed border. */
+.output-chip__button--estimated {
+  border-style: dashed;
+}
+
 .output-chip__dot {
   width: 6px;
   height: 6px;


### PR DESCRIPTION
Promotes the verified 0.8.7-rc.10 staging build to stable.

Smoke test (docs/beta-smoke-test.md) run on rc.10: checks 1-4, 7-15 and C1 PASS or correctly skipped. Check 11b shows only the known upstream #2990 discard reasons (structural_diff_vs_original, image_compression), no new ones. Checks 5, 6, C2-C4 need a click or a Codex session and were not run.

No release notes for this bump.
