### PR TITLE
Fix the new Sentry batch: a data-loss path, a reporting panic, and three untriageable groupings

### DIFF
--- a/src-tauri/src/client_adapters.rs
+++ b/src-tauri/src/client_adapters.rs
@@ -1990,13 +1990,29 @@ fn load_setup_state() -> ClientSetupState {
             match try_load_setup_state(&path) {
                 Ok(state) => normalize_setup_state(state),
                 Err(second_err) => {
+                    // Only a parse failure is evidence that the bytes on disk
+                    // are unusable. An I/O failure says nothing about them, and
+                    // quarantining on one is destructive: it renames the user's
+                    // real setup away, every caller gets the empty default (the
+                    // tray reads that as "every client disconnected"), and the
+                    // next write_setup_state persists that emptiness over the
+                    // top. Worse, `quarantine_unparsable` reuses one `.corrupt`
+                    // slot, so a second failure overwrites the rescue copy of
+                    // the first with the now-empty file and the original is
+                    // gone for good. RUST-5T is exactly that: one machine out
+                    // of file descriptors system-wide (ENFILE), both attempts
+                    // failing in `read`, 8 times. Leave the file alone and let
+                    // the next launch read it once the machine recovers.
+                    let unreadable = first_err.is_io() && second_err.is_io();
+                    let verb = if unreadable { "read" } else { "read/parse" };
                     log::warn!(
-                        "load_setup_state: failed to read/parse {} twice ({first_err:#}; {second_err:#}); returning default",
-                        path.display()
+                        "load_setup_state: failed to {verb} {} twice ({first_err:#}; {second_err:#}); returning default{}",
+                        path.display(),
+                        if unreadable { " without quarantining" } else { "" }
                     );
-                    // The next write_setup_state would overwrite the file with
-                    // the empty default; keep the original for recovery.
-                    quarantine_unparsable(&path, "client setup state");
+                    if !unreadable {
+                        quarantine_unparsable(&path, "client setup state");
+                    }
                     ClientSetupState::default()
                 }
             }
@@ -2004,10 +2020,39 @@ fn load_setup_state() -> ClientSetupState {
     }
 }
 
-fn try_load_setup_state(path: &Path) -> Result<ClientSetupState> {
-    let bytes = std::fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+/// Why a `client-setup.json` load failed. The two cases must never be handled
+/// alike: `Parse` means the bytes on disk are unusable and moving them aside is
+/// the recovery path, while `Io` means we never saw the bytes at all and have
+/// no grounds to touch the file. See the quarantine decision in
+/// `load_setup_state` for what conflating them cost (RUST-5T).
+enum SetupStateLoadError {
+    Io(anyhow::Error),
+    Parse(anyhow::Error),
+}
+
+impl SetupStateLoadError {
+    fn is_io(&self) -> bool {
+        matches!(self, SetupStateLoadError::Io(_))
+    }
+}
+
+impl std::fmt::Display for SetupStateLoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `{:#}` on the inner anyhow error: the callers log with `{err:#}` and
+        // the context chain ("reading <path>: <os error>") is the whole signal.
+        match self {
+            SetupStateLoadError::Io(err) | SetupStateLoadError::Parse(err) => write!(f, "{err:#}"),
+        }
+    }
+}
+
+fn try_load_setup_state(path: &Path) -> std::result::Result<ClientSetupState, SetupStateLoadError> {
+    let bytes = std::fs::read(path)
+        .with_context(|| format!("reading {}", path.display()))
+        .map_err(SetupStateLoadError::Io)?;
     serde_json::from_slice::<ClientSetupState>(&bytes)
         .with_context(|| format!("parsing {}", path.display()))
+        .map_err(SetupStateLoadError::Parse)
 }
 
 fn normalize_setup_state(mut state: ClientSetupState) -> ClientSetupState {
@@ -6782,6 +6827,51 @@ mod tests {
         let state: ClientSetupState = serde_json::from_str(dropped).unwrap();
         assert!(state.managed_shell_files.contains_key("codex_cli"));
         assert!(state.rtk_disabled);
+    }
+
+    /// RUST-5T: both load attempts failed in `read` (the machine was out of
+    /// file descriptors), and the old code quarantined on that -- renaming the
+    /// user's real setup away and handing every caller the empty default. An
+    /// unreadable file must be left exactly where it is.
+    #[test]
+    fn an_unreadable_setup_state_is_never_quarantined() {
+        let _home = TestHome::new();
+        let mut state = super::ClientSetupState::default();
+        state
+            .configured_clients
+            .insert("claude_code".into(), "2026-01-01T00:00:00+00:00".into());
+        super::write_setup_state(&state).expect("write");
+        let path = super::setup_state_path();
+        let original = std::fs::read(&path).expect("read back");
+
+        // Unreadable, not unparsable: a directory where the file is expected
+        // makes every `fs::read` fail without saying anything about contents,
+        // which is the same class of evidence as ENFILE.
+        std::fs::remove_file(&path).expect("remove");
+        std::fs::create_dir(&path).expect("dir in its place");
+        assert!(super::try_load_setup_state(&path).is_err_and(|e| e.is_io()));
+        assert!(
+            super::load_setup_state().configured_clients.is_empty(),
+            "callers still get the default"
+        );
+        assert!(
+            !path.with_extension("json.corrupt").exists(),
+            "an unreadable file must not be moved aside"
+        );
+
+        // A genuinely unparsable file still is: the bytes were read and are bad.
+        std::fs::remove_dir(&path).expect("undo");
+        std::fs::write(&path, b"{ truncated").expect("corrupt it");
+        assert!(super::load_setup_state().configured_clients.is_empty());
+        let corrupt = path.with_extension("json.corrupt");
+        assert!(corrupt.exists(), "unparsable bytes are quarantined");
+        assert_eq!(std::fs::read(&corrupt).unwrap(), b"{ truncated");
+
+        // And the healthy path is untouched.
+        std::fs::write(&path, &original).expect("restore");
+        assert!(super::load_setup_state()
+            .configured_clients
+            .contains_key("claude_code"));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1620,6 +1620,50 @@ impl BootstrapFailureKind {
     }
 }
 
+/// Sentry drops an extra larger than roughly 16KB, so every log/output tail we
+/// attach is capped well under that. One constant so the three call sites stay
+/// in step.
+const SENTRY_EXTRA_TAIL_BYTES: usize = 12_000;
+
+/// Last `max_bytes` of `text`, prefixed with how much was dropped.
+///
+/// Slices on a char boundary. The three call sites this replaced each did
+/// `&s[s.len() - 12_000..]` with a raw byte offset, which panics ("byte index N
+/// is not a char boundary") the moment the cut lands mid-codepoint -- and these
+/// inputs are precisely where non-ASCII turns up: app logs quoting Windows
+/// paths with accented usernames, and Python's non-ASCII startup banner
+/// (RUST-7C). Panicking here loses the very report being assembled, and on the
+/// `bootstrap_abandoned` path it happens during startup, before there is a
+/// window to show anything in.
+fn tail_bytes_for_sentry(text: &str, max_bytes: usize) -> String {
+    if text.len() <= max_bytes {
+        return text.to_string();
+    }
+    // Round the cut forward to the next boundary: dropping a few extra bytes is
+    // always safe, and this can never run past the end because `text.len()` is
+    // itself a boundary.
+    let mut cut = text.len() - max_bytes;
+    while !text.is_char_boundary(cut) {
+        cut += 1;
+    }
+    format!("[truncated {cut} bytes]\n...{}", &text[cut..])
+}
+
+/// Drop the per-request connection-pool debug lines from an app-log tail.
+///
+/// The health poll opens a connection to the local proxy several times a second
+/// and `reqwest` logs every one, so on a machine that sat at a bootstrap step
+/// for minutes these crowd out everything else. RUST-9Y spent its entire 12KB
+/// budget on them and arrived with nothing about the install in it at all,
+/// which is the one thing the extra exists to carry. Only this exact line is
+/// dropped -- connection *failures* and every other target are kept.
+fn strip_connection_noise(log: &str) -> String {
+    log.lines()
+        .filter(|line| !line.contains("reqwest::connect: starting new connection"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 fn classify_bootstrap_failure(err: &anyhow::Error) -> BootstrapFailureKind {
     // pip/venv failures surface as CommandFailure, where stdout/stderr carry the
     // real signal. Our own reqwest downloads (Python runtime, rtk binary) have no
@@ -1687,7 +1731,7 @@ fn is_app_control_signal(text: &str) -> bool {
 ///
 /// Returns an empty list off Windows, where these names do not exist -- no
 /// `cfg`, so the scan stays testable on any platform.
-fn conflicting_openssl_dirs(path_var: &str) -> Vec<String> {
+pub(crate) fn conflicting_openssl_dirs(path_var: &str) -> Vec<String> {
     const NAMES: &[&str] = &["libcrypto-3-x64.dll", "libssl-3-x64.dll"];
     let mut hits = Vec::new();
     for dir in std::env::split_paths(path_var) {
@@ -2544,14 +2588,7 @@ pub(crate) fn capture_upgrade_failure(
 
     // Sentry drops extras larger than ~16KB. Cap the tail aggressively so the
     // tail's tail (where the panic/error usually lives) survives.
-    let log_tail_capped = log_tail.map(|s| {
-        if s.len() > 12_000 {
-            let cut = s.len() - 12_000;
-            format!("[truncated {cut} bytes]\n...{}", &s[cut..])
-        } else {
-            s.to_string()
-        }
-    });
+    let log_tail_capped = log_tail.map(|s| tail_bytes_for_sentry(s, SENTRY_EXTRA_TAIL_BYTES));
 
     let outcome_for_fingerprint = outcome.unwrap_or("none");
     let fingerprint: [&str; 3] = ["runtime_upgrade", phase, outcome_for_fingerprint];
@@ -2651,15 +2688,8 @@ pub(crate) fn capture_upgrade_failure(
                     // Cap aggressively — Sentry drops extras > ~16KB and the
                     // tail (where pip warnings/skips/successfully-installed
                     // lines live) is the most informative part.
-                    let tail = if diag.pip_output_tail.len() > 12_000 {
-                        let cut = diag.pip_output_tail.len() - 12_000;
-                        format!(
-                            "[truncated {cut} bytes]\n...{}",
-                            &diag.pip_output_tail[cut..]
-                        )
-                    } else {
-                        diag.pip_output_tail.clone()
-                    };
+                    let tail =
+                        tail_bytes_for_sentry(&diag.pip_output_tail, SENTRY_EXTRA_TAIL_BYTES);
                     scope.set_extra("pip_install_output", tail.into());
                 }
             }
@@ -4609,17 +4639,12 @@ pub fn run() {
     if let Some(abandoned) = state.tool_manager.take_abandoned_bootstrap() {
         // The tail of the previous run's app log usually holds the last thing
         // the install did before dying. Same 12KB cap as
-        // capture_upgrade_failure: Sentry drops extras past ~16KB.
+        // capture_upgrade_failure: Sentry drops extras past ~16KB. Connection-
+        // pool debug lines are dropped first so the budget goes to the install
+        // rather than to health polling (RUST-9Y).
         let log_tail = std::fs::read_to_string(logging::log_path())
             .ok()
-            .map(|s| {
-                if s.len() > 12_000 {
-                    let cut = s.len() - 12_000;
-                    format!("[truncated {cut} bytes]\n...{}", &s[cut..])
-                } else {
-                    s
-                }
-            })
+            .map(|s| tail_bytes_for_sentry(&strip_connection_noise(&s), SENTRY_EXTRA_TAIL_BYTES))
             .unwrap_or_else(|| "app log unreadable".into());
         sentry::with_scope(
             |scope| {
@@ -5532,6 +5557,56 @@ fn extract_llm_failure_warnings(stderr: &str) -> Option<String> {
     }
 }
 
+/// Strip the machine-specific part out of an LLM-failure signature so the same
+/// failure groups as one Sentry issue across the fleet.
+///
+/// Upstream renders the reason as ``LLM analysis failed: `<cli> -p --output-format
+/// stream-json --verbose` failed (exit N):``, where `<cli>` is the *resolved*
+/// path to the agent binary on that machine. That path is different on every
+/// host, and because the signature is the fingerprint, one failure class opened
+/// one issue per user: RUST-A2 (`~\AppData\Roaming\npm\claude.CMD`) and
+/// RUST-9Z (a bare `claude`) are the same thing seen twice. Rewriting the
+/// program to its bare stem groups them while leaving every discriminator that
+/// actually means something -- the flags and the exit code -- in place. (The
+/// exit code stays: 1 and 3221226505/0xC0000409 really are different failures,
+/// an error exit versus the CLI crashing.)
+///
+/// Path-shaped input only: anything without a separator is already bare and is
+/// returned untouched, so a reason that is not command-shaped passes through.
+fn normalize_learn_failure_signature(signature: &str) -> String {
+    let Some(open) = signature.find('`') else {
+        return signature.to_string();
+    };
+    let rest = &signature[open + 1..];
+    let Some(close) = rest.find('`') else {
+        return signature.to_string();
+    };
+    let command = &rest[..close];
+    let (program, args) = command
+        .split_once(char::is_whitespace)
+        .unwrap_or((command, ""));
+    // Both separators unconditionally: these strings arrive from Windows hosts
+    // and are read on any platform, so `Path` (which does not treat `\` as a
+    // separator off Windows) is the wrong tool.
+    let stem = program.rsplit(['/', '\\']).next().unwrap_or(program);
+    // Drop the executable suffix so `claude.CMD`, `claude.exe` and `claude` are
+    // one program. Only the last dot, and only when it looks like an extension.
+    let stem = match stem.rsplit_once('.') {
+        Some((base, ext)) if !base.is_empty() && ext.chars().all(char::is_alphanumeric) => base,
+        _ => stem,
+    };
+    let normalized_command = if args.is_empty() {
+        stem.to_string()
+    } else {
+        format!("{stem} {args}")
+    };
+    format!(
+        "{}`{normalized_command}`{}",
+        &signature[..open],
+        &rest[close + 1..]
+    )
+}
+
 /// Turn a `headroom learn` stdout line into the step shown under the scan timer,
 /// or None to leave the current step alone.
 ///
@@ -5802,7 +5877,7 @@ fn execute_headroom_learn_run(
                     // usage limit, a dead local route, or our own 400. Warning
                     // (not Error) because some causes are user-environment;
                     // fingerprinted on the reason so the split is visible.
-                    let signature: String = warnings
+                    let raw_signature: String = warnings
                         .lines()
                         .map(str::trim)
                         .find(|l| !l.is_empty())
@@ -5810,12 +5885,18 @@ fn execute_headroom_learn_run(
                         .chars()
                         .take(160)
                         .collect();
+                    // Fingerprint and title on the normalized form: the raw one
+                    // carries the machine's resolved CLI path and split one
+                    // failure class per user (RUST-A2/RUST-9Z). The unmodified
+                    // text stays in `reason` and `stderr_tail` below.
+                    let signature = normalize_learn_failure_signature(&raw_signature);
                     sentry::with_scope(
                         |scope| {
                             scope.set_tag("flow", "headroom_learn");
                             scope.set_tag("learn_outcome", "llm_analysis_failed");
                             scope.set_tag("learn_agent", agent.as_tag());
                             scope.set_extra("reason", warnings.clone().into());
+                            scope.set_extra("raw_signature", raw_signature.clone().into());
                             scope.set_extra("project_name", project_name.to_string().into());
                             // The marker line ends at its colon: upstream
                             // appends the child's stderr, and `claude -p
@@ -5899,14 +5980,22 @@ fn execute_headroom_learn_run(
                 } else {
                     stdout.as_str()
                 };
-                let signature: String = signature_source
-                    .lines()
-                    .map(str::trim)
-                    .find(|l| !l.is_empty())
-                    .unwrap_or("no output")
-                    .chars()
-                    .take(160)
-                    .collect();
+                // Same normalization as the exit-0 branch above, and for the
+                // same reason: when upstream's first stderr line is the
+                // command-shaped reason, the resolved CLI path in it would
+                // split one failure class per machine. A no-op on any line that
+                // is not command-shaped.
+                let signature: String = normalize_learn_failure_signature(
+                    signature_source
+                        .lines()
+                        .map(str::trim)
+                        .find(|l| !l.is_empty())
+                        .unwrap_or("no output")
+                        .chars()
+                        .take(160)
+                        .collect::<String>()
+                        .as_str(),
+                );
                 let stderr_head: String = stderr.chars().take(2000).collect();
                 let stdout_head: String = stdout.chars().take(2000).collect();
                 let cli_path_str = cli_path
@@ -7442,18 +7531,19 @@ mod tests {
         install_pending_update, is_disk_full_signal, is_endpoint_protection_signal,
         is_network_download_signal, is_port_conflict_failure, is_prerelease_version,
         learn_step_label, lifetime_token_milestone_kind, noop_app_update_progress_emitter,
-        onboarding_recovery_copy, parse_live_learnings, parse_magic_link_auth,
-        parse_request_count_from_stats_body, parse_request_counts_by_agent,
+        normalize_learn_failure_signature, onboarding_recovery_copy, parse_live_learnings,
+        parse_magic_link_auth, parse_request_count_from_stats_body, parse_request_counts_by_agent,
         parse_updater_endpoint_list, pattern_matches_project, persistent_zero_spend,
         physical_rect_from_rect, read_applied_patterns_for_project, readyz_failed_checks_csv,
         readyz_failure_has_core_unhealthy, readyz_failure_is_upstream_only,
         readyz_outcome_fingerprint_key, recent_savings_days, resolve_release_updater_config,
-        select_updater_endpoints, store_checked_update, take_pending_magic_link, user_message_for,
-        watchdog_should_be_up, zero_spend_affected_days, AppUpdateProgress,
-        AppUpdateProgressEmitter, AvailableAppUpdate, BootstrapFailureKind, DailySavingsPoint,
-        HeadroomLearnPrereqStatus, InstallPendingUpdateFuture, InstallableAppUpdate, LearnAgent,
-        MonitorBounds, PhysicalRect, QuitSource, TrayRuntimeVisual, DEFAULT_UPDATER_ENDPOINT,
-        DEFAULT_UPDATER_PUBLIC_KEY, PENDING_MAGIC_LINK,
+        select_updater_endpoints, store_checked_update, strip_connection_noise,
+        tail_bytes_for_sentry, take_pending_magic_link, user_message_for, watchdog_should_be_up,
+        zero_spend_affected_days, AppUpdateProgress, AppUpdateProgressEmitter, AvailableAppUpdate,
+        BootstrapFailureKind, DailySavingsPoint, HeadroomLearnPrereqStatus,
+        InstallPendingUpdateFuture, InstallableAppUpdate, LearnAgent, MonitorBounds, PhysicalRect,
+        QuitSource, TrayRuntimeVisual, DEFAULT_UPDATER_ENDPOINT, DEFAULT_UPDATER_PUBLIC_KEY,
+        PENDING_MAGIC_LINK,
     };
     use parking_lot::Mutex;
     use serde_json::json;
@@ -8493,6 +8583,96 @@ mod tests {
             codex_cli_available: codex_cli,
             codex_cli_path: codex_cli.then(|| "/usr/bin/codex".to_string()),
             codex_logged_in,
+        }
+    }
+
+    /// The three tail sites used to slice on a raw byte offset, which panics
+    /// when the cut lands mid-codepoint. These inputs carry non-ASCII routinely
+    /// (Windows paths with accented usernames, Python's startup banner), so the
+    /// crash reporter could take the process down while building its report.
+    #[test]
+    fn sentry_tail_never_splits_a_codepoint() {
+        // A 3-byte codepoint repeated: every offset that is not a multiple of 3
+        // is mid-character, so most caps land on one.
+        let text = "\u{2500}".repeat(8_000);
+        assert_eq!(text.len(), 24_000);
+        for cap in [11_999, 12_000, 12_001, 1, 2, 23_999] {
+            let tail = tail_bytes_for_sentry(&text, cap);
+            assert!(tail.len() <= cap + 64, "cap {cap} respected (plus prefix)");
+            assert!(tail.contains("[truncated "), "cap {cap} announces the cut");
+            assert!(
+                tail.trim_start_matches(|c| c != '\u{2500}').is_empty()
+                    || tail.ends_with('\u{2500}'),
+                "cap {cap} produced valid text"
+            );
+        }
+        // Under the cap the text is returned whole, with no prefix.
+        assert_eq!(tail_bytes_for_sentry("short", 12_000), "short");
+        assert_eq!(tail_bytes_for_sentry("", 12_000), "");
+    }
+
+    /// RUST-9Y arrived with 12KB of connection-pool debug lines and nothing
+    /// about the install it was supposed to be reporting on.
+    #[test]
+    fn abandoned_bootstrap_tail_drops_connection_pool_noise() {
+        let log = "2026-08-27 18:06:32.282 DEBUG reqwest::connect: starting new connection: http://localhost:6767/\n                   2026-08-27 18:06:33.000 INFO installing pip into the managed venv\n                   2026-08-27 18:06:33.100 DEBUG reqwest::connect: starting new connection: http://127.0.0.1:6767/\n                   2026-08-27 18:06:34.000 WARN pip install attempt 1 failed";
+        let stripped = strip_connection_noise(log);
+        assert!(!stripped.contains("starting new connection"));
+        assert!(stripped.contains("installing pip into the managed venv"));
+        assert!(stripped.contains("pip install attempt 1 failed"));
+        // A connection *failure* is signal, not noise, and stays.
+        let failure = "DEBUG reqwest::connect: connection refused for http://localhost:6767/";
+        assert_eq!(strip_connection_noise(failure), failure);
+    }
+
+    /// RUST-A2 and RUST-9Z are one failure class that opened two issues because
+    /// the fingerprint carried each machine's resolved CLI path.
+    #[test]
+    fn learn_failure_signatures_group_across_machines() {
+        let windows = normalize_learn_failure_signature(
+            "LLM analysis failed: `~\\AppData\\Roaming\\npm\\claude.CMD -p --output-format stream-json --verbose` failed (exit 1):",
+        );
+        let bare = normalize_learn_failure_signature(
+            "LLM analysis failed: `claude -p --output-format stream-json --verbose` failed (exit 1):",
+        );
+        let posix = normalize_learn_failure_signature(
+            "LLM analysis failed: `/Users/x/.nvm/versions/node/v22/bin/claude -p --output-format stream-json --verbose` failed (exit 1):",
+        );
+        assert_eq!(windows, bare);
+        assert_eq!(posix, bare);
+        assert_eq!(
+            bare,
+            "LLM analysis failed: `claude -p --output-format stream-json --verbose` failed (exit 1):"
+        );
+
+        // The exit code still discriminates: an error exit and a Windows crash
+        // (0xC0000409) are different failures and must stay different issues.
+        assert_ne!(
+            bare,
+            normalize_learn_failure_signature(
+                "LLM analysis failed: `claude -p --output-format stream-json --verbose` failed (exit 3221226505):",
+            )
+        );
+        // So does the agent.
+        assert_ne!(
+            bare,
+            normalize_learn_failure_signature(
+                "LLM analysis failed: `codex -p --output-format stream-json --verbose` failed (exit 1):",
+            )
+        );
+    }
+
+    /// Anything not command-shaped passes through untouched -- the normalizer
+    /// must never eat a reason it does not recognize.
+    #[test]
+    fn learn_failure_signature_normalization_is_a_no_op_off_the_command_shape() {
+        for raw in [
+            "no reason",
+            "Credit balance is too low",
+            "LLM analysis failed: usage limit reached",
+            "unterminated `backtick",
+        ] {
+            assert_eq!(normalize_learn_failure_signature(raw), raw);
         }
     }
 

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -111,17 +111,31 @@ fn is_windows_session_end_panic(msg: &str) -> bool {
     msg.contains("cannot move state from Destroyed")
 }
 
+// The whole machine is out of file descriptors (ENFILE). Like disk-full this
+// is a system-wide resource the app cannot free -- it is not our per-process
+// limit, so no leak of ours is the cause and no release can change the outcome
+// -- and it fails every file touch identically, so it fragments into one
+// un-fixable issue per call site (RUST-A3 on the usage-counters write, RUST-5T
+// on the client-setup read, same class). Every affected read/write is retried
+// on its next tick and heals once the machine has descriptors again.
+//
+// ENFILE only. EMFILE ("Too many open files", os error 24) is the PER-PROCESS
+// limit and would mean we are leaking descriptors -- that one stays reportable.
+fn is_system_fd_exhaustion(msg: &str) -> bool {
+    msg.contains("Too many open files in system") // unix ENFILE
+}
+
 // Environmental or otherwise unfixable-by-release: keep the local log, never
 // send. One predicate so panics and log records answer it the same way.
 fn is_unreportable(msg: &str) -> bool {
-    is_disk_full(msg) || is_windows_session_end_panic(msg)
+    is_disk_full(msg) || is_system_fd_exhaustion(msg) || is_windows_session_end_panic(msg)
 }
 
 // Drop transient transport errors (offline laptop, flaky wifi, upstream blip)
 // from Sentry. They still hit the local log file via write_record.
 fn skip_sentry(target: &str, msg: &str) -> bool {
     // Environmental and target-agnostic: keep the local log, drop the event.
-    if is_disk_full(msg) {
+    if is_disk_full(msg) || is_system_fd_exhaustion(msg) {
         return true;
     }
     if target.starts_with("tauri_plugin_updater") {
@@ -346,6 +360,20 @@ fn skip_sentry(target: &str, msg: &str) -> bool {
     if target.starts_with("tauri_runtime_wry")
         && msg.starts_with("WebView2 error:")
         && msg.contains("HRESULT(0x8007139F)")
+    {
+        return true;
+    }
+    // The canary captures its own fully-scoped event at the emit site (flow
+    // tag, sample/zero/strata/models extras, and the fixed `zero_savings_canary`
+    // fingerprint that makes the fleet-wide event count the blast radius). This
+    // log line fires in the same breath with none of that, so one detection
+    // landed as two issues in the same millisecond: RUST-A5 (the capture) and
+    // RUST-A4 (this warn, parameterized into its own group because the counts
+    // and model list are baked into the text). Same split as the intercept-port
+    // and backend-port lines above. Keep the local log -- it is what a support
+    // thread reads -- and drop the Sentry twin.
+    if target.starts_with("headroom_desktop_lib::savings_canary")
+        && msg.starts_with("zero-savings canary:")
     {
         return true;
     }
@@ -592,6 +620,42 @@ mod tests {
         assert!(!skip_sentry(
             "headroom_desktop_lib::client_adapters",
             "codex retag headroom->openai: a state_*.sqlite is present but has no `threads` table under [\"~/.codex/sqlite\"]; the history menu may split. Codex likely renamed the table."
+        ));
+    }
+
+    /// One detection, two issues: the fully-scoped capture at the emit site
+    /// (RUST-A5) and this bridged log line (RUST-A4). The capture is the Sentry
+    /// path; the warn is local only.
+    #[test]
+    fn skips_the_zero_savings_canary_log_twin() {
+        assert!(skip_sentry(
+            "headroom_desktop_lib::savings_canary",
+            "zero-savings canary: 32/32 requests over 10000 tokens saved nothing (models: anthropic/glm-5.3; strata: other|new_user_ask|xl|tools)"
+        ));
+        // The emit-site capture's own wording must still reach Sentry -- it is
+        // the half that carries the fingerprint and the extras.
+        assert!(!skip_sentry(
+            "headroom_desktop_lib::savings_canary",
+            "zero_savings_canary: 32/32 large requests compressed to nothing (models: anthropic/glm-5.3; strata: other|new_user_ask|xl|tools)"
+        ));
+    }
+
+    /// ENFILE is a machine-wide resource we cannot free, and it fails every
+    /// file touch identically (RUST-A3 writing, RUST-5T reading). EMFILE is the
+    /// per-process limit and would mean we leak descriptors -- keep reporting it.
+    #[test]
+    fn skips_system_wide_fd_exhaustion_but_not_our_own() {
+        assert!(skip_sentry(
+            "headroom_desktop_lib::client_adapters",
+            "failed to persist usage-counters.json: writing ~/Library/Application Support/Headroom/config/usage-counters.json.tmp.22503.30753: Too many open files in system (os error 23)"
+        ));
+        assert!(skip_sentry(
+            "headroom_desktop_lib::client_adapters",
+            "load_setup_state: could not read ~/Library/Application Support/Headroom/config/client-setup.json twice (reading: Too many open files in system (os error 23))"
+        ));
+        assert!(!skip_sentry(
+            "headroom_desktop_lib::client_adapters",
+            "failed to persist usage-counters.json: writing /tmp/x: Too many open files (os error 24)"
         ));
     }
 

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -50,9 +50,16 @@ pub fn command(program: impl AsRef<OsStr>) -> Command {
 /// PATH entry contains the separator, returns the existing PATH unchanged
 /// rather than corrupting it.
 pub fn path_with_dir_prepended(dir: &Path) -> OsString {
-    let existing = std::env::var_os("PATH").unwrap_or_default();
-    std::env::join_paths(std::iter::once(dir.to_path_buf()).chain(std::env::split_paths(&existing)))
-        .unwrap_or(existing)
+    path_with_dir_prepended_to(dir, &std::env::var_os("PATH").unwrap_or_default())
+}
+
+/// As `path_with_dir_prepended`, but over a caller-supplied base instead of the
+/// process PATH -- so a caller that has already filtered the inherited PATH can
+/// still put the binary's own directory first (and keep it there, whatever the
+/// filter dropped).
+pub fn path_with_dir_prepended_to(dir: &Path, existing: &OsStr) -> OsString {
+    std::env::join_paths(std::iter::once(dir.to_path_buf()).chain(std::env::split_paths(existing)))
+        .unwrap_or_else(|_| existing.to_os_string())
 }
 
 #[cfg(test)]

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -9293,10 +9293,78 @@ fn context7_package_spec() -> String {
     format!("@upstash/context7-mcp@{CONTEXT7_PINNED_VERSION}")
 }
 
+/// PATH directories that would load a foreign OpenSSL into a bundled
+/// interpreter. Computed once -- our own PATH does not change under us, and
+/// this stats every entry.
+fn foreign_openssl_path_dirs() -> &'static [String] {
+    static DIRS: std::sync::OnceLock<Vec<String>> = std::sync::OnceLock::new();
+    DIRS.get_or_init(|| crate::conflicting_openssl_dirs(&std::env::var("PATH").unwrap_or_default()))
+}
+
+/// `path_var` with every entry in `drop` removed. Pure and unconditional so it
+/// stays testable off Windows; the caller decides when it applies.
+fn path_without_dirs(path_var: &std::ffi::OsStr, drop: &[String]) -> std::ffi::OsString {
+    if drop.is_empty() {
+        return path_var.to_os_string();
+    }
+    let kept: Vec<PathBuf> = std::env::split_paths(path_var)
+        .filter(|dir| !drop.iter().any(|d| Path::new(d) == dir))
+        .collect();
+    std::env::join_paths(kept).unwrap_or_else(|_| path_var.to_os_string())
+}
+
+/// True for our managed CPython, whatever the platform names it
+/// (`python3`, `python.exe`, `pythonw.exe`).
+fn is_python_interpreter(binary: &Path) -> bool {
+    binary
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .is_some_and(|s| s.to_ascii_lowercase().starts_with("python"))
+}
+
+/// PATH for a child of `binary`, with the binary's own directory first.
+///
+/// For our bundled interpreter the inherited PATH is filtered first. Windows
+/// resolves a DLL by base name along PATH, so a `libcrypto-3-x64.dll` left in
+/// some unrelated program's directory is loaded into our interpreter ahead of
+/// the one we ship; `_ssl.pyd` does not export `OPENSSL_Applink`, so that
+/// libcrypto aborts the instant it is used and ensurepip dies before pip speaks
+/// a word. RUST-8K was 25 relaunches into that wall on one host, RUST-A0 the
+/// same abort with a WAMP PHP directory on PATH. Until now all we could do was
+/// name the directory in the failure report and ask the user to change their
+/// own PATH; dropping it from the *child's* environment fixes it for them.
+///
+/// Scoped deliberately. Only the child's PATH changes -- the user's is
+/// untouched -- and only for the interpreter, because a directory is dropped
+/// here purely for holding an OpenSSL DLL and a non-Python child (a node CLI,
+/// say) may legitimately need to exec something else out of it. Our runtime is
+/// never on PATH, so every entry dropped is foreign by construction, and the
+/// interpreter's own directory is prepended *after* the filter so a DLL we ship
+/// beside it can never be the thing removed. Off Windows the scan finds nothing
+/// (it looks for `.dll` names) and this is a no-op.
 fn path_with_binary_dir(binary: &Path) -> std::ffi::OsString {
+    let inherited = std::env::var_os("PATH").unwrap_or_default();
+    let base = if is_python_interpreter(binary) {
+        let foreign = foreign_openssl_path_dirs();
+        if !foreign.is_empty() {
+            // info, not warn: this is the mitigation working. A warn would
+            // bridge to Sentry (see logging.rs) once per spawn on every machine
+            // that has any OpenSSL on PATH, which is a lot of them.
+            log::info!(
+                "dropping {} foreign OpenSSL dir(s) from the interpreter's PATH: {}",
+                foreign.len(),
+                foreign.join(", ")
+            );
+        }
+        path_without_dirs(&inherited, foreign)
+    } else {
+        inherited
+    };
     match binary.parent() {
-        Some(dir) if !dir.as_os_str().is_empty() => crate::proc::path_with_dir_prepended(dir),
-        _ => std::env::var_os("PATH").unwrap_or_default(),
+        Some(dir) if !dir.as_os_str().is_empty() => {
+            crate::proc::path_with_dir_prepended_to(dir, &base)
+        }
+        _ => base,
     }
 }
 
@@ -10053,7 +10121,6 @@ mod tests {
 
     use chrono::Local;
 
-    use super::log_tail;
     #[cfg(windows)]
     use super::python_distribution_artifact;
     use super::rotate_log_if_large;
@@ -10083,6 +10150,7 @@ mod tests {
         MARKITDOWN_PINNED_VERSION, PLUGIN_ADDONS, PLUGIN_DISPLAY_VERSION, RTK_VERSION,
         UNKNOWN_OCCUPANT,
     };
+    use super::{is_python_interpreter, log_tail, path_without_dirs};
     use crate::backend_port;
     use crate::models::ManagedTool;
     use crate::port_conflict;
@@ -10566,6 +10634,60 @@ asyncio.run(verify())
         // No bundle, or blank -> nothing to bridge.
         assert!(httpx_ca_bundle_bridge_from(false, None).is_empty());
         assert!(httpx_ca_bundle_bridge_from(false, Some("  ")).is_empty());
+    }
+
+    /// RUST-A0/RUST-8K: a foreign `libcrypto-3-x64.dll` on PATH aborts our
+    /// interpreter before pip runs. Drop those directories from the child's
+    /// PATH -- but only for the interpreter, and never the one we spawn from.
+    #[test]
+    fn foreign_openssl_dirs_are_dropped_from_the_interpreter_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let wamp = dir.path().join("wamp64").join("php");
+        let innocent = dir.path().join("tools");
+        let runtime = dir.path().join("runtime").join("Scripts");
+        for d in [&wamp, &innocent, &runtime] {
+            std::fs::create_dir_all(d).unwrap();
+        }
+        // The interpreter ships its own copy beside itself; it must survive.
+        std::fs::write(wamp.join("libcrypto-3-x64.dll"), b"foreign").unwrap();
+        std::fs::write(runtime.join("libcrypto-3-x64.dll"), b"ours").unwrap();
+
+        let path_var = std::env::join_paths([&wamp, &innocent, &runtime]).unwrap();
+        let foreign = crate::conflicting_openssl_dirs(&path_var.to_string_lossy());
+        assert!(foreign.contains(&wamp.display().to_string()));
+
+        let filtered = path_without_dirs(&path_var, &foreign);
+        let kept: Vec<PathBuf> = std::env::split_paths(&filtered).collect();
+        assert!(!kept.contains(&wamp), "the foreign dir is dropped");
+        assert!(kept.contains(&innocent), "unrelated dirs are kept");
+
+        // And prepending puts the interpreter's own dir back at the front even
+        // when the scan flagged it, so a DLL we ship is never the casualty.
+        let python = runtime.join("python.exe");
+        let restored =
+            crate::proc::path_with_dir_prepended_to(python.parent().unwrap(), &filtered);
+        assert_eq!(
+            std::env::split_paths(&restored).next(),
+            Some(runtime.clone())
+        );
+
+        // Nothing to drop leaves PATH byte-identical.
+        assert_eq!(path_without_dirs(&path_var, &[]), path_var);
+    }
+
+    #[test]
+    fn only_the_interpreter_gets_the_openssl_filter() {
+        // Built with `join`, the way the real caller does: a hardcoded
+        // "C:\\...\\python.exe" literal is one string with no separators to a
+        // non-Windows `Path`, so it would assert nothing off Windows.
+        let venv: PathBuf = ["Headroom", "runtime", "venv", "Scripts"].iter().collect();
+        assert!(is_python_interpreter(&venv.join("python.exe")));
+        assert!(is_python_interpreter(&venv.join("pythonw.exe")));
+        assert!(is_python_interpreter(Path::new("/usr/bin/python3")));
+        assert!(is_python_interpreter(Path::new("python")));
+        // A node CLI may legitimately need something out of a dropped dir.
+        assert!(!is_python_interpreter(&venv.join("codex")));
+        assert!(!is_python_interpreter(Path::new("/opt/nvm/bin/node")));
     }
 
     #[test]
@@ -12264,7 +12386,9 @@ S(('127.0.0.1', int(sys.argv[1])), H).serve_forever()
         assert!(py.contains("if self.current_upstream in (None, self.default_upstream):"));
         // A renamed instance attribute fails closed at bind time rather than
         // binding a wrapper that raises on every tick and resets nothing.
-        assert!(py.contains(r#"for _hd_ccs_needed in ("proxy_url", "default_upstream", "set_upstream", "path"):"#));
+        assert!(py.contains(
+            r#"for _hd_ccs_needed in ("proxy_url", "default_upstream", "set_upstream", "path"):"#
+        ));
         // And a wrapper that does fail at runtime says so once.
         assert!(py.contains("event=cc_switch_official_reset_failed"));
     }


### PR DESCRIPTION
Triage of the eight issues that first appeared in the last 24h, plus one older sibling they implicated. Branched off `staging`, which already carries the previous Sentry pass.

## What was actually wrong

Two of these are real defects. The rest are reporting defects: issues no release could have resolved, because the report was either duplicated, fragmented per machine, or empty.

**A transient read failure destroys the user's client setup** (RUST-5T). `load_setup_state` retries once, then treats any second failure as proof the file is corrupt: it renames the real setup to `.corrupt` and hands every caller the empty default. Only a *parse* failure is that proof. An I/O failure says nothing about the bytes. The empty default reads as "every client disconnected" in the tray, and the next `write_setup_state` persists it over the top. Worse, `quarantine_unparsable` reuses a single `.corrupt` slot, so a second round overwrites the rescue copy of the first with the now-empty file and the original is gone for good. RUST-5T is exactly that in production: one machine out of file descriptors system-wide, both attempts failing inside `read`, eight times. The quarantine now runs only when an attempt actually read the bytes and found them unusable.

**The bundled interpreter aborts on a foreign OpenSSL** (RUST-A0). Windows resolves a DLL by base name along PATH, so a `libcrypto-3-x64.dll` in an unrelated program's directory is loaded into our interpreter ahead of the one we ship. `_ssl.pyd` does not export `OPENSSL_Applink`, so it aborts the instant it is used and `ensurepip` dies before pip speaks a word. This was already classified (RUST-8K) but not fixable: all we could do was name the directory and ask the user to change their own PATH. Dropping those directories from the *child's* PATH fixes it unattended. Scoped to the interpreter only — a directory is dropped here purely for holding an OpenSSL DLL, and a node CLI may legitimately need to exec something out of it. The interpreter's own directory is prepended after the filter, so a DLL we ship beside it is never the casualty.

**A latent panic inside the crash reporter** (found via RUST-9Y). The three Sentry tail sites each sliced with a raw byte offset (`&s[s.len() - 12_000..]`), which panics the moment the cut lands mid-codepoint. These inputs are precisely where non-ASCII turns up: app logs quoting Windows paths with accented usernames, and Python's non-ASCII startup banner (RUST-7C). A sweep of 30 realistic log lengths with a non-ASCII tail panics on 8 of them. Panicking here loses the report being assembled, and on the `bootstrap_abandoned` path that happens during startup. They now share one char-boundary-safe helper.

**RUST-9Y itself carried no signal.** Its entire 12KB budget went to `reqwest::connect: starting new connection` lines from the health poll — nothing about the install it exists to report on. Those are dropped before the cap; connection *failures* are kept.

**One detection, two issues** (RUST-A5 + RUST-A4). The zero-savings canary captures a fully-scoped event at its emit site, then logs the same finding with `log::warn!` — and every warn bridges to Sentry. RUST-A4 is that twin, parameterized into its own group because the counts and model list are baked into its text. Same split already handled for the intercept-port and backend-port lines.

**One failure class, one issue per machine** (RUST-A2 + RUST-9Z). Upstream's `headroom learn` failure reason embeds the *resolved* path to the agent binary, and the reason is the fingerprint. RUST-A2 (`~\AppData\Roaming\npm\claude.CMD`) and RUST-9Z (a bare `claude`) are the same thing seen twice. The program is now normalized to its bare stem for the fingerprint and title; the flags and exit code stay, since 1 and 3221226505/0xC0000409 really are different failures (an error exit versus the CLI crashing). The unmodified text stays in the extras.

**Machine-wide fd exhaustion is environmental** (RUST-A3, and the reporting half of RUST-5T). ENFILE is not our per-process limit, so no leak of ours is the cause and no release changes the outcome — and it fails every file touch identically, fragmenting into one un-fixable issue per call site. Treated like disk-full. EMFILE (os error 24) *is* the per-process limit and would mean we are leaking descriptors, so that one stays reportable.

## Not changed, and why

- **RUST-A5** — the underlying signal is real and is left reporting. 32/32 large `anthropic/glm-5.3` requests compressed to nothing on one machine, at strata `other|new_user_ask|xl|tools`. That points at the compression pipeline in the wheel, not at this repo, and one machine is a lead rather than a graph. Only its duplicate was suppressed; if this is a live regression it now shows up as a clean event count on one issue.
- **RUST-A1** — already fixed. The reporting release is 0.4.4; the "no `state_<N>.sqlite` store was found" wording no longer exists, having been replaced by the narrower rename canary in the RUST-3R/RUST-43 work.
- **RUST-7M** — already addressed on `staging` by the bind-retry `skip_sentry` change, and not part of this batch (8 days old).

## Verification

- `cargo test --lib`: 1036 passed, 8 new tests among them. Two failures (`remove_dir_all_retry_clears_readonly_instead_of_giving_up`, `purge_dir_tolerantly_skips_past_an_undeletable_entry`) are pre-existing on the unmodified base — they assert that read-only bits block a delete, which does not hold for the root user this container runs as.
- `cargo clippy --all-targets`: 50 warnings, identical to baseline.
- `cargo fmt --check`, `scripts/check-no-console.sh`, `npx tsc --noEmit`, `npm run check:colors` (480, baseline): all clean. No frontend or CSS changes.
- The truncation panic was reproduced against the old code before fixing rather than assumed.

The Windows-only paths (the OpenSSL PATH filter, and `is_python_interpreter` on `python.exe`) are covered by tests that build paths with `join` and by the platform-independent `conflicting_openssl_dirs` scan, but have not been exercised on a real Windows host from this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXPcj6PkDjS5RmV1rntoLE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXPcj6PkDjS5RmV1rntoLE)_