### PR TITLE
Make the ignored-issue backlog actionable: RUST-4H, RUST-87, RUST-4V

### DIFF
--- a/src-tauri/src/proxy_intercept.rs
+++ b/src-tauri/src/proxy_intercept.rs
@@ -1490,10 +1490,19 @@ fn report_codex_upstream_error(status: u16, req_path: &str, head: &[u8], chunk: 
     // challenges and real 502/503 connection errors into one un-triageable
     // bucket that regresses the moment any sibling status reappears (RUST-46).
     let status_str = status.to_string();
+    // Tags, not extras: an extra can only be read one event at a time, so the
+    // shape RUST-4V's 578 events shared was never visible from the issue view.
+    // Both values are bounded and content-free, so they stay aggregatable.
+    let shape = codex_error_shape_tag(&body);
+    let content_type = response_content_type(head);
     sentry::with_scope(
         |scope| {
             scope.set_tag("codex_upstream_status", status);
             scope.set_tag("codex_request_path", &path);
+            scope.set_tag("codex_error_shape", &shape);
+            if let Some(content_type) = content_type.as_deref() {
+                scope.set_tag("codex_response_content_type", content_type);
+            }
             scope.set_extra("error_body", snippet.clone().into());
             scope.set_fingerprint(Some(&["codex-upstream-error", status_str.as_str()]));
         },
@@ -1516,6 +1525,15 @@ fn is_geo_blocked_codex_error(body: &[u8]) -> bool {
     err.get("code").and_then(|v| v.as_str()) == Some("unsupported_country_region_territory")
 }
 
+/// The response's media type with any parameters (`; charset=...`) stripped, so
+/// it stays a low-cardinality tag. Distinguishes a JSON error from an HTML
+/// gateway page or an SSE frame without reading a byte of the body.
+fn response_content_type(head: &[u8]) -> Option<String> {
+    let value = extract_header_value(head, "content-type")?;
+    let media_type = value.split(';').next()?.trim().to_ascii_lowercase();
+    (!media_type.is_empty()).then_some(media_type)
+}
+
 /// Reduce an upstream error body to structural fields safe for Sentry:
 /// `error.type` / `error.code` / `error.param`, never free-text (the
 /// `message` field and raw bodies can quote request content).
@@ -1523,21 +1541,87 @@ fn codex_error_summary(body: &[u8]) -> String {
     match serde_json::from_slice::<serde_json::Value>(body) {
         Ok(json) => {
             let err = json.get("error").unwrap_or(&json);
-            let field = |key: &str| {
-                err.get(key)
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("-")
-                    .to_string()
-            };
+            let field = |key: &str| err.get(key).and_then(|v| v.as_str());
+            let (kind, code, param) = (field("type"), field("code"), field("param"));
+            // All three absent means the body parsed but carried none of the
+            // schema we know how to read, and "type=- code=- param=-" then
+            // says only "something failed" -- RUST-4V collected 578 events
+            // that were all exactly that string and stayed untriageable for
+            // two months. Describe the shape instead, so the next one is a
+            // lead rather than another tally mark.
+            if kind.is_none() && code.is_none() && param.is_none() {
+                return format!(
+                    "no structural error fields; shape={} ({} bytes)",
+                    codex_error_body_shape(&json),
+                    body.len()
+                );
+            }
             format!(
                 "type={} code={} param={}",
-                field("type"),
-                field("code"),
-                field("param")
+                kind.unwrap_or("-"),
+                code.unwrap_or("-"),
+                param.unwrap_or("-")
             )
         }
         // Truncated (peek is bounded) or non-JSON body — report size only.
         Err(_) => format!("unparseable error body ({} bytes)", body.len()),
+    }
+}
+
+/// Content-free descriptor of an error body's JSON shape.
+///
+/// Key NAMES are schema; only values can quote the request, and none are read
+/// here. Top-level keys of an HTTP error body are chosen by the API, not by the
+/// user, so naming them cannot leak prompt content even when a 400 echoes
+/// request fields. `is_safe_shape_key` is the belt-and-braces: anything that
+/// does not look like an identifier is dropped rather than forwarded.
+fn codex_error_body_shape(json: &serde_json::Value) -> String {
+    use serde_json::Value;
+    match json {
+        Value::Object(map) => {
+            let mut keys: Vec<&str> = map
+                .keys()
+                .map(String::as_str)
+                .filter(|key| is_safe_shape_key(key))
+                .collect();
+            keys.sort_unstable();
+            keys.truncate(SHAPE_MAX_KEYS);
+            format!("object{{{}}}", keys.join(","))
+        }
+        Value::Array(_) => "array".to_string(),
+        Value::String(_) => "string".to_string(),
+        Value::Number(_) => "number".to_string(),
+        Value::Bool(_) => "bool".to_string(),
+        Value::Null => "null".to_string(),
+    }
+}
+
+/// Cap on keys named in a shape descriptor. Bounds both the message length and
+/// the cardinality of the `codex_error_shape` tag built from it.
+const SHAPE_MAX_KEYS: usize = 8;
+
+/// Whether a JSON key is safe to forward as schema: a short, identifier-shaped
+/// name. Rejects anything long or punctuated, which is what a key carrying
+/// user content would look like.
+fn is_safe_shape_key(key: &str) -> bool {
+    !key.is_empty()
+        && key.len() <= 32
+        && key
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.')
+}
+
+/// The shape descriptor as a Sentry TAG value.
+///
+/// Deliberately a tag and not an extra: extras cannot be aggregated or
+/// searched, so `error_body` could only ever be read one event at a time --
+/// which is why RUST-4V's 578 events never revealed that they shared one
+/// shape. A tag makes "which shapes are these?" a single query.
+fn codex_error_shape_tag(body: &[u8]) -> String {
+    match serde_json::from_slice::<serde_json::Value>(body) {
+        Ok(json) => codex_error_body_shape(&json),
+        Err(_) if body.is_empty() => "empty".to_string(),
+        Err(_) => "non-json".to_string(),
     }
 }
 
@@ -2659,14 +2743,15 @@ fn extract_bearer(buf: &[u8]) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        bearer_value_changed, codex_error_summary, codex_snapshot_from_usage_payload,
-        codex_window_label, decode_codex_plan_tier, extract_bearer, extract_header_value,
-        find_header_end, intercept_request_counts, is_codex_request_head, is_codex_sse_response,
-        is_geo_blocked_codex_error, is_hop_by_hop_request_header, is_hop_by_hop_response_header,
-        is_local_proxy_path, is_openai_path, is_prompt_request_head, is_reportable_codex_error,
-        os_error_key, parse_codex_rate_limit_headers, parse_request_head, parse_response_status,
+        bearer_value_changed, codex_error_shape_tag, codex_error_summary,
+        codex_snapshot_from_usage_payload, codex_window_label, decode_codex_plan_tier,
+        extract_bearer, extract_header_value, find_header_end, intercept_request_counts,
+        is_codex_request_head, is_codex_sse_response, is_geo_blocked_codex_error,
+        is_hop_by_hop_request_header, is_hop_by_hop_response_header, is_local_proxy_path,
+        is_openai_path, is_prompt_request_head, is_reportable_codex_error, os_error_key,
+        parse_codex_rate_limit_headers, parse_request_head, parse_response_status,
         read_http_headers, request_has_header, request_is_loopback_safe, request_uses_chatgpt_auth,
-        rewrite_use_responses_lite, run, sanitize_stale_tool_references,
+        response_content_type, rewrite_use_responses_lite, run, sanitize_stale_tool_references,
         set_response_content_length, should_report_throttled, stamp_client_header,
         stamp_codex_client_header, stamp_headroom_bypass_header, stamp_request_header,
         strip_request_header, BypassFlag, CodexTerminalReader, ModelsRewrite, ParsedRequestHead,
@@ -4552,6 +4637,82 @@ mod tests {
             codex_error_summary(b"<html>gateway error</html>"),
             "unparseable error body (26 bytes)"
         );
+    }
+
+    #[test]
+    fn codex_error_summary_describes_shape_when_fields_are_absent() {
+        // The RUST-4V case: valid JSON, none of type/code/param, which used to
+        // render as the useless "type=- code=- param=-".
+        let summary = codex_error_summary(br#"{"detail":"nope","status":400}"#);
+        assert_eq!(
+            summary,
+            "no structural error fields; shape=object{detail,status} (30 bytes)"
+        );
+        // `{"error": "..."}` — error present but a string, so no fields resolve.
+        assert_eq!(
+            codex_error_summary(br#"{"error":"boom"}"#),
+            "no structural error fields; shape=object{error} (16 bytes)"
+        );
+        // An empty object and a bare null are both distinguishable now.
+        assert_eq!(
+            codex_error_summary(b"{}"),
+            "no structural error fields; shape=object{} (2 bytes)"
+        );
+        assert_eq!(
+            codex_error_summary(b"null"),
+            "no structural error fields; shape=null (4 bytes)"
+        );
+    }
+
+    #[test]
+    fn codex_error_summary_still_prefers_structural_fields() {
+        // A partially-populated body must keep the field rendering, not fall
+        // through to the shape branch.
+        assert_eq!(
+            codex_error_summary(br#"{"error":{"code":"invalid_prompt"}}"#),
+            "type=- code=invalid_prompt param=-"
+        );
+    }
+
+    #[test]
+    fn codex_error_shape_tag_stays_low_cardinality_and_content_free() {
+        assert_eq!(
+            codex_error_shape_tag(br#"{"error":{"code":"x"}}"#),
+            "object{error}"
+        );
+        assert_eq!(codex_error_shape_tag(b"<html>502</html>"), "non-json");
+        assert_eq!(codex_error_shape_tag(b""), "empty");
+        assert_eq!(codex_error_shape_tag(b"[]"), "array");
+
+        // Keys are sorted (stable tag value) and capped at SHAPE_MAX_KEYS.
+        let many = (0..20)
+            .map(|i| format!("\"k{i:02}\":1"))
+            .collect::<Vec<_>>()
+            .join(",");
+        let tag = codex_error_shape_tag(format!("{{{many}}}").as_bytes());
+        assert_eq!(tag, "object{k00,k01,k02,k03,k04,k05,k06,k07}");
+
+        // A key shaped like user content is dropped rather than forwarded.
+        let leaky = br#"{"Summarise this: my password is hunter2":1,"detail":2}"#;
+        let tag = codex_error_shape_tag(leaky);
+        assert_eq!(tag, "object{detail}");
+        assert!(!tag.contains("hunter2"), "{tag}");
+    }
+
+    #[test]
+    fn response_content_type_strips_parameters() {
+        let head =
+            b"HTTP/1.1 400 Bad Request\r\nContent-Type: application/json; charset=utf-8\r\n\r\n";
+        assert_eq!(
+            response_content_type(head).as_deref(),
+            Some("application/json")
+        );
+        let sse = b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n";
+        assert_eq!(
+            response_content_type(sse).as_deref(),
+            Some("text/event-stream")
+        );
+        assert_eq!(response_content_type(b"HTTP/1.1 400 Bad\r\n\r\n"), None);
     }
 
     #[test]

--- a/src-tauri/src/proxy_intercept.rs
+++ b/src-tauri/src/proxy_intercept.rs
@@ -1473,6 +1473,17 @@ fn report_codex_upstream_error(status: u16, req_path: &str, head: &[u8], chunk: 
     if (500..600).contains(&status) {
         return;
     }
+    // A geo-block is a property of where the user is, not of anything we sent:
+    // OpenAI refuses the request before it is ever evaluated, and no release we
+    // ship can change the outcome. Same reasoning that already excludes 401 and
+    // 429 above, applied one level deeper because the status alone does not say
+    // it -- a 403 can also be an org-verification challenge, which IS
+    // actionable, so the body's `code` is what splits them. RUST-4H collected
+    // 139 of these from hosts in unsupported regions. The raw body still
+    // reaches the local log::warn! above.
+    if is_geo_blocked_codex_error(&body) {
+        return;
+    }
     // Group by status so each upstream failure class is its own Sentry issue.
     // Without an explicit fingerprint, Sentry parameterizes the message
     // ("codex upstream error {status} on {path}") and collapses 401 noise, 403
@@ -1493,6 +1504,16 @@ fn report_codex_upstream_error(status: u16, req_path: &str, head: &[u8], chunk: 
             );
         },
     );
+}
+
+/// True when an upstream error body carries OpenAI's unsupported-region code.
+/// Only the structural `code` field is read; no free text is inspected or kept.
+fn is_geo_blocked_codex_error(body: &[u8]) -> bool {
+    let Ok(json) = serde_json::from_slice::<serde_json::Value>(body) else {
+        return false;
+    };
+    let err = json.get("error").unwrap_or(&json);
+    err.get("code").and_then(|v| v.as_str()) == Some("unsupported_country_region_territory")
 }
 
 /// Reduce an upstream error body to structural fields safe for Sentry:
@@ -2641,9 +2662,9 @@ mod tests {
         bearer_value_changed, codex_error_summary, codex_snapshot_from_usage_payload,
         codex_window_label, decode_codex_plan_tier, extract_bearer, extract_header_value,
         find_header_end, intercept_request_counts, is_codex_request_head, is_codex_sse_response,
-        is_hop_by_hop_request_header, is_hop_by_hop_response_header, is_local_proxy_path,
-        is_openai_path, is_prompt_request_head, is_reportable_codex_error, os_error_key,
-        parse_codex_rate_limit_headers, parse_request_head, parse_response_status,
+        is_geo_blocked_codex_error, is_hop_by_hop_request_header, is_hop_by_hop_response_header,
+        is_local_proxy_path, is_openai_path, is_prompt_request_head, is_reportable_codex_error,
+        os_error_key, parse_codex_rate_limit_headers, parse_request_head, parse_response_status,
         read_http_headers, request_has_header, request_is_loopback_safe, request_uses_chatgpt_auth,
         rewrite_use_responses_lite, run, sanitize_stale_tool_references,
         set_response_content_length, should_report_throttled, stamp_client_header,
@@ -4531,6 +4552,29 @@ mod tests {
             codex_error_summary(b"<html>gateway error</html>"),
             "unparseable error body (26 bytes)"
         );
+    }
+
+    #[test]
+    fn geo_blocked_codex_error_detects_unsupported_region() {
+        // The exact shape RUST-4H captured 139 times.
+        let body = br#"{"error":{"message":"Country, region, or territory not supported","type":"request_forbidden","code":"unsupported_country_region_territory","param":null}}"#;
+        assert!(is_geo_blocked_codex_error(body));
+    }
+
+    #[test]
+    fn geo_blocked_codex_error_ignores_other_403s() {
+        // An org-verification 403 IS actionable and must still reach Sentry.
+        let body =
+            br#"{"error":{"type":"request_forbidden","code":"organization_must_be_verified"}}"#;
+        assert!(!is_geo_blocked_codex_error(body));
+        // Unrelated shapes must not be mistaken for a geo-block.
+        assert!(!is_geo_blocked_codex_error(
+            br#"{"error":{"type":"invalid_request_error","code":"invalid_prompt"}}"#
+        ));
+        assert!(!is_geo_blocked_codex_error(b"<html>gateway error</html>"));
+        assert!(!is_geo_blocked_codex_error(b""));
+        // A null code must not panic or match.
+        assert!(!is_geo_blocked_codex_error(br#"{"error":{"code":null}}"#));
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -5775,25 +5775,38 @@ fn warn_stats_fetch_failed(reason: &str) {
     // one fact that splits "foreign squatter" from "orphaned old Headroom" --
     // RUST-87 shipped three unattributable 404s before this. Throttled to one
     // lookup per 15-minute warn window, so the lsof subprocess is free here.
-    let held_by = if category.starts_with("http-4") {
-        crate::tool_manager::listener_identity(6767)
-            .map(|who| format!("; port 6767 is held by {who}"))
-            .unwrap_or_default()
+    // `foreign_holder` stays false when the lookup returns None: "we could not
+    // resolve the listener" is not evidence that it is someone else's, and
+    // guessing wrong here silently drops a real backend fault.
+    let (held_by, foreign_holder) = if category.starts_with("http-4") {
+        match crate::tool_manager::listener_identity_and_ownership(6767) {
+            Some((who, is_ours)) => (format!("; port 6767 is held by {who}"), !is_ours),
+            None => (String::new(), false),
+        }
     } else {
-        String::new()
+        (String::new(), false)
     };
     let message = format!(
         "headroom /stats fetch failed ({reason}){held_by}; dashboard loses the layers \
          only this endpoint reports (output shaping, tool schema)"
     );
-    sentry::with_scope(
-        |scope| {
-            scope.set_fingerprint(Some(&["stats-fetch-failed", &category]));
-        },
-        || {
-            sentry::capture_message(&message, sentry::Level::Warning);
-        },
-    );
+    // A 4xx answered by a process that is demonstrably not ours means another
+    // application owns 6767 on this host. Nothing we ship changes that -- the
+    // backoff above was added for exactly this case (RUST-87) and only slowed
+    // the bleed: one mac still sent 129 events with no end state, because a
+    // throttle cannot reach zero. The user-visible remedy is freeing the port,
+    // which the local log states in full; Sentry gains nothing from a repeat.
+    // Our OWN backend answering 4xx is a real fault and still reports.
+    if !foreign_holder {
+        sentry::with_scope(
+            |scope| {
+                scope.set_fingerprint(Some(&["stats-fetch-failed", &category]));
+            },
+            || {
+                sentry::capture_message(&message, sentry::Level::Warning);
+            },
+        );
+    }
     // Local only: the fingerprinted capture above is the Sentry path, and the
     // bridged warn would double-report it under the old flat grouping.
     log::warn!("{message}");

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -8093,19 +8093,24 @@ pub fn running_proxy_argv() -> Option<String> {
     ps_command(pid)
 }
 
-/// Identity of whatever is listening on `port`, for diagnostics that need to
-/// tell a foreign squatter from an orphaned old Headroom: a port that answers
-/// HTTP without the backend's routes is invisible to the readyz gate (a 404
-/// there deliberately counts as reachable), so the listener's name is the one
-/// fact that resolves the ambiguity. Best-effort: `None` where lsof is
-/// unavailable (Windows), and the caller's message must read fine without it.
-pub(crate) fn listener_identity(port: u16) -> Option<String> {
+/// Identity of whatever is listening on `port`, plus whether it is one of ours.
+///
+/// Diagnostics need to tell a foreign squatter from an orphaned old Headroom: a
+/// port that answers HTTP without the backend's routes is invisible to the
+/// readyz gate (a 404 there deliberately counts as reachable), so the listener
+/// is the one fact that resolves the ambiguity. The identity string alone
+/// cannot: "python3.12 (pid 7)" is our managed runtime on one host and an
+/// unrelated venv on the next, so ownership goes through
+/// `pid_is_headroom_backend`, which checks argv (or the executable path on
+/// Windows) rather than the process name.
+///
+/// Best-effort: `None` where lsof is unavailable (Windows) or no listener could
+/// be resolved. That is "unknown", not "foreign" -- callers must not read it as
+/// proof of either, and the caller's message must read fine without it.
+pub(crate) fn listener_identity_and_ownership(port: u16) -> Option<(String, bool)> {
     let (cmd, pid) = listener_process(port)?;
-    Some(format_listener_identity(
-        &cmd,
-        pid,
-        ps_command(pid).as_deref(),
-    ))
+    let identity = format_listener_identity(&cmd, pid, ps_command(pid).as_deref());
+    Some((identity, pid_is_headroom_backend(pid)))
 }
 
 fn format_listener_identity(cmd: &str, pid: u32, argv: Option<&str>) -> String {


### PR DESCRIPTION
Three of the highest-volume ignored issues, each stuck for a different reason. Two are unfixable-by-release conditions that no throttle can drive to zero, so they stop reporting. The third is not noise at all - it is a real signal that was captured too poorly to act on, so it starts reporting properly. All three keep their full local log.

## RUST-4H - geo-blocked Codex 403s stop reporting (139 events)

Every event is `403 request_forbidden` / `unsupported_country_region_territory`: OpenAI refusing the request because the caller's region is not served. Nothing the desktop sent caused it and no release changes it, which is the same reasoning that already excludes 401 and 429 from capture.

Status alone cannot make the call - a 403 is also how an org-verification challenge arrives, and that one *is* actionable - so the split is on the body's structural `code` field, read through the same JSON path `codex_error_summary` already uses. No free text is inspected or forwarded.

## RUST-87 - `/stats` 4xx from a foreign process on 6767 stops reporting (129 events)

A 4xx on `/stats` means something answered 6767 without the backend's routes. When that something is demonstrably not ours, another application owns the port on that host. The exponential backoff already in the code was added for this exact case and could only slow the bleed - one mac still sent 129 events with no end state, because a throttle cannot reach zero.

`listener_identity` gains the fact that was missing: whether the pid holding the port is ours. The process name cannot answer that (`python3.12` is our managed runtime on one host and an unrelated venv on the next), so ownership goes through `pid_is_headroom_backend`, which checks argv, or the executable path on Windows.

Two deliberate non-changes:

- **Failing open is load-bearing.** An unresolvable listener - Windows, no lsof - counts as "unknown", not "foreign", and still reports. Guessing the other way would silently drop real backend faults.
- **Our own backend answering 4xx is untouched.** That is a genuine fault and still reports.

## RUST-4V - untriageable upstream errors become diagnosable (578 events)

All 578 events summarize as `type=- code=- param=-`. The body parsed as JSON but carried none of `error.type/code/param`, so the capture proved only that something failed. Two months in, the issue still says nothing about what. Two reasons it stayed dark:

**The summary discarded the evidence it had.** It collapsed "field absent" into the same `-` it uses for "present but null", then stopped. When all three are absent it now describes the body's shape instead: the JSON kind, and for an object its top-level key names. `{"detail":...}`, `{"error":"..."}` and `{}` were indistinguishable before; they are three different leads now.

**The summary was an extra, and extras cannot be aggregated or searched.** They are readable one event at a time, which is precisely how 578 events can share a single shape without anyone noticing. The shape now goes up as a *tag*, alongside the response media type, so "what are these actually?" is one query instead of 578 clicks.

Both tag values are bounded and content-free. Key names are schema, not content - only values can quote the request, and none are read. Top-level keys of an error body are API-chosen, and `is_safe_shape_key` drops anything that is not identifier-shaped, so a key carrying user text is rejected rather than forwarded. Keys are sorted and capped at 8, keeping the tag stable and its cardinality bounded.

## Testing

- `cargo test --manifest-path src-tauri/Cargo.toml --lib` - 1019 passed. Two failures in `client_adapters` (`purge_dir_tolerantly_skips_past_an_undeletable_entry`, `remove_dir_all_retry_clears_readonly_instead_of_giving_up`) are pre-existing and reproduce identically on a clean tree: the sandbox runs as uid 0, which bypasses the readonly bit those tests depend on.
- Six new tests. The geo-block predicate is checked against the exact RUST-4H body, an org-verification 403 that must still report, unrelated shapes, non-JSON, empty input and a null `code`. The shape descriptor is checked for stable ordering, the key cap, and that a key shaped like user text is dropped rather than forwarded.
- `cargo fmt --check` clean; no new compiler warnings. The one remaining warning (`unused_mut` in `lib.rs:4431`) is pre-existing.
- Rust-only change, so `check-colors` and `tsc` are unaffected.

## Note on the release-scoped resolve this came out of

Sentry's `Fixes RUST-XX` commit keyword would resolve these in the release containing the commit - the release-scoped resolve the MCP `update_issue` tool cannot express. It is deliberately **not** used here: every release in this project currently reports `lastCommit: null`, so commit tracking is not wired up and the keyword would be a no-op. Worth enabling separately if release-scoped resolution is the goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCZRHEFqyaGWe1EsqyFj23