### PR TITLE
Fix RUST-7M: intercept port bind failures on Windows update relaunch

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1811,6 +1811,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2",
+ "socket2",
  "sys-locale",
  "tar",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -59,6 +59,10 @@ mac-notification-sys = "0.6"
 [target.'cfg(target_os = "windows")'.dependencies]
 keyring = { version = "3", features = ["windows-native"] }
 windows-sys = { version = "0.60", features = ["Win32_Storage_FileSystem", "Win32_Foundation"] }
+# Windows-only: std/tokio set SO_REUSEADDR on Unix but not here, so rebinding
+# the intercept port over a previous instance's draining TIME_WAIT sockets
+# needs the option set by hand before bind. See `reuse_bound_std_listener`.
+socket2 = "0.6"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # Same crate as the Windows entry above, different backend: sync-secret-service

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -149,13 +149,17 @@ fn skip_sentry(target: &str, msg: &str) -> bool {
     // capture at the emit site (RUST-62); this warn repeats on every 15s bind
     // retry and only duplicated it (RUST-5R). Local log only.
     //
-    // Coupled to the emit site's wording in `proxy_intercept::spawn` -- if that
-    // message changes and this substring is not changed with it, the retry warn
-    // silently starts flooding Sentry again. `skips_foreign_port_bind_retry_warns`
-    // is the guard; keep its fixture a copy of the real message.
+    // Matched on the retry marker rather than one variant's prose: the emit
+    // site now says three different things about a held port (draining after a
+    // restart, stuck past the drain window, held by a named process), and
+    // keying on any single wording is what made this fragile before. Every
+    // bind-retry warn ends in the same "retrying in 15s" and every one of them
+    // has an explicit capture at the emit site, so they all belong here.
+    // `skips_foreign_port_bind_retry_warns` is the guard; keep its fixtures
+    // copies of the real messages.
     if target.starts_with("headroom_desktop_lib::proxy_intercept")
         && msg.starts_with("[proxy_intercept] port")
-        && msg.contains("held but not answering")
+        && msg.contains("retrying in 15s")
     {
         return true;
     }
@@ -593,9 +597,15 @@ mod tests {
 
     #[test]
     fn skips_foreign_port_bind_retry_warns() {
+        // Named foreign holder -- captured once at the emit site.
         assert!(skip_sentry(
             "headroom_desktop_lib::proxy_intercept",
-            "[proxy_intercept] port 6767 is held but not answering /health (leftover Headroom, another app, or a reserved range); retrying in 15s (Address already in use (os error 48))"
+            "[proxy_intercept] port 6767 is held by Affinity (pid 54915); retrying in 15s (Address already in use (os error 48))"
+        ));
+        // Stuck past the drain window -- also captured once at the emit site.
+        assert!(skip_sentry(
+            "headroom_desktop_lib::proxy_intercept",
+            "[proxy_intercept] port 6767 still in use with nothing listening after 420s; retrying in 15s (Only one usage of each socket address (protocol/network address/port) is normally permitted. (os error 10048))"
         ));
         // Other bind/loop errors from proxy_intercept stay in Sentry.
         assert!(!skip_sentry(

--- a/src-tauri/src/proxy_intercept.rs
+++ b/src-tauri/src/proxy_intercept.rs
@@ -478,6 +478,19 @@ pub(crate) enum HeldPortVerdict {
     Foreign { name: String, pid: u32 },
 }
 
+/// Whether a verdict makes a `SO_REUSEADDR` rebind safe.
+///
+/// Only `Draining` does, and the distinction is a correctness boundary rather
+/// than a preference. On Windows `SO_REUSEADDR` also permits binding over a
+/// socket that is actively LISTENING, so reusing on `Foreign` would bind us
+/// alongside a live holder, and reusing on any verdict reached while another
+/// Headroom held the port would defeat single-instance protection and split
+/// traffic across two proxies. `Draining` is the only verdict that guarantees
+/// nothing is listening.
+pub(crate) fn verdict_permits_reuse(verdict: &HeldPortVerdict) -> bool {
+    matches!(verdict, HeldPortVerdict::Draining)
+}
+
 pub(crate) fn classify_held_port(
     occupant: Option<(String, u32)>,
     elapsed: std::time::Duration,
@@ -578,9 +591,16 @@ pub fn spawn(
                 const DRAIN_GRACE: std::time::Duration = std::time::Duration::from_secs(300);
                 let launched_at = tokio::time::Instant::now();
                 let mut consecutive_failures = 0usize;
+                // Set only by the `Draining` verdict, which is the one case
+                // where nothing is listening and the port is held purely by
+                // sockets on their way out. Never reset: once we have
+                // established that, a plain bind has nothing left to prove,
+                // and `run` does not return after it binds.
+                let mut reuse_addr = false;
                 loop {
                     match run(
                         bind_addr,
+                        reuse_addr,
                         token_slot.clone(),
                         codex_slot.clone(),
                         codex_plan_slot.clone(),
@@ -667,11 +687,19 @@ pub fn spawn(
                                 let occupant =
                                     crate::tool_manager::listener_process(INTERCEPT_PORT);
                                 let key = os_error_key(&e);
-                                match classify_held_port(
+                                let verdict = classify_held_port(
                                     occupant,
                                     launched_at.elapsed(),
                                     DRAIN_GRACE,
-                                ) {
+                                );
+                                // Nothing listening means the only thing
+                                // holding the port is sockets draining, so the
+                                // next attempt can take it back now instead of
+                                // waiting out TcpTimedWaitDelay.
+                                if verdict_permits_reuse(&verdict) {
+                                    reuse_addr = true;
+                                }
+                                match verdict {
                                     HeldPortVerdict::Draining => {
                                         // Still a real outage from the user's
                                         // side, so the banner stays -- but it
@@ -794,8 +822,54 @@ pub fn spawn(
 }
 
 #[allow(clippy::too_many_arguments)]
+/// Bind the intercept port on Windows with `SO_REUSEADDR` set.
+///
+/// Rust sets `SO_REUSEADDR` for you on Unix but not on Windows, so a listener
+/// there cannot rebind a port whose previous owner left connections in
+/// TIME_WAIT -- which is every update relaunch, for up to `TcpTimedWaitDelay`
+/// (120s by default, 300s at most). That wait was RUST-7M.
+///
+/// Only ever reached from the `Draining` verdict, and that is load-bearing.
+/// `SO_REUSEADDR` on Windows also lets a bind succeed over a socket that is
+/// actively LISTENING, so using it unconditionally would let a second Headroom
+/// bind 6767 alongside the first and split traffic between two proxies -- the
+/// `probe_existing_intercept` branch relies on that bind failing. `Draining`
+/// is only reached when `listener_process` found nothing in LISTENING state,
+/// which rules out both another Headroom and a foreign holder, leaving the
+/// kernel's TIME_WAIT reservation as the only thing this can bind over.
+#[cfg(windows)]
+fn reuse_bound_std_listener(addr: SocketAddr) -> std::io::Result<std::net::TcpListener> {
+    use socket2::{Domain, Protocol, Socket, Type};
+
+    let socket = Socket::new(Domain::for_address(addr), Type::STREAM, Some(Protocol::TCP))?;
+    socket.set_reuse_address(true)?;
+    socket.bind(&addr.into())?;
+    // Matches the backlog tokio's own `TcpListener::bind` requests.
+    socket.listen(1024)?;
+    let listener: std::net::TcpListener = socket.into();
+    // tokio's reactor requires this; `from_std` documents it as the caller's job.
+    listener.set_nonblocking(true)?;
+    Ok(listener)
+}
+
+/// Plain bind, or a `SO_REUSEADDR` bind when the caller has established that
+/// nothing is listening and the port is only held by draining sockets.
+///
+/// `reuse_addr` is inert off Windows: Unix already sets the option, so the
+/// plain path there is the reuse path.
+async fn bind_intercept(addr: SocketAddr, reuse_addr: bool) -> std::io::Result<TcpListener> {
+    #[cfg(windows)]
+    if reuse_addr {
+        return TcpListener::from_std(reuse_bound_std_listener(addr)?);
+    }
+    #[cfg(not(windows))]
+    let _ = reuse_addr;
+    TcpListener::bind(addr).await
+}
+
 async fn run(
     bind_addr: SocketAddr,
+    reuse_addr: bool,
     token_slot: SharedToken,
     codex_slot: CodexRateLimitSlot,
     codex_plan_slot: CodexPlanSlot,
@@ -806,7 +880,7 @@ async fn run(
     upstream_base: Arc<String>,
     bind_error: BindErrorSlot,
 ) -> std::io::Result<()> {
-    let listener = TcpListener::bind(bind_addr).await?;
+    let listener = bind_intercept(bind_addr, reuse_addr).await?;
     // Serving again: clear whatever the previous attempt recorded so a
     // recovered port stops showing a stale cause in the UI.
     *bind_error.lock() = None;
@@ -2757,7 +2831,7 @@ fn extract_bearer(buf: &[u8]) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        bearer_value_changed, classify_held_port, codex_error_summary,
+        bearer_value_changed, bind_intercept, classify_held_port, codex_error_summary,
         codex_snapshot_from_usage_payload, codex_window_label, decode_codex_plan_tier,
         extract_bearer, extract_header_value, find_header_end, intercept_request_counts,
         is_codex_request_head, is_codex_sse_response, is_hop_by_hop_request_header,
@@ -2767,8 +2841,8 @@ mod tests {
         request_is_loopback_safe, request_uses_chatgpt_auth, rewrite_use_responses_lite, run,
         sanitize_stale_tool_references, set_response_content_length, should_report_throttled,
         stamp_client_header, stamp_codex_client_header, stamp_headroom_bypass_header,
-        stamp_request_header, strip_request_header, BypassFlag, CodexTerminalReader,
-        HeldPortVerdict, ModelsRewrite, ParsedRequestHead, SharedToken,
+        stamp_request_header, strip_request_header, verdict_permits_reuse, BypassFlag,
+        CodexTerminalReader, HeldPortVerdict, ModelsRewrite, ParsedRequestHead, SharedToken,
         FIRST_OPTIMIZED_REQUEST_REPORTED,
     };
     use crate::backend_port;
@@ -2828,6 +2902,37 @@ mod tests {
             classify_held_port(None, std::time::Duration::from_secs(91), HELD_GRACE),
             HeldPortVerdict::Draining
         );
+    }
+
+    /// The safety boundary for the SO_REUSEADDR rebind. Draining is the only
+    /// verdict that establishes nothing is listening, and on Windows
+    /// SO_REUSEADDR binds over live listeners too -- so widening this to any
+    /// other verdict would let a second Headroom bind 6767 alongside the
+    /// first, or park us next to a foreign holder, instead of failing.
+    #[test]
+    fn only_a_draining_port_may_be_rebound_with_reuseaddr() {
+        assert!(verdict_permits_reuse(&HeldPortVerdict::Draining));
+        assert!(!verdict_permits_reuse(&HeldPortVerdict::Stuck));
+        assert!(!verdict_permits_reuse(&HeldPortVerdict::Foreign {
+            name: "Affinity".into(),
+            pid: 54915
+        }));
+    }
+
+    /// Off Windows the flag is inert (Unix already sets SO_REUSEADDR), so both
+    /// paths must still produce a usable listener.
+    #[tokio::test]
+    async fn bind_intercept_binds_either_way() {
+        for reuse in [false, true] {
+            let listener = bind_intercept("127.0.0.1:0".parse().unwrap(), reuse)
+                .await
+                .expect("bind");
+            let addr = listener.local_addr().expect("local_addr");
+            assert_ne!(addr.port(), 0);
+            let joined = tokio::spawn(async move { listener.accept().await.is_ok() });
+            let _client = TcpStream::connect(addr).await.expect("connect");
+            assert!(joined.await.expect("join"));
+        }
     }
 
     #[test]
@@ -3152,6 +3257,7 @@ mod tests {
             // run() loops forever; the test cancels it via abort below.
             let _ = run(
                 intercept_addr,
+                false,
                 slot_for_run,
                 Arc::new(Mutex::new(None)),
                 Arc::new(Mutex::new(None)),
@@ -3257,6 +3363,7 @@ mod tests {
         let run_task = tokio::spawn(async move {
             let _ = run(
                 intercept_addr,
+                false,
                 Arc::new(Mutex::new(None)),
                 Arc::new(Mutex::new(None)),
                 Arc::new(Mutex::new(None)),
@@ -3336,6 +3443,7 @@ mod tests {
         let run_task = tokio::spawn(async move {
             let _ = run(
                 intercept_addr,
+                false,
                 slot_for_run,
                 Arc::new(Mutex::new(None)),
                 Arc::new(Mutex::new(None)),
@@ -3914,6 +4022,7 @@ mod tests {
         let run_task = tokio::spawn(async move {
             let _ = run(
                 intercept_addr,
+                false,
                 token_for_run,
                 Arc::new(Mutex::new(None)),
                 Arc::new(Mutex::new(None)),
@@ -4059,6 +4168,7 @@ mod tests {
         let run_task = tokio::spawn(async move {
             let _ = run(
                 intercept_addr,
+                false,
                 token_slot,
                 Arc::new(Mutex::new(None)),
                 Arc::new(Mutex::new(None)),
@@ -4162,6 +4272,7 @@ mod tests {
         let run_task = tokio::spawn(async move {
             let _ = run(
                 intercept_addr,
+                false,
                 token_for_run,
                 Arc::new(Mutex::new(None)),
                 Arc::new(Mutex::new(None)),
@@ -4503,6 +4614,7 @@ mod tests {
         let run_task = tokio::spawn(async move {
             let _ = run(
                 intercept_addr,
+                false,
                 slot_for_run,
                 Arc::new(Mutex::new(None)),
                 Arc::new(Mutex::new(None)),
@@ -4616,6 +4728,7 @@ mod tests {
         let run_task = tokio::spawn(async move {
             let _ = run(
                 intercept_addr,
+                false,
                 slot_for_run,
                 Arc::new(Mutex::new(None)),
                 Arc::new(Mutex::new(None)),

--- a/src-tauri/src/proxy_intercept.rs
+++ b/src-tauri/src/proxy_intercept.rs
@@ -457,6 +457,39 @@ pub type FreshBearerNotifier = mpsc::Sender<()>;
 pub const ANTHROPIC_DIRECT_BASE: &str = "https://api.anthropic.com";
 pub const OPENAI_DIRECT_BASE: &str = "https://api.openai.com";
 
+/// What a held intercept port means, given who (if anyone) is listening on it
+/// and how long we have been trying.
+///
+/// Split out from the bind loop so the decision is testable: the loop itself
+/// is an infinite async retry that cannot be driven from a unit test.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HeldPortVerdict {
+    /// Bind says in-use but nothing is LISTENING, and we are still inside the
+    /// window where a previous instance's sockets could be draining. Windows
+    /// only in practice: Rust sets `SO_REUSEADDR` on Unix but not there, so an
+    /// exiting instance's accepted connections hold the port through
+    /// TIME_WAIT. Self-healing, so it is not worth an error report.
+    Draining,
+    /// Same shape, but past the longest drain Windows can be configured for
+    /// (`TcpTimedWaitDelay` maxes at 300s). No longer safe to assume it clears.
+    Stuck,
+    /// A live foreign listener. Does not clear on its own, and we can name it,
+    /// so this is the one the user can actually act on.
+    Foreign { name: String, pid: u32 },
+}
+
+pub(crate) fn classify_held_port(
+    occupant: Option<(String, u32)>,
+    elapsed: std::time::Duration,
+    drain_grace: std::time::Duration,
+) -> HeldPortVerdict {
+    match occupant {
+        Some((name, pid)) => HeldPortVerdict::Foreign { name, pid },
+        None if elapsed < drain_grace => HeldPortVerdict::Draining,
+        None => HeldPortVerdict::Stuck,
+    }
+}
+
 /// Locale-invariant identity for an OS error.
 ///
 /// `io::Error`'s `Display` is the *localized* platform string, so keying a
@@ -536,6 +569,13 @@ pub fn spawn(
                 // this; anything still held after it is something the user has
                 // to be told about.
                 const HINT_GRACE: std::time::Duration = std::time::Duration::from_secs(15);
+                // Past RELAUNCH_GRACE a held port is still not necessarily a
+                // problem: on Windows the exiting instance's accepted
+                // connections hold the port through TIME_WAIT with nothing
+                // in LISTENING state, and `TcpTimedWaitDelay` tops out at
+                // 300s. Below that a listener-less port is still draining;
+                // above it, it is stuck and worth saying so.
+                const DRAIN_GRACE: std::time::Duration = std::time::Duration::from_secs(300);
                 let launched_at = tokio::time::Instant::now();
                 let mut consecutive_failures = 0usize;
                 loop {
@@ -608,25 +648,104 @@ pub fn spawn(
                                         continue;
                                     }
                                 }
-                                log::warn!(
-                                    "[proxy_intercept] port {INTERCEPT_PORT} is held but not answering /health (leftover Headroom, another app, or a reserved range); retrying in 15s ({e})"
-                                );
+                                // Who actually holds it decides whether this
+                                // is worth a report. `listener_process` only
+                                // ever names a socket in LISTENING state, so
+                                // `None` here means bind says in-use while
+                                // nothing is listening -- on Windows that is
+                                // the previous instance's accepted connections
+                                // draining through TIME_WAIT, because Rust
+                                // sets SO_REUSEADDR on Unix but not there.
+                                // RUST-7M was exactly this: one event per
+                                // update relaunch, Windows-only, every one of
+                                // them self-healing. Reporting it filed an
+                                // error at the user that named no cause they
+                                // could act on and that fixed itself minutes
+                                // later. `Some` is the opposite case -- a live
+                                // foreign listener, which does not clear on
+                                // its own and which we can name.
+                                let occupant =
+                                    crate::tool_manager::listener_process(INTERCEPT_PORT);
                                 let key = os_error_key(&e);
-                                if reported_errors.insert(format!("foreign:{key}")) {
-                                    sentry::with_scope(
-                                        |scope| {
-                                            scope.set_extra(
-                                                "os_error", e.to_string().into());
-                                        },
-                                        || {
-                                            sentry::capture_message(
-                                                &format!(
-                                                    "proxy_intercept bind failed: {key} (port {INTERCEPT_PORT} held but not answering /health; retrying)"
-                                                ),
-                                                sentry::Level::Error,
+                                match classify_held_port(
+                                    occupant,
+                                    launched_at.elapsed(),
+                                    DRAIN_GRACE,
+                                ) {
+                                    HeldPortVerdict::Draining => {
+                                        // Still a real outage from the user's
+                                        // side, so the banner stays -- but it
+                                        // says what is happening instead of
+                                        // the bare OS string, which reads as
+                                        // "the runtime is broken".
+                                        *bind_error.lock() = Some(format!(
+                                            "port {INTERCEPT_PORT} is still being released after a restart; reconnecting"
+                                        ));
+                                        log::info!(
+                                            "[proxy_intercept] port {INTERCEPT_PORT} in use but nothing is listening {}s after launch (a previous instance's sockets draining looks exactly like this); retrying in 15s ({e})",
+                                            launched_at.elapsed().as_secs()
+                                        );
+                                    }
+                                    HeldPortVerdict::Stuck => {
+                                        // Past the longest drain Windows can
+                                        // be configured for, so "it will
+                                        // clear itself" has stopped being
+                                        // true. Nothing to name, but worth
+                                        // knowing about.
+                                        log::warn!(
+                                            "[proxy_intercept] port {INTERCEPT_PORT} still in use with nothing listening after {}s; retrying in 15s ({e})",
+                                            launched_at.elapsed().as_secs()
+                                        );
+                                        if reported_errors.insert(format!("stuck:{key}")) {
+                                            sentry::with_scope(
+                                                |scope| {
+                                                    scope.set_extra(
+                                                        "os_error", e.to_string().into());
+                                                    scope.set_extra(
+                                                        "held_secs",
+                                                        launched_at.elapsed().as_secs().into());
+                                                },
+                                                || {
+                                                    sentry::capture_message(
+                                                        &format!(
+                                                            "proxy_intercept bind failed: {key} (port {INTERCEPT_PORT} in use with no listener past the drain window; retrying)"
+                                                        ),
+                                                        sentry::Level::Error,
+                                                    );
+                                                },
                                             );
-                                        },
-                                    );
+                                        }
+                                    }
+                                    HeldPortVerdict::Foreign { name, pid } => {
+                                        // Actionable: the user can quit this.
+                                        // Reclaim already declined it, so it
+                                        // is not one of ours.
+                                        log::warn!(
+                                            "[proxy_intercept] port {INTERCEPT_PORT} is held by {name} (pid {pid}); retrying in 15s ({e})"
+                                        );
+                                        *bind_error.lock() = Some(format!(
+                                            "port {INTERCEPT_PORT} is held by {name} (pid {pid})"
+                                        ));
+                                        if reported_errors.insert(format!("foreign:{key}:{name}")) {
+                                            sentry::with_scope(
+                                                |scope| {
+                                                    scope.set_extra(
+                                                        "os_error", e.to_string().into());
+                                                    scope.set_extra(
+                                                        "occupant", name.clone().into());
+                                                    scope.set_extra("occupant_pid", pid.into());
+                                                },
+                                                || {
+                                                    sentry::capture_message(
+                                                        &format!(
+                                                            "proxy_intercept bind failed: {key} (port {INTERCEPT_PORT} held by {name}; retrying)"
+                                                        ),
+                                                        sentry::Level::Error,
+                                                    );
+                                                },
+                                            );
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -2638,18 +2757,19 @@ fn extract_bearer(buf: &[u8]) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        bearer_value_changed, codex_error_summary, codex_snapshot_from_usage_payload,
-        codex_window_label, decode_codex_plan_tier, extract_bearer, extract_header_value,
-        find_header_end, intercept_request_counts, is_codex_request_head, is_codex_sse_response,
-        is_hop_by_hop_request_header, is_hop_by_hop_response_header, is_local_proxy_path,
-        is_openai_path, is_prompt_request_head, is_reportable_codex_error, os_error_key,
-        parse_codex_rate_limit_headers, parse_request_head, parse_response_status,
-        read_http_headers, request_has_header, request_is_loopback_safe, request_uses_chatgpt_auth,
-        rewrite_use_responses_lite, run, sanitize_stale_tool_references,
-        set_response_content_length, should_report_throttled, stamp_client_header,
-        stamp_codex_client_header, stamp_headroom_bypass_header, stamp_request_header,
-        strip_request_header, BypassFlag, CodexTerminalReader, ModelsRewrite, ParsedRequestHead,
-        SharedToken, FIRST_OPTIMIZED_REQUEST_REPORTED,
+        bearer_value_changed, classify_held_port, codex_error_summary,
+        codex_snapshot_from_usage_payload, codex_window_label, decode_codex_plan_tier,
+        extract_bearer, extract_header_value, find_header_end, intercept_request_counts,
+        is_codex_request_head, is_codex_sse_response, is_hop_by_hop_request_header,
+        is_hop_by_hop_response_header, is_local_proxy_path, is_openai_path, is_prompt_request_head,
+        is_reportable_codex_error, os_error_key, parse_codex_rate_limit_headers,
+        parse_request_head, parse_response_status, read_http_headers, request_has_header,
+        request_is_loopback_safe, request_uses_chatgpt_auth, rewrite_use_responses_lite, run,
+        sanitize_stale_tool_references, set_response_content_length, should_report_throttled,
+        stamp_client_header, stamp_codex_client_header, stamp_headroom_bypass_header,
+        stamp_request_header, strip_request_header, BypassFlag, CodexTerminalReader,
+        HeldPortVerdict, ModelsRewrite, ParsedRequestHead, SharedToken,
+        FIRST_OPTIMIZED_REQUEST_REPORTED,
     };
     use crate::backend_port;
     use crate::bearer::BearerToken;
@@ -2683,6 +2803,71 @@ mod tests {
         // Non-OS errors have no code; fall back to the text so they stay distinct.
         let synthetic = std::io::Error::other("synthesized by a wrapper");
         assert_eq!(os_error_key(&synthetic), "synthesized by a wrapper");
+    }
+
+    const HELD_GRACE: std::time::Duration = std::time::Duration::from_secs(300);
+
+    /// RUST-7M: Windows-only, one event per update relaunch, every one
+    /// self-healing. Nothing is LISTENING because the port is held by the
+    /// previous instance's connections in TIME_WAIT, so there is no pid to
+    /// name and nothing for the user to do about it.
+    #[test]
+    fn a_listener_less_port_inside_the_grace_is_draining_not_an_error() {
+        assert_eq!(
+            classify_held_port(None, std::time::Duration::from_secs(120), HELD_GRACE),
+            HeldPortVerdict::Draining
+        );
+    }
+
+    /// The 90s RELAUNCH_GRACE expires while Windows' TcpTimedWaitDelay (120s
+    /// by default) is still running, which is exactly why RUST-7M reported at
+    /// all. Past 90s but inside the drain window must stay quiet.
+    #[test]
+    fn the_relaunch_grace_alone_does_not_cover_the_windows_drain() {
+        assert_eq!(
+            classify_held_port(None, std::time::Duration::from_secs(91), HELD_GRACE),
+            HeldPortVerdict::Draining
+        );
+    }
+
+    #[test]
+    fn a_listener_less_port_past_the_grace_is_stuck() {
+        assert_eq!(
+            classify_held_port(None, std::time::Duration::from_secs(301), HELD_GRACE),
+            HeldPortVerdict::Stuck
+        );
+    }
+
+    /// A named holder does not clear on its own, so the drain window is
+    /// irrelevant to it -- report immediately rather than sitting on it 300s.
+    #[test]
+    fn a_live_listener_is_foreign_however_early_it_shows_up() {
+        assert_eq!(
+            classify_held_port(
+                Some(("Affinity".into(), 54915)),
+                std::time::Duration::from_secs(1),
+                HELD_GRACE
+            ),
+            HeldPortVerdict::Foreign {
+                name: "Affinity".into(),
+                pid: 54915
+            }
+        );
+    }
+
+    #[test]
+    fn a_live_listener_past_the_grace_is_still_named_not_stuck() {
+        assert_eq!(
+            classify_held_port(
+                Some(("node".into(), 99)),
+                std::time::Duration::from_secs(9_999),
+                HELD_GRACE
+            ),
+            HeldPortVerdict::Foreign {
+                name: "node".into(),
+                pid: 99
+            }
+        );
     }
     use tokio::time::{timeout, Duration};
 

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -7439,7 +7439,7 @@ fn probe_headroom_http(port: u16, timeout: Duration) -> bool {
 /// `None` means "could not identify the listener" — never "nothing is
 /// listening" and never "it is not ours". Both the port-reclaim kill path and
 /// the stale-argv check hang off this, so neither may treat None as evidence.
-fn listener_process(port: u16) -> Option<(String, u32)> {
+pub(crate) fn listener_process(port: u16) -> Option<(String, u32)> {
     for lsof in ["/usr/sbin/lsof", "/usr/bin/lsof"] {
         // Only `-iTCP:{port}` — a bare `-iTCP` here would OR with the port
         // selector (lsof ORs `-i` options) and match every listening socket on


### PR DESCRIPTION
## Summary

RUST-7M (`proxy_intercept bind failed: os error 10048`) fired once per update relaunch, Windows-only (20/20 events), and every occurrence healed itself. The 90s `RELAUNCH_GRACE` added in rc18 was meant to cover exactly this and did not, because it is shorter than the window it has to outlast. The issue was still firing on 0.9.2, 22 minutes after #65 merged.

**Root cause:** `proxy_intercept` bound with a plain `TcpListener::bind`, and std/tokio set `SO_REUSEADDR` on Unix but **not on Windows**. After the old instance exits, its accepted connections hold 6767 through TIME_WAIT, whose `TcpTimedWaitDelay` defaults to 120s and can be configured up to 300s. Both exceed the 90s grace, so the retry escalated to a Sentry error while the port was still draining normally. macOS never saw it because `SO_REUSEADDR` is set there by default.

The same single cause produced the two symptoms that made this look like a foreign process squatting the port: nothing answers `/health` because no process owns the port, and `reclaim_stranded_intercept_holder` bails at its first guard because `parse_netstat_listener` only matches rows in state `LISTENING`, and a TIME_WAIT row is not one.

Evidence: the release histogram is one event per release (`0.9.0` 04:37, `0.9.1` 12:31, `0.9.2` 14:00, one each), `os.name` is `windows` for 20 of 20 events, and the affected user had Headroom working earlier (RUST-5B, "backend processed requests", release 0.8.4).

## Changes

**1. Classify the held port by who is actually listening**, replacing a single post-grace path that treated every failure alike:

- nothing listening, inside the drain window -> `Draining`. Log only, and a banner that says a restart is finishing rather than the bare OS string, which reads as a broken runtime.
- nothing listening, past 300s -> `Stuck`. No longer self-healing, so report it with how long it has been held.
- a live listener -> `Foreign`. Name the process and pid in both banner and report. This is the RUST-87 shape (Affinity holding 6767) reaching the bind path, and the only case a user can act on.

`classify_held_port` is a pure function because the bind loop is an infinite async retry that cannot be driven from a test.

**2. Rebind over draining sockets on Windows** via `socket2`, so the relaunch takes the port back immediately instead of waiting out `TcpTimedWaitDelay`.

## Why the reuse bind is gated on `Draining`

This is a correctness boundary, not tidiness. On Windows `SO_REUSEADDR` also lets a bind succeed over a socket that is actively `LISTENING`. Setting it unconditionally would let a second Headroom bind 6767 alongside the first and split traffic across two proxies, because the `probe_existing_intercept` branch depends on that bind failing.

`Draining` is only reached when `listener_process` found nothing in `LISTENING` state, which rules out both another Headroom and a foreign holder, leaving the kernel's TIME_WAIT reservation as the only thing the reuse bind can take over. `verdict_permits_reuse` encodes that boundary and is tested against all three verdicts, so widening it later has to be deliberate.

## Note on the log bridge

`logging.rs` skipped the 15s retry warns from Sentry by matching the literal phrase `"held but not answering"`, which this change removes. Its own comment warned that letting the two drift would silently flood Sentry with those warns. Re-keyed on the `"retrying in 15s"` marker every variant shares, with test fixtures updated to copies of the new real messages.

## Testing

- `cargo test --lib`: 1020 passed. Two failures in `client_adapters` (`purge_dir_tolerantly_skips_past_an_undeletable_entry`, `remove_dir_all_retry_clears_readonly_instead_of_giving_up`) are pre-existing and fail identically on a clean tree, because the container runs as root and root ignores the readonly bits those tests depend on.
- 7 new tests covering the classifier, the reuse gate, and both bind paths.
- Cross-checked the `x86_64-pc-windows-gnu` target, including confirming the `cfg(windows)` body is really compiled rather than skipped (verified by introducing a deliberate type error and watching it fail there).

**Runtime behavior on Windows is unverified here** — this container is Linux, where the reuse flag is inert because Unix already sets the option. The relaunch path needs a VM pass: update from a prior build and confirm the proxy rebinds 6767 immediately instead of after ~2 minutes, and that a second instance still cannot bind alongside the first.

`socket2` is declared only under `cfg(target_os = "windows")` and resolves to the 0.6 already in the tree via hyper, so this adds no new crate version.

## Not included

This does not close RUST-7M automatically. The false report is gone and the wait should be too, but I left the trailer off pending the VM pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7H98SzcHgztBWtiGceukb

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7H98SzcHgztBWtiGceukb)_