### PR TITLE
0.9.2

### DIFF
--- a/docs/beta-smoke-test.md
+++ b/docs/beta-smoke-test.md
@@ -10,7 +10,7 @@ After installing a new beta (`-rc.N`) build, paste this file into Claude Code an
 
 ## Checks (Claude Code pass)
 
-Run these from a Claude Code session and report PASS / FAIL with the observed value. Check 14 has a step that must run **before** you install the rc - read it first. Checks 1, 5, 8, 9, 10, 11, 12, 14, and 15 are client-agnostic — run them once in either client. Codex has very different wiring (no RTK, no `~/.claude/settings.json`, pay-per-token), so its equivalents of checks 6 and 7 live in the **Codex pass** below; run that whole section from a Codex session.
+Run these from a Claude Code session and report PASS / FAIL with the observed value. Check 14 has a step that must run **before** you install the rc - read it first. Checks 1, 5, 8, 9, 10, 11, 12, 14, 15, and 16 are client-agnostic — run them once in either client. Codex has very different wiring (no RTK, no `~/.claude/settings.json`, pay-per-token), so its equivalents of checks 6 and 7 live in the **Codex pass** below; run that whole section from a Codex session.
 
 ### 1. Version matches the new beta
 ```bash
@@ -269,6 +269,21 @@ Expect: every pair is `0/0` or `1/1` - never `2/2` (duplicated block) and never 
 A `2/2` is the duplicate-block bug: `strip_marker_block` loops for exactly this reason, and `upsert_managed_block` treats reordered `end`-before-`start` markers as absent and appends fresh rather than rebuilding around them. Both behaviours have unit tests (`managed_block_upsert_replaces_existing_block_without_duplication`, `managed_block_upsert_treats_reordered_markers_as_absent`, `updating_one_managed_block_does_not_touch_other_blocks_or_user_content`), so a failure here means a new writer, not a regression in those.
 
 Note what this check does **not** cover: the CLAUDE.md damage users reported in 0.34.0 was never on disk. Upstream's user-turn compression split the file's content mid-tag as it was sent to the model, so the file was fine and the model saw mangled instructions. That class is invisible to any filesystem check - it is caught by check 11 (mutations reaching the wire) and by reading a `/v1/messages` request body, not here. Fixed upstream in #2887, shipped in 0.35.0.
+
+### 16. Lifetime card covers "saved today" (rollup backfill regression)
+
+The two Home figures come from different bucket series: "Total costs saved" sums UTC-day buckets, the chart's "saved today" sums local-hour buckets. On 2026-08-27 a fresh backend data dir under an older local tracker made `drop_rollup_backfill` discard the ring's entire live-day daily bucket, so the lifetime card read $0.50 against a $0.91 "saved today" (the real day was $1.24). Fixed in 0.9.2-rc.3 by `settle_rollup_backfill` (subtract the ring's first-checkpoint cumulative instead of dropping the bucket); unit coverage is `settle_rollup_backfill_keeps_a_real_day_minus_the_ring_start` and `lifetime_card_never_reads_below_saved_today_on_a_fresh_ring`.
+
+With the dashboard open and the backend up for at least a minute (history fetched, tray tick fired):
+
+1. Visual: Home -> "Total costs saved" must be >= the chart's "saved today" figure (day view, today). Strictly less is a FAIL - lifetime is a superset of today.
+2. Cross-check today's magnitude against the backend's own ring:
+```bash
+curl -s 127.0.0.1:6767/stats-history | jq -r --arg d "$(date -u +%Y-%m-%d)"   '[.series.daily[] | select(.timestamp | startswith($d)) | .compression_savings_usd_delta] | add // 0'
+```
+Expect: the chart's "saved today" is in the same ballpark as this number plus any output-shaping dollars (it may run slightly lower - the ring-start remainder and the live tray cadence - but must not be a small fraction of it, and the lifetime card must not sit below either).
+
+This regression only reproduces when the local tracker's history predates the backend ring (reset/recreated backend data dir). A truly fresh install cannot show it; if this machine's install is fresh, report the visual invariant only and note the scenario did not apply.
 
 ## Codex checks (Codex pass)
 

--- a/docs/windows-smoke-test.md
+++ b/docs/windows-smoke-test.md
@@ -13,7 +13,7 @@ Run the commands from Git Bash unless a section says PowerShell. Paths below use
 
 ## Checks (Claude Code pass)
 
-Run these from a Claude Code session and report PASS / FAIL with the observed value. Checks 1, 5, 7, 8, 9, and 10 are client-agnostic — run them once in either client. Codex has very different wiring (no RTK, no `%USERPROFILE%\.claude\settings.json`, pay-per-token), so its equivalents live in the **Codex pass** below; run that whole section from a Codex session.
+Run these from a Claude Code session and report PASS / FAIL with the observed value. Checks 1, 5, 7, 8, 9, 10, and 12 are client-agnostic — run them once in either client. Codex has very different wiring (no RTK, no `%USERPROFILE%\.claude\settings.json`, pay-per-token), so its equivalents live in the **Codex pass** below; run that whole section from a Codex session.
 
 ### 1. Version matches the new build (PowerShell)
 The uninstall registry key carries no `DisplayVersion` value (only MainBinaryName / DisplayName / InstallLocation / UninstallString), so grepping the registry for a version returns nothing even on a healthy install. Read the binary's version resource instead:
@@ -116,6 +116,17 @@ grep -c 'headroom-rtk-rewrite' "$USERPROFILE/.claude/settings.json"
 grep -c 'markitdown' "$USERPROFILE/.claude/settings.json"
 ```
 Expect: non-zero only when the RTK / markitdown addons are installed; `0` on a fresh install is the correct state, not a failure. When markitdown is installed, a prompt that Reads an Office file should route through the shim and report compressed input.
+
+### 12. Lifetime card covers "saved today" (rollup backfill regression)
+
+Same check as beta check 16 - this class was found on a Windows install (2026-08-27: fresh `%USERPROFILE%\.headroom` under an older tracker showed a $0.50 lifetime against a $0.91 "saved today"), but it is platform-agnostic desktop logic. With the dashboard open and the backend up for a minute:
+
+1. Visual: Home -> "Total costs saved" must be >= the chart's "saved today". Strictly less is a FAIL.
+2. Cross-check against the backend's ring (Git Bash):
+```bash
+curl -s 127.0.0.1:6767/stats-history | jq -r --arg d "$(date -u +%Y-%m-%d)"   '[.series.daily[] | select(.timestamp | startswith($d)) | .compression_savings_usd_delta] | add // 0'
+```
+Expect: "saved today" in the same ballpark as this number (plus output dollars, if any); the lifetime card at or above both. Only reproduces when the tracker predates the ring (reset/recreated `.headroom`); on a truly fresh install report the visual invariant only.
 
 ## Codex checks (Codex pass)
 

--- a/docs/windows-smoke-test.md
+++ b/docs/windows-smoke-test.md
@@ -17,9 +17,10 @@ Run these from a Claude Code session and report PASS / FAIL with the observed va
 
 ### 1. Version matches the new build (PowerShell)
 The uninstall registry key carries no `DisplayVersion` value (only MainBinaryName / DisplayName / InstallLocation / UninstallString), so grepping the registry for a version returns nothing even on a healthy install. Read the binary's version resource instead:
+Two traps: `InstallLocation` comes back with embedded quotes (breaks `Join-Path`), and the binary is `$k.MainBinaryName` (`headroom-desktop.exe`), not `Headroom.exe`.
 ```powershell
 $k = Get-ItemProperty HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where-Object { $_.DisplayName -like '*Headroom*' }
-(Get-Item (Join-Path $k.InstallLocation 'Headroom.exe')).VersionInfo.ProductVersion
+(Get-Item (Join-Path $k.InstallLocation.Trim('"') $k.MainBinaryName)).VersionInfo.ProductVersion
 ```
 Expect: the `-rc.N` version you just installed (the dashboard Settings page shows the same version as a cross-check). If this shows an older rc, STOP - every other check below would measure the stale build, not the one being promoted.
 
@@ -45,7 +46,7 @@ Expect: a version line and a gain summary, no "command not found". Claude Code's
 ### 4. MCP retrieve tool is available (Claude Code only; only if memory tools are enabled)
 First check whether the proxy was started with memory tools:
 ```bash
-ls "$LOCALAPPDATA/Headroom/headroom/logs/" | grep -E 'no-memory-tools' >/dev/null && echo 'memory tools DISABLED — skip this check' || echo 'memory tools enabled — run check'
+ls -t "$LOCALAPPDATA/Headroom/headroom/logs/" | grep 'port-6767' | head -1 | grep -q 'no-memory-tools' && echo 'memory tools DISABLED - skip this check' || echo 'memory tools enabled - run check'
 ```
 If enabled, have Claude call `mcp__headroom__headroom_retrieve` with any small query and expect a tool result (not "No such tool available").
 

--- a/docs/windows-smoke-test.md
+++ b/docs/windows-smoke-test.md
@@ -15,11 +15,13 @@ Run the commands from Git Bash unless a section says PowerShell. Paths below use
 
 Run these from a Claude Code session and report PASS / FAIL with the observed value. Checks 1, 5, 7, 8, 9, and 10 are client-agnostic — run them once in either client. Codex has very different wiring (no RTK, no `%USERPROFILE%\.claude\settings.json`, pay-per-token), so its equivalents live in the **Codex pass** below; run that whole section from a Codex session.
 
-### 1. Version matches the new build
-```bash
-reg query "HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall" /s /f Headroom 2>/dev/null | grep -i version
+### 1. Version matches the new build (PowerShell)
+The uninstall registry key carries no `DisplayVersion` value (only MainBinaryName / DisplayName / InstallLocation / UninstallString), so grepping the registry for a version returns nothing even on a healthy install. Read the binary's version resource instead:
+```powershell
+$k = Get-ItemProperty HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where-Object { $_.DisplayName -like '*Headroom*' }
+(Get-Item (Join-Path $k.InstallLocation 'Headroom.exe')).VersionInfo.ProductVersion
 ```
-Expect: the `-rc.N` version you just installed.
+Expect: the `-rc.N` version you just installed (the dashboard Settings page shows the same version as a cross-check). If this shows an older rc, STOP - every other check below would measure the stale build, not the one being promoted.
 
 ### 2. Proxy is intercepting this conversation
 Send a trivial prompt ("say hi"), then:
@@ -51,7 +53,7 @@ If enabled, have Claude call `mcp__headroom__headroom_retrieve` with any small q
 Click the tray icon, open the dashboard. Expect savings chart and per-client stats render without a blank/error state.
 
 ### 6. Pause / resume cleanly strips and restores interception
-In Settings, toggle Pause then Resume. After Pause, `grep -c headroom-rtk-rewrite "$USERPROFILE/.claude/settings.json"` should return `0`; after Resume it should return `1`. This verifies the Claude Code config only — Pause clears *all* clients, so check C4 in the Codex pass confirms Codex's config is stripped and restored too.
+In Settings, toggle Pause then Resume. After Pause, `grep -c '127.0.0.1:6767' "$USERPROFILE/.claude/settings.json"` should return `0`; after Resume it should be non-zero. The base-URL marker exists on every install; do not grep for `headroom-rtk-rewrite` here - that hook only exists when the opt-in RTK addon is installed, so its baseline is already `0` on a fresh install. This verifies the Claude Code config only — Pause clears *all* clients, so check C4 in the Codex pass confirms Codex's config is stripped and restored too.
 
 ### 7. Proxy is actively optimizing this conversation (not just a heartbeat)
 The proxy always runs in `token` mode now (`HEADROOM_MODE=token`, hardcoded). The compression policy is chosen per request by the auth-mode classifier from the client `User-Agent`: Claude Code subscription/OAuth traffic (UA `claude-code/`) is classified `SUBSCRIPTION` → conservative policy; pay-per-token API-key / Codex traffic is classified `PAYG`/`OAUTH` → aggressive policy, so `requests_compressed` and `total_tokens_removed` move directly.
@@ -61,20 +63,20 @@ Timing matters either way: a `Read` result becomes part of Claude's *next* outgo
 **Claude Code subscription/OAuth traffic** (classified `SUBSCRIPTION`):
 1. Capture the baseline:
    ```bash
-   "$LOCALAPPDATA/Headroom/headroom/bin/rtk.exe" proxy curl -s http://127.0.0.1:6767/stats | jq '{primary_model: .summary.primary_model, prefix_frozen: .summary.uncompressed_requests.prefix_frozen, requests_compressed: .summary.compression.requests_compressed, cache_savings_usd: .summary.cost.breakdown.cache_savings_usd, total_tokens_before: .summary.compression.total_tokens_before_with_cli_filtering}'
+   "$LOCALAPPDATA/Headroom/headroom/runtime/venv/Scripts/python.exe" -c "import json,urllib.request; s=json.load(urllib.request.urlopen('http://127.0.0.1:6767/stats'))['summary']; print(json.dumps({'primary_model': s['primary_model'], 'prefix_frozen': s['uncompressed_requests']['prefix_frozen'], 'requests_compressed': s['compression']['requests_compressed'], 'cache_savings_usd': s['cost']['breakdown']['cache_savings_usd'], 'total_tokens_before': s['compression']['total_tokens_before']}, indent=2))"
    ```
 2. End the turn with a large Read in flight — ask Claude to read a long file (~1300-1500 lines).
-3. On the *next* turn, re-run the same `jq` command.
+3. On the *next* turn, re-run the same command.
 
 Expect: `primary_model` is a `claude-*` model, `cache_savings_usd` is strictly greater, `total_tokens_before` jumped by at least the size of the Read, and `prefix_frozen` + `requests_compressed` together increased by at least 1.
 
 **Pay-per-token API-key traffic** (classified `PAYG`/`OAUTH` — the branch Codex hits):
 1. Capture the baseline:
    ```bash
-   "$LOCALAPPDATA/Headroom/headroom/bin/rtk.exe" proxy curl -s http://127.0.0.1:6767/stats | jq '.summary.compression.requests_compressed, .summary.compression.total_tokens_removed'
+   "$LOCALAPPDATA/Headroom/headroom/runtime/venv/Scripts/python.exe" -c "import json,urllib.request; s=json.load(urllib.request.urlopen('http://127.0.0.1:6767/stats'))['summary']['compression']; print(s['requests_compressed'], s['total_tokens_removed'])"
    ```
 2. End the turn with the same large Read in flight (~1300-1500 lines clears the compression threshold).
-3. On the *next* turn, re-run the same `jq` command.
+3. On the *next* turn, re-run the same command.
 
 Expect: `requests_compressed` increased by at least 1, and `total_tokens_removed` is strictly greater.
 
@@ -96,15 +98,24 @@ Expect: a stored credential entry for Headroom. Sign out and back in, then re-ru
 ```powershell
 reg query "HKCU\Software\Microsoft\Windows\CurrentVersion\Run" /v Headroom
 ```
-Expect: the value points at the installed Headroom executable. Toggle autostart off in Settings and confirm the value disappears; toggle back on and confirm it returns.
+Expect: check the Settings autostart toggle first - the key's presence must match it. An absent key with the toggle off is the correct managed state, not a failure; only "toggle on but key absent" (or vice versa) fails. To verify it is managed, flip the toggle both ways and confirm the value appears (pointing at the installed Headroom executable) and disappears accordingly.
 
 ### 11. Claude Code integration is intact
+Always present, on every install:
 ```bash
-grep -c 'headroom-rtk-rewrite' "$USERPROFILE/.claude/settings.json"
-grep -c 'markitdown' "$USERPROFILE/.claude/settings.json"
+grep -c '127.0.0.1:6767' "$USERPROFILE/.claude/settings.json"
+grep -c 'headroom-claude-guard' "$USERPROFILE/.claude/settings.json"
 ls "$USERPROFILE/.claude/hooks/" 2>/dev/null
 ```
-Expect: non-zero hook references for RTK rewrite and markitdown, and the hook scripts exist under `~/.claude/hooks/` (the guard hook and markitdown shim run through Git Bash's `bash` on Windows). Sending a prompt that triggers a `Read` should route through markitdown and report compressed input.
+Expect: both greps non-zero (the `ANTHROPIC_BASE_URL` routing env and the SessionStart guard hook), and `headroom-claude-guard.py` listed under `~/.claude/hooks/` (hooks run through Git Bash's `bash` on Windows).
+
+Opt-in addons - same gate as check 3, skip when `bin/` is empty:
+```bash
+ls "$LOCALAPPDATA/Headroom/headroom/bin/" 2>/dev/null
+grep -c 'headroom-rtk-rewrite' "$USERPROFILE/.claude/settings.json"
+grep -c 'markitdown' "$USERPROFILE/.claude/settings.json"
+```
+Expect: non-zero only when the RTK / markitdown addons are installed; `0` on a fresh install is the correct state, not a failure. When markitdown is installed, a prompt that Reads an Office file should route through the shim and report compressed input.
 
 ## Codex checks (Codex pass)
 
@@ -123,7 +134,7 @@ Expect: `PASS`.
 ### C2. Codex traffic is actively optimized (token mode)
 1. Capture the baseline:
    ```bash
-   "$LOCALAPPDATA/Headroom/headroom/bin/rtk.exe" proxy curl -s http://127.0.0.1:6767/stats | jq '{mode: .summary.mode, primary_model: .summary.primary_model, requests_compressed: .summary.compression.requests_compressed, total_tokens_removed: .summary.compression.total_tokens_removed}'
+   "$LOCALAPPDATA/Headroom/headroom/runtime/venv/Scripts/python.exe" -c "import json,urllib.request; s=json.load(urllib.request.urlopen('http://127.0.0.1:6767/stats'))['summary']; print(json.dumps({'mode': s['mode'], 'primary_model': s['primary_model'], 'requests_compressed': s['compression']['requests_compressed'], 'total_tokens_removed': s['compression']['total_tokens_removed']}, indent=2))"
    ```
 2. End the turn with a large file read in flight from Codex (~1300-1500 lines).
 3. On the next turn, re-run the same command.
@@ -142,11 +153,13 @@ Expect: after Pause it prints `0`; after Resume it is non-zero (back to `4` mark
 
 ## Inspecting the proxy directly
 
-When inspecting the running proxy by hand (e.g. checking `/stats`), wrap `curl` with `rtk proxy` to bypass RTK's output filtering — otherwise large JSON responses get summarized into a type-shape view that looks like a broken endpoint:
+A fresh Windows install has neither `rtk.exe` (opt-in addon) nor `jq` (not bundled with Git Bash), so use the bundled Python to hit `/stats`:
 
 ```bash
-"$LOCALAPPDATA/Headroom/headroom/bin/rtk.exe" proxy curl -s http://127.0.0.1:6767/stats | jq .summary
+"$LOCALAPPDATA/Headroom/headroom/runtime/venv/Scripts/python.exe" -c "import json,urllib.request; print(json.dumps(json.load(urllib.request.urlopen('http://127.0.0.1:6767/stats'))['summary'], indent=2))"
 ```
+
+If RTK *is* installed, its rewrite hook filters large `curl` output into a type-shape view that looks like a broken endpoint; bypass it with `"$LOCALAPPDATA/Headroom/headroom/bin/rtk.exe" proxy curl -s http://127.0.0.1:6767/stats`. Python invocations are never rewritten, so the command above is safe either way.
 
 ## When something fails
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.2-rc.2",
+  "version": "0.9.2-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.2-rc.2",
+      "version": "0.9.2-rc.3",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.2-rc.1",
+  "version": "0.9.2-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.2-rc.1",
+      "version": "0.9.2-rc.2",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.2-rc.5",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.2-rc.5",
+      "version": "0.9.2",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.2-rc.4",
+  "version": "0.9.2-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.2-rc.4",
+      "version": "0.9.2-rc.5",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.2-rc.3",
+  "version": "0.9.2-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.2-rc.3",
+      "version": "0.9.2-rc.4",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.1-rc.6",
+  "version": "0.9.2-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.1-rc.6",
+      "version": "0.9.2-rc.1",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.2-rc.2",
+  "version": "0.9.2-rc.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.2-rc.3",
+  "version": "0.9.2-rc.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.2-rc.5",
+  "version": "0.9.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.2-rc.1",
+  "version": "0.9.2-rc.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.1-rc.6",
+  "version": "0.9.2-rc.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.2-rc.4",
+  "version": "0.9.2-rc.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.2-rc.5"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.1-rc.6"
+version = "0.9.2-rc.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.2-rc.2"
+version = "0.9.2-rc.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.2-rc.3"
+version = "0.9.2-rc.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.2-rc.1"
+version = "0.9.2-rc.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.2-rc.4"
+version = "0.9.2-rc.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.2-rc.5"
+version = "0.9.2"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.2-rc.2"
+version = "0.9.2-rc.3"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.2-rc.4"
+version = "0.9.2-rc.5"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.1-rc.6"
+version = "0.9.2-rc.1"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.2-rc.1"
+version = "0.9.2-rc.2"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.2-rc.3"
+version = "0.9.2-rc.4"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/src/client_adapters.rs
+++ b/src-tauri/src/client_adapters.rs
@@ -2113,7 +2113,9 @@ pub(crate) fn atomic_write(path: &Path, contents: &[u8]) -> Result<()> {
 /// Retries `op` while it fails `PermissionDenied`, sleeping 50/100/200ms
 /// between attempts (4 tries total). Any other error, or the final denial,
 /// is returned as-is.
-fn retry_transient_denied<T>(mut op: impl FnMut() -> std::io::Result<T>) -> std::io::Result<T> {
+pub(crate) fn retry_transient_denied<T>(
+    mut op: impl FnMut() -> std::io::Result<T>,
+) -> std::io::Result<T> {
     let mut delay = std::time::Duration::from_millis(50);
     for _ in 0..3 {
         match op() {

--- a/src-tauri/src/client_adapters.rs
+++ b/src-tauri/src/client_adapters.rs
@@ -1266,6 +1266,7 @@ fn revert_external_mutations_with_status() -> (Vec<String>, bool) {
     (removed, oss_hooks_pending)
 }
 
+#[cfg_attr(target_os = "windows", allow(dead_code))] // Windows uninstall uses perform_full_cleanup()
 pub fn revert_external_mutations() -> Vec<String> {
     revert_external_mutations_with_status().0
 }
@@ -5073,6 +5074,8 @@ fn write_file_if_changed(
     content: &str,
     executable: bool,
 ) -> Result<(bool, Option<PathBuf>)> {
+    #[cfg(not(unix))]
+    let _ = executable; // only used for chmod on unix
     if let Some(parent) = file_path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("creating {}", parent.display()))?;

--- a/src-tauri/src/output_savings.rs
+++ b/src-tauri/src/output_savings.rs
@@ -71,12 +71,6 @@ impl Accum {
         let n = self.n as f64;
         ((self.sumsq - self.sum * self.sum / n) / (n - 1.0)).max(0.0)
     }
-
-    fn merge(&mut self, other: &Accum) {
-        self.n += other.n;
-        self.sum += other.sum;
-        self.sumsq += other.sumsq;
-    }
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -753,8 +753,10 @@ enum RemoteAccountSyncError {
     Unauthorized,
     /// Anything that is not a 401, carrying what actually failed. RUST-8Z
     /// fired with a bare "Other" after 59 silent hours, which could not tell
-    /// an HTTP 5xx from a transport error from a decode failure.
-    Other(String),
+    /// an HTTP 5xx from a transport error from a decode failure. The payload
+    /// is read only via the derived Debug in the sync-failure log, which
+    /// dead-code analysis deliberately ignores.
+    Other(#[allow(dead_code)] String),
 }
 
 pub fn get_pricing_status(state: &AppState) -> Result<HeadroomPricingStatus, String> {

--- a/src-tauri/src/proxy_intercept.rs
+++ b/src-tauri/src/proxy_intercept.rs
@@ -507,6 +507,11 @@ pub fn spawn(
                 // forever; report each distinct error to Sentry once.
                 let mut reported_errors: std::collections::HashSet<String> =
                     std::collections::HashSet::new();
+                // One reclaim attempt per launch: past the grace, a
+                // held-but-not-serving port is most often a stranded prior
+                // Headroom desktop instance (updater relaunch), which nothing
+                // else ever clears -- see reclaim_stranded_intercept_holder.
+                let mut reclaim_attempted = false;
                 // A restart -- the updater relaunch, or the "Restart now"
                 // button -- starts the new process while the old one still
                 // holds the port, so the first bind after launch routinely
@@ -586,6 +591,23 @@ pub fn spawn(
                                 // asserted the holder was not ours and sent a
                                 // whole investigation down the wrong path.
                                 *bind_error.lock() = Some(e.to_string());
+                                // Identity-gated: only ever kills a process
+                                // running this exact executable, so a foreign
+                                // holder or reserved range is untouched and
+                                // falls through to the report below. Blocking
+                                // shell-outs are fine here: bind failed, so
+                                // nothing is being served on this runtime.
+                                if !reclaim_attempted {
+                                    reclaim_attempted = true;
+                                    if crate::tool_manager::reclaim_stranded_intercept_holder(
+                                        INTERCEPT_PORT,
+                                    ) {
+                                        log::info!(
+                                            "[proxy_intercept] reclaimed stranded instance on port {INTERCEPT_PORT}; retrying bind"
+                                        );
+                                        continue;
+                                    }
+                                }
                                 log::warn!(
                                     "[proxy_intercept] port {INTERCEPT_PORT} is held but not answering /health (leftover Headroom, another app, or a reserved range); retrying in 15s ({e})"
                                 );

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -8044,6 +8044,71 @@ mod tests {
     }
 
     #[test]
+    fn lifetime_card_never_reads_below_saved_today_on_a_fresh_ring() {
+        // Full display-pipeline regression for 2026-08-27: fresh backend data
+        // dir (ring starts near zero) + tracker history older than the ring.
+        // The daily settle used to drop the whole live day, so the lifetime
+        // card (daily sum) read $0.50 while "saved today" (hourly sum, which
+        // only lost one hour) read $0.91.
+        let ring_start = RingStartTotals {
+            tokens_saved: 1_917,
+            compression_savings_usd: 0.003834,
+            ..RingStartTotals::default()
+        };
+        // The backend's rollups for the live day.
+        let native_daily = vec![daily("2026-08-27", 480_748, 1.244165)];
+        let mut native_hourly = vec![
+            hourly("2026-08-27T10:00", 250_000),
+            hourly("2026-08-27T11:00", 180_000),
+            hourly("2026-08-27T12:00", 50_748),
+        ];
+        native_hourly[0].estimated_savings_usd = 0.53;
+        native_hourly[1].estimated_savings_usd = 0.60;
+        native_hourly[2].estimated_savings_usd = 0.114165;
+        // The local tracker predates the ring and only saw part of today.
+        let tracker_daily = vec![
+            daily("2026-08-20", 134_000, 0.30),
+            daily("2026-08-27", 200_000, 0.50),
+        ];
+        let tracker_hourly = vec![
+            hourly("2026-08-20T09:00", 134_000),
+            hourly("2026-08-27T11:00", 200_000),
+        ];
+
+        let settled_daily = settle_rollup_backfill(
+            native_daily,
+            tracker_daily.iter().map(|p| p.date.as_str()).min(),
+            Some(&ring_start),
+            |p| p.date.as_str(),
+        );
+        let settled_hourly = settle_rollup_backfill(
+            native_hourly,
+            tracker_hourly.iter().map(|p| p.hour.as_str()).min(),
+            Some(&ring_start),
+            |p| p.hour.as_str(),
+        );
+        let merged_daily = merge_daily_savings(tracker_daily, settled_daily, "2026-06-02");
+        let merged_hourly =
+            merge_hourly_savings(tracker_hourly, settled_hourly, "2026-06-02T00:00");
+
+        // The two figures the Home screen renders.
+        let lifetime: f64 = merged_daily.iter().map(|p| p.estimated_savings_usd).sum();
+        let today: f64 = merged_hourly
+            .iter()
+            .filter(|p| p.hour.starts_with("2026-08-27"))
+            .map(|p| p.estimated_savings_usd + p.output_savings_usd)
+            .sum();
+        assert!(
+            lifetime >= today,
+            "lifetime {lifetime} must cover saved-today {today}"
+        );
+        // Today survives at full ring value minus the ring start, on both
+        // series -- not the tracker's partial $0.50 observation.
+        assert!((today - 1.240331).abs() < 1e-9, "{today}");
+        assert!((lifetime - (0.30 + 1.240331)).abs() < 1e-9, "{lifetime}");
+    }
+
+    #[test]
     fn lifetime_output_savings_prices_the_estimators_full_history() {
         // Buckets: 2 days, 100k tokens for $2.50 -> $25/M blended.
         let mut buckets = vec![daily("2026-08-04", 0, 0.0), daily("2026-08-05", 0, 0.0)];

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -2409,14 +2409,16 @@ impl AppState {
                 (history.daily_savings(), history.hourly_savings())
             } else {
                 (
-                    drop_rollup_backfill(
+                    settle_rollup_backfill(
                         history.daily_savings(),
                         daily_savings.iter().map(|p| p.date.as_str()).min(),
+                        history.ring_start.as_ref(),
                         |p| p.date.as_str(),
                     ),
-                    drop_rollup_backfill(
+                    settle_rollup_backfill(
                         history.hourly_savings(),
                         hourly_savings.iter().map(|p| p.hour.as_str()).min(),
+                        history.ring_start.as_ref(),
                         |p| p.hour.as_str(),
                     ),
                 )
@@ -5631,6 +5633,13 @@ struct HeadroomSavingsHistoryResponse {
     /// leave the series alone: applying both drops eats a real day, and with
     /// only two buckets in the window it emptied the series outright.
     backfill_bucket_dropped: bool,
+    /// Cumulative counter totals at the oldest raw `history` checkpoint.
+    /// The rollup's leading bucket diffs that checkpoint against a zero
+    /// baseline, so these totals are exactly the pre-ring history folded into
+    /// that bucket: ~zero for a data dir created at the series start (a
+    /// genuine first day), large when counters survived a reset or trim.
+    /// None when the payload carries no raw history.
+    ring_start: Option<RingStartTotals>,
 }
 
 impl HeadroomSavingsHistoryResponse {
@@ -6191,6 +6200,61 @@ fn drop_oldest_rollup_bucket(series: &mut Vec<HeadroomSavingsRollupPoint>) {
     }
 }
 
+/// Cumulative counter totals at the raw ring's oldest checkpoint. See the
+/// field doc on `HeadroomSavingsHistoryResponse::ring_start`.
+#[derive(Debug, Default, Clone, Copy)]
+struct RingStartTotals {
+    tokens_saved: u64,
+    compression_savings_usd: f64,
+    total_input_tokens: u64,
+    total_input_cost_usd: f64,
+    output_tokens_saved: u64,
+    output_savings_usd: f64,
+}
+
+fn ring_start_totals(root: &Value) -> Option<RingStartTotals> {
+    let Some(Value::Array(items)) = value_at_path(root, &["history"]) else {
+        return None;
+    };
+    items
+        .iter()
+        .filter_map(|item| {
+            let map = item.as_object()?;
+            let timestamp = map
+                .get("timestamp")
+                .and_then(|value| value.as_str())
+                .and_then(parse_history_timestamp)?;
+            Some((timestamp, map))
+        })
+        .min_by_key(|(timestamp, _)| *timestamp)
+        .map(|(_, map)| RingStartTotals {
+            tokens_saved: map
+                .get("total_tokens_saved")
+                .and_then(parse_u64_value)
+                .unwrap_or(0),
+            compression_savings_usd: map
+                .get("compression_savings_usd")
+                .and_then(parse_f64_value)
+                .unwrap_or(0.0),
+            total_input_tokens: map
+                .get("total_input_tokens")
+                .and_then(parse_u64_value)
+                .unwrap_or(0),
+            total_input_cost_usd: map
+                .get("total_input_cost_usd")
+                .and_then(parse_f64_value)
+                .unwrap_or(0.0),
+            output_tokens_saved: map
+                .get("output_tokens_saved")
+                .and_then(parse_u64_value)
+                .unwrap_or(0),
+            output_savings_usd: map
+                .get("output_savings_usd")
+                .and_then(parse_f64_value)
+                .unwrap_or(0.0),
+        })
+}
+
 fn parse_headroom_stats_history_from_json(body: &str) -> Option<HeadroomSavingsHistoryResponse> {
     let root = serde_json::from_str::<Value>(body).ok()?;
     let mut hourly = value_at_path(&root, &["series", "hourly"])
@@ -6239,6 +6303,7 @@ fn parse_headroom_stats_history_from_json(body: &str) -> Option<HeadroomSavingsH
             daily,
             lifetime,
             backfill_bucket_dropped,
+            ring_start: ring_start_totals(&root),
         })
     }
 }
@@ -7432,6 +7497,90 @@ fn drop_rollup_backfill<T>(
     native.into_iter().filter(|p| key(p) != first).collect()
 }
 
+/// A rollup bucket whose leading against-zero delta can be settled exactly by
+/// subtracting the ring's starting totals (see `settle_rollup_backfill`).
+trait BackfillSettle {
+    fn subtract_ring_start(&mut self, start: &RingStartTotals);
+    fn is_empty_after_settle(&self) -> bool;
+}
+
+impl BackfillSettle for DailySavingsPoint {
+    fn subtract_ring_start(&mut self, start: &RingStartTotals) {
+        self.estimated_tokens_saved = self
+            .estimated_tokens_saved
+            .saturating_sub(start.tokens_saved);
+        self.estimated_savings_usd =
+            (self.estimated_savings_usd - start.compression_savings_usd).max(0.0);
+        self.total_tokens_sent = self
+            .total_tokens_sent
+            .saturating_sub(start.total_input_tokens);
+        self.actual_cost_usd = (self.actual_cost_usd - start.total_input_cost_usd).max(0.0);
+        self.output_tokens_saved = self
+            .output_tokens_saved
+            .saturating_sub(start.output_tokens_saved);
+        self.output_savings_usd = (self.output_savings_usd - start.output_savings_usd).max(0.0);
+    }
+    fn is_empty_after_settle(&self) -> bool {
+        self.estimated_tokens_saved == 0 && self.total_tokens_sent == 0
+    }
+}
+
+impl BackfillSettle for HourlySavingsPoint {
+    fn subtract_ring_start(&mut self, start: &RingStartTotals) {
+        self.estimated_tokens_saved = self
+            .estimated_tokens_saved
+            .saturating_sub(start.tokens_saved);
+        self.estimated_savings_usd =
+            (self.estimated_savings_usd - start.compression_savings_usd).max(0.0);
+        self.total_tokens_sent = self
+            .total_tokens_sent
+            .saturating_sub(start.total_input_tokens);
+        self.actual_cost_usd = (self.actual_cost_usd - start.total_input_cost_usd).max(0.0);
+        self.output_tokens_saved = self
+            .output_tokens_saved
+            .saturating_sub(start.output_tokens_saved);
+        self.output_savings_usd = (self.output_savings_usd - start.output_savings_usd).max(0.0);
+    }
+    fn is_empty_after_settle(&self) -> bool {
+        self.estimated_tokens_saved == 0 && self.total_tokens_sent == 0
+    }
+}
+
+/// Like `drop_rollup_backfill`, but exact when the payload's raw ring is
+/// available: the leading bucket's spurious content is precisely the ring's
+/// starting cumulative totals, so subtract those and keep whatever real
+/// traffic remains. Whole-bucket dropping stays as the fallback without a
+/// ring, and for a bucket the subtraction empties. Dropping unconditionally
+/// cost a full real day when the backend data dir was fresh (ring start
+/// ~zero): the tracker predating the ring made today look like backfill, and
+/// the lifetime card fell back to the tracker's partial observation
+/// (2026-08-27: $0.50 shown against a $1.24 day).
+fn settle_rollup_backfill<T: BackfillSettle>(
+    native: Vec<T>,
+    earliest_local: Option<&str>,
+    ring_start: Option<&RingStartTotals>,
+    key: impl Fn(&T) -> &str,
+) -> Vec<T> {
+    let Some(ring_start) = ring_start else {
+        return drop_rollup_backfill(native, earliest_local, key);
+    };
+    let Some(earliest_local) = earliest_local else {
+        return native;
+    };
+    let Some(first) = native.iter().map(|p| key(p).to_string()).min() else {
+        return native;
+    };
+    if earliest_local >= first.as_str() {
+        return native;
+    }
+    let mut native = native;
+    if let Some(point) = native.iter_mut().find(|p| key(p) == first) {
+        point.subtract_ring_start(ring_start);
+    }
+    native.retain(|p| key(p) != first.as_str() || !p.is_empty_after_settle());
+    native
+}
+
 /// What a cached prefix token costs relative to a fresh input token.
 ///
 /// Anthropic bills a cache read at 10% of the input rate; OpenAI's discount is
@@ -7778,12 +7927,12 @@ mod tests {
         merge_hourly_savings, most_recent_monday, parse_headroom_stats_from_json,
         parse_headroom_stats_history_from_json, parse_ps_cpu_time,
         proxy_readyz_503_body_is_upstream_only, proxy_readyz_status_is_reachable,
-        rebuild_persisted_savings_from_records, savings_rate_implausible,
+        rebuild_persisted_savings_from_records, savings_rate_implausible, settle_rollup_backfill,
         stats_fetch_warn_interval, support_tier_for_platform, tcp_port_accepts_connection,
         tool_schema_savings_usd, total_dir_size_bytes, warn_stats_fetch_failed, AppState,
         BootValidationOutcome, ClaudeProjectScan, DailySavingsBucket, Duration,
         HeadroomDashboardStats, HeadroomSavingsHistoryPoint, Instant, OutputSampleBucket,
-        PersistedSavingsState, SavingsObservation, SavingsRecord, SavingsTracker,
+        PersistedSavingsState, RingStartTotals, SavingsObservation, SavingsRecord, SavingsTracker,
         OUTPUT_SAMPLE_SERIES_VERSION, STATS_FETCH_WARNED_AT, STATS_FETCH_WARN_INTERVAL,
         STATS_FETCH_WARN_MAX_INTERVAL,
     };
@@ -7817,6 +7966,81 @@ mod tests {
         // Tracker starts with the series: nothing predates it, nothing to drop.
         let kept = drop_rollup_backfill(native, Some("2026-08-02"), |p| p.date.as_str());
         assert_eq!(kept.len(), 2);
+    }
+
+    #[test]
+    fn settle_rollup_backfill_keeps_a_real_day_minus_the_ring_start() {
+        // Fresh backend data dir: the ring's first checkpoint is near zero, so
+        // the leading bucket is a genuine day, not backfill. Dropping it showed
+        // a $0.50 lifetime against a $0.91 "saved today" on 2026-08-27.
+        let native = vec![daily("2026-08-27", 480_748, 1.244165)];
+        let ring_start = RingStartTotals {
+            tokens_saved: 1_917,
+            compression_savings_usd: 0.003834,
+            total_input_tokens: 48_545,
+            total_input_cost_usd: 0.11771,
+            output_tokens_saved: 0,
+            output_savings_usd: 0.0,
+        };
+        let settled = settle_rollup_backfill(native, Some("2026-08-20"), Some(&ring_start), |p| {
+            p.date.as_str()
+        });
+        assert_eq!(settled.len(), 1);
+        assert_eq!(settled[0].estimated_tokens_saved, 478_831);
+        assert!((settled[0].estimated_savings_usd - 1.240331).abs() < 1e-9);
+
+        // A true backfill lump -- counters survived a trim or reset, so the
+        // whole bucket is pre-ring history -- still empties and drops.
+        let native = vec![
+            daily("2026-08-02", 900_000, 5134.28),
+            daily("2026-08-03", 500, 3.35),
+        ];
+        let lump = RingStartTotals {
+            tokens_saved: 900_000,
+            compression_savings_usd: 5134.28,
+            ..RingStartTotals::default()
+        };
+        let settled =
+            settle_rollup_backfill(native.clone(), Some("2026-07-15"), Some(&lump), |p| {
+                p.date.as_str()
+            });
+        assert_eq!(
+            settled.iter().map(|p| p.date.as_str()).collect::<Vec<_>>(),
+            vec!["2026-08-03"]
+        );
+
+        // No raw ring in the payload: fall back to the whole-bucket drop.
+        let settled = settle_rollup_backfill(native.clone(), Some("2026-07-15"), None, |p| {
+            p.date.as_str()
+        });
+        assert_eq!(settled.len(), 1);
+
+        // Tracker does not predate the ring: untouched either way.
+        let settled =
+            settle_rollup_backfill(native, Some("2026-08-02"), Some(&lump), |p| p.date.as_str());
+        assert_eq!(settled.len(), 2);
+    }
+
+    #[test]
+    fn parser_extracts_ring_start_from_the_oldest_raw_checkpoint() {
+        let body = r#"{
+            "lifetime": { "tokens_saved": 10, "compression_savings_usd": 0.1 },
+            "series": { "daily": [] },
+            "history": [
+                { "timestamp": "2026-08-27T11:00:00Z", "total_tokens_saved": 60,
+                  "compression_savings_usd": 0.6, "total_input_tokens": 600,
+                  "total_input_cost_usd": 0.06, "cache_read_tokens": 0 },
+                { "timestamp": "2026-08-27T10:00:00Z", "total_tokens_saved": 50,
+                  "compression_savings_usd": 0.5, "total_input_tokens": 500,
+                  "total_input_cost_usd": 0.05, "cache_read_tokens": 0 }
+            ]
+        }"#;
+        let parsed = parse_headroom_stats_history_from_json(body).expect("parsed");
+        let start = parsed.ring_start.expect("ring start");
+        assert_eq!(start.tokens_saved, 50);
+        assert!((start.compression_savings_usd - 0.5).abs() < 1e-9);
+        assert_eq!(start.total_input_tokens, 500);
+        assert_eq!(start.output_tokens_saved, 0);
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -2528,9 +2528,12 @@ impl AppState {
         );
         let lifetime_tool_schema_savings_usd =
             tool_schema_savings_usd(&daily_savings, lifetime_tool_schema_tokens_saved);
-        let lifetime_estimated_savings_usd = lifetime_compression_savings_usd
-            + lifetime_output_savings_usd
-            + lifetime_tool_schema_savings_usd;
+        // The tool-schema layer is deliberately NOT in the headline card: it
+        // has no time dimension (lifetime counter, no backfill), so including
+        // it made "Total costs saved" exceed anything the history chart can
+        // show. It renders in the drill-down as "Additional costs saved".
+        let lifetime_estimated_savings_usd =
+            lifetime_compression_savings_usd + lifetime_output_savings_usd;
         warn_once_if_savings_rate_implausible(&daily_savings);
         // Tokens stay input-only: the card is labelled "Total input tokens
         // saved", and this total also drives the milestone notifications, which

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -3517,7 +3517,7 @@ impl ToolManager {
         Ok(())
     }
 
-    pub fn bootstrap_all_with_progress<F>(&self, mut progress: F) -> Result<ManagedRuntime>
+    pub fn bootstrap_all_with_progress<F>(&self, progress: F) -> Result<ManagedRuntime>
     where
         F: FnMut(BootstrapStepUpdate),
     {

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -9113,8 +9113,12 @@ fn verbosity_baseline_present() -> bool {
 /// — it is exactly the path headroom's plugin resolves to, so `--project <cwd>`
 /// matches. Returns `None` when no non-empty transcript exists.
 fn busiest_claude_project_cwd() -> Option<String> {
-    let home = std::env::var_os("HOME")?;
-    let projects_dir = PathBuf::from(home).join(".claude").join("projects");
+    // client_adapters::home_dir, not a bare $HOME: a Windows GUI process has
+    // no HOME env var, and bailing here silently skipped verbosity-baseline
+    // seeding on every Windows install (output savings stayed $0 forever).
+    let projects_dir = crate::client_adapters::home_dir()
+        .join(".claude")
+        .join("projects");
 
     let mut best: Option<(u64, PathBuf)> = None;
     for entry in std::fs::read_dir(&projects_dir).ok()?.flatten() {

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -2050,9 +2050,16 @@ impl ToolManager {
         // re-downloads the distribution and rebuilds the venv from it -- the
         // only thing standing between the user and a self-repair was this
         // check. Same blind spot as RUST-66/6M one level down.
+        // pyvenv.cfg is the same blind spot one file over: the venv's python
+        // stub resolves the interpreter through it, so a venv missing only
+        // this file passes the three checks below while every spawn (and
+        // every pip) dies with exit 106 / `No pyvenv.cfg file` (RUST-6S,
+        // third shape). Checking it here is what routes that machine back to
+        // bootstrap's rebuild instead of a permanent pip-retry loop.
         self.runtime.ready_flag().exists()
             && self.runtime.managed_python().exists()
             && self.runtime.standalone_python().exists()
+            && self.runtime.venv_dir.join("pyvenv.cfg").exists()
     }
 
     pub fn logs_dir(&self) -> PathBuf {
@@ -2442,7 +2449,7 @@ impl ToolManager {
                     use std::os::unix::process::CommandExt;
                     command.process_group(0);
                 }
-                let mut child = command
+                command
                     .env("PYTHONNOUSERSITE", "1")
                     .env("PYTHONPATH", &inject_dir)
                     .env("PYTHONUNBUFFERED", "1")
@@ -2653,8 +2660,14 @@ impl ToolManager {
                             .try_clone()
                             .with_context(|| format!("cloning {}", log_path.display()))?,
                     ))
-                    .stderr(Stdio::from(log_file))
-                    .spawn()
+                    .stderr(Stdio::from(log_file));
+                // Windows: AV/Defender briefly holds the just-installed (or
+                // just-scanned) exe open and CreateProcess fails ACCESS_DENIED
+                // (os error 5) even though nothing is wrong -- the spawn twin
+                // of RUST-9M's rename (Sentry RUST-9X, launch auto-start on
+                // 0.8.8). Transient by nature; retry briefly before failing
+                // the launch.
+                let mut child = crate::client_adapters::retry_transient_denied(|| command.spawn())
                     .with_context(|| {
                         format!(
                             "starting headroom background process: {} {}",
@@ -7699,6 +7712,109 @@ fn reclaim_orphan_proxy(port: u16, force_unhealthy_too: bool) -> Result<()> {
     Ok(())
 }
 
+/// Kill a stranded prior Headroom DESKTOP instance holding `port` (the
+/// intercept port). A restart or updater relaunch can leave the old
+/// headroom-desktop process holding 6767 while no longer serving on it, and
+/// nothing else ever reclaims that port -- the intercept's bind loop just
+/// retries forever, so the app stays "not hooked up" until the user kills
+/// the process by hand (RUST-7M; kill-and-restart is the confirmed field
+/// fix). Identity gate: the listener must be running THIS same executable
+/// (exact current_exe path match) and not be this process. A foreign
+/// squatter or a reserved range never matches, and nothing is killed.
+/// Returns true when a kill was issued and the port came free.
+pub(crate) fn reclaim_stranded_intercept_holder(port: u16) -> bool {
+    let Some((_, pid)) = listener_process(port) else {
+        return false;
+    };
+    if pid == std::process::id() {
+        return false;
+    }
+    if !pid_is_headroom_desktop_twin(pid) {
+        return false;
+    }
+    log::warn!(
+        "[proxy_intercept] reclaiming stranded Headroom desktop instance pid {pid} on port {port}"
+    );
+    kill_pid(pid, false);
+    if !wait_for_port_free(port, Duration::from_secs(3)) {
+        kill_pid(pid, true);
+        if !wait_for_port_free(port, Duration::from_secs(2)) {
+            return false;
+        }
+    }
+    sentry::with_scope(
+        |scope| {
+            scope.set_tag("flow", "intercept_stranded_instance_reclaimed");
+            scope.set_extra("port", port.into());
+            scope.set_extra("occupant_pid", pid.into());
+        },
+        || {
+            sentry::capture_message(
+                &format!(
+                    "intercept_stranded_instance_reclaimed: killed pid {pid} holding port {port}"
+                ),
+                sentry::Level::Info,
+            );
+        },
+    );
+    true
+}
+
+/// True when `pid` runs the same executable as this process. The strictest
+/// identity claim available: an updater-stranded old instance runs from the
+/// exact same install path as us, while any foreign process cannot.
+fn pid_is_headroom_desktop_twin(pid: u32) -> bool {
+    let Some(me) = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.to_str().map(str::to_owned))
+    else {
+        return false;
+    };
+    #[cfg(windows)]
+    let theirs = {
+        let Ok(output) = crate::proc::command("powershell")
+            .args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                &format!("(Get-Process -Id {pid} -ErrorAction SilentlyContinue).Path"),
+            ])
+            .output()
+        else {
+            return false;
+        };
+        String::from_utf8_lossy(&output.stdout).into_owned()
+    };
+    #[cfg(not(windows))]
+    let theirs = {
+        let Ok(output) = crate::proc::command("/bin/ps")
+            .args(["-o", "command=", "-p", &pid.to_string()])
+            .output()
+        else {
+            return false;
+        };
+        String::from_utf8_lossy(&output.stdout).into_owned()
+    };
+    exe_identity_matches(&theirs, &me)
+}
+
+/// True when `listener_exe` -- a bare exe path (Windows `Get-Process .Path`)
+/// or an argv line (unix `ps -o command=`) -- names exactly `my_exe`.
+/// Case-insensitive (Windows and default macOS filesystems are), and the
+/// match must end at a boundary so `...\Headroom-old.exe` cannot pass for
+/// `...\Headroom.exe`.
+fn exe_identity_matches(listener_exe: &str, my_exe: &str) -> bool {
+    let theirs = listener_exe.trim().to_lowercase();
+    let mine = my_exe.trim().to_lowercase();
+    if mine.is_empty() || !theirs.starts_with(&mine) {
+        return false;
+    }
+    match theirs[mine.len()..].chars().next() {
+        None => true,        // exact path match
+        Some(c) => c == ' ', // argv: path followed by arguments
+    }
+}
+
 /// Bail message when 6768 is foreign-held AND every port in the fallback
 /// range is also taken. Must contain `"is occupied by a non-headroom process"`
 /// so `port_conflict::is_port_conflict` continues to match, and the
@@ -9278,6 +9394,15 @@ pub(crate) fn pip_failure_category(compact: &str) -> &'static str {
         // cause: the App Control machine on retry -- python.exe was allowed
         // through, but _ssl's DLLs were still blocked).
         "ssl-missing"
+    } else if lower.contains("no pyvenv.cfg") {
+        // The venv launcher stub found no pyvenv.cfg next to it (exit 106):
+        // the venv was damaged in place (AV quarantine, disk cleanup) while
+        // the READY flag survived, so pip dies before it ever runs. A broken
+        // install of OURS, not a user-machine problem -- and the
+        // `python_runtime_installed` gate now checks pyvenv.cfg, so the next
+        // launch routes to bootstrap self-repair (RUST-6S third shape, 0.9.1;
+        // same blind-spot family as RUST-8E's missing base interpreter).
+        "venv-broken"
     } else if lower.contains("no usable temporary directory") {
         "no-tempdir"
     } else if crate::is_disk_full_signal(&lower) {
@@ -11494,6 +11619,31 @@ asyncio.run(verify())
     /// that never matches, so the identity check could never pass and every
     /// reclaim stayed dead.
     #[test]
+    fn exe_identity_matches_twin_paths_and_argv_only() {
+        // RUST-7M reclaim gate: a stranded old instance is the same binary.
+        let me = "/Applications/Headroom.app/Contents/MacOS/headroom-desktop";
+        // Bare path (Windows Get-Process .Path), case-insensitive.
+        assert!(super::exe_identity_matches(me, me));
+        assert!(super::exe_identity_matches(&me.to_uppercase(), me));
+        // Argv line (unix ps): path plus arguments.
+        assert!(super::exe_identity_matches(
+            "/Applications/Headroom.app/Contents/MacOS/headroom-desktop --flag",
+            me
+        ));
+        // Prefix collisions and strangers must NOT pass.
+        assert!(!super::exe_identity_matches(
+            "/Applications/Headroom.app/Contents/MacOS/headroom-desktop-old",
+            me
+        ));
+        assert!(!super::exe_identity_matches(
+            "/usr/bin/python3 serve.py",
+            me
+        ));
+        assert!(!super::exe_identity_matches("", me));
+        assert!(!super::exe_identity_matches(me, ""));
+    }
+
+    #[test]
     fn exe_path_is_under_accepts_both_windows_python_layouts() {
         let runtime = PathBuf::from(r"C:\Users\garm\AppData\Local\Headroom\headroom\runtime");
         assert!(exe_path_is_under(
@@ -12342,9 +12492,18 @@ after
         let base = runtime.standalone_python();
         fs::create_dir_all(base.parent().expect("parent")).expect("mkdir");
         fs::write(&base, b"").expect("base");
+
+        // RUST-6S third shape: same blind spot one file over. A venv whose
+        // pyvenv.cfg was deleted in place keeps all three markers, but every
+        // spawn dies with exit 106 / `No pyvenv.cfg file`.
+        assert!(
+            !manager.python_runtime_installed(),
+            "a venv missing pyvenv.cfg must not read as installed"
+        );
+        fs::write(runtime.venv_dir.join("pyvenv.cfg"), b"").expect("pyvenv.cfg");
         assert!(
             manager.python_runtime_installed(),
-            "all three markers present must read as installed"
+            "all four markers present must read as installed"
         );
     }
 
@@ -14267,6 +14426,9 @@ exit 0
                 "network",
             ),
             ("exit=1; stderr tail: something new", "other"),
+            // RUST-6S third shape: venv damaged in place, launcher stub can't
+            // resolve the interpreter, pip never runs.
+            ("exit=106; stderr tail: No pyvenv.cfg file", "venv-broken"),
             // RUST-8K, verbatim: Windows access-denied on a Korean install.
             // Only the numeric code survives translation.
             (

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.2-rc.4",
+  "version": "0.9.2-rc.5",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.2-rc.3",
+  "version": "0.9.2-rc.4",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.1-rc.6",
+  "version": "0.9.2-rc.1",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.2-rc.2",
+  "version": "0.9.2-rc.3",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.2-rc.1",
+  "version": "0.9.2-rc.2",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.2-rc.5",
+  "version": "0.9.2",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7950,7 +7950,7 @@ export default function App() {
                     {(dashboard.savingsBreakdown.toolSchemaTokensSaved ?? 0) > 0 ? (
                       <>
                         <div className="savings-breakdown__row">
-                          <span>Tool schemas deferred (Headroom)</span>
+                          <span>Additional costs saved (tool schemas deferred)</span>
                           <strong>{currencyExact(dashboard.savingsBreakdown.toolSchemaSavingsUsd ?? 0)}</strong>
                         </div>
                         {/* Priced at the cache-read rate, not the input rate --
@@ -7959,7 +7959,8 @@ export default function App() {
                           {compactNumber(dashboard.savingsBreakdown.toolSchemaTokensSaved ?? 0)} tokens
                           of tool definitions Headroom kept out of your requests until they were
                           needed. These sit at the front of the cached prefix, so they are priced at
-                          the provider's cache-read rate rather than the full input rate.
+                          the provider's cache-read rate rather than the full input rate. Counted in
+                          addition to the Total costs saved figure, not inside it.
                         </p>
                       </>
                     ) : null}


### PR DESCRIPTION
Stable 0.9.2 for all platforms. Highlights since 0.9.1:

- Savings: settle rollup backfill exactly instead of dropping a real day (lifetime card could read below "saved today")
- Windows: verbosity-baseline seeding never ran (bare $HOME) - output savings stayed $0
- Home: tool-schema savings moved out of the headline card into the drill-down as "Additional costs saved"
- Sub-$1 savings render with 2 decimals
- Windows stability fixes (RUST-9X, RUST-7M, RUST-6S)

No release notes for this version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)