### PR TITLE
Stop five Sentry issue groups from the last 12h at their source

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -238,6 +238,11 @@ static WATCHDOG_DOWN_CAPTURED: AtomicBool = AtomicBool::new(false);
 // doesn't drown in the sleep/wake / kill -9 race noise.
 static PORT_CONFLICT_CAPTURED: AtomicBool = AtomicBool::new(false);
 
+// Same once-per-session shape as PORT_CONFLICT_CAPTURED, for a runtime the
+// machine's security policy refuses to execute at all. See
+// `capture_headroom_start_failure`.
+static ENDPOINT_PROTECTION_CAPTURED: AtomicBool = AtomicBool::new(false);
+
 // Guards the quit-time `clear_client_setups()` so it runs at most once per
 // process. The exit handler fires for both `ExitRequested` and `Exit`, and a
 // second `clear_client_setups()` call is destructive: its `disable_client_setup`
@@ -2083,6 +2088,51 @@ pub(crate) fn capture_headroom_start_failure(context: &str, err: &anyhow::Error)
             },
             || {
                 sentry::capture_message(&truncated, sentry::Level::Warning);
+            },
+        );
+        return;
+    }
+
+    // Windows Application Control (Smart App Control / WDAC / AppLocker), an
+    // EDR agent, or Gatekeeper refusing to execute the runtime we just
+    // installed. Two things were wrong with letting this fall through:
+    //
+    //   - Level::Error, for a machine-policy verdict no release we ship can
+    //     change. `classify_startup_error` already turns it into an actionable
+    //     hint for the user; Sentry is not where that gets fixed.
+    //   - No fingerprint, so Sentry grouped on the message -- which embeds the
+    //     full proxy command line, including the port and the user's home
+    //     path. One cause, one issue per machine: RUST-AD and RUST-AC are the
+    //     same Windows host's same App Control block, filed twice because the
+    //     two call sites prefix it differently.
+    //
+    // Once per session at Warning under a stable fingerprint, so the cohort
+    // stays countable without either splintering or drowning the dashboard.
+    if is_endpoint_protection_signal(&technical_err) {
+        if ENDPOINT_PROTECTION_CAPTURED
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        sentry::with_scope(
+            |scope| {
+                let fp: &[&str] = &["proxy_start_endpoint_protection"];
+                scope.set_fingerprint(Some(fp));
+                if let Some(failure) = startup_failure {
+                    scope.set_extra("program", failure.program.clone().into());
+                    scope.set_extra("args", failure.args.join(" ").into());
+                    scope.set_extra("log_path", failure.log_path.clone().into());
+                    scope.set_extra("log_tail", failure.log_tail.clone().into());
+                    scope.set_extra("reason", failure.reason.clone().into());
+                }
+                scope.set_extra("error_chain", technical_err.clone().into());
+            },
+            || {
+                sentry::capture_message(
+                    "headroom runtime blocked by endpoint protection at start",
+                    sentry::Level::Warning,
+                );
             },
         );
         return;
@@ -4123,7 +4173,12 @@ async fn apply_client_setup(
         .load(std::sync::atomic::Ordering::Acquire);
     if state.runtime_is_paused() || bypassed {
         if let Err(err) = state.resume_runtime() {
-            log::warn!("apply_client_setup: resume_runtime failed: {err:#}");
+            // Local log keeps the full chain; the capture below is the Sentry
+            // path (fingerprinted, and silent for a machine-policy block).
+            // Bridging this warn instead grouped on a message that embeds the
+            // port and the user's home path -- RUST-AD.
+            log::info!("apply_client_setup: resume_runtime failed: {err:#}");
+            capture_headroom_start_failure("apply_client_setup: resume_runtime failed", &err);
         }
     }
     match client_adapters::apply_client_setup(&client_id) {
@@ -10347,6 +10402,39 @@ Some unrelated content.
         // Localized Windows prose: only the numeric code survives.
         assert!(is_endpoint_protection_signal(
             "차단되었습니다. (os error 4551)"
+        ));
+    }
+
+    /// The exact strings RUST-AD and RUST-AC carried: one Windows host, one
+    /// App Control policy, filed as two issues because the two call sites
+    /// prefix the same error differently and neither set a fingerprint. Both
+    /// must reach the endpoint-protection branch of
+    /// `capture_headroom_start_failure`, which is what collapses them.
+    #[test]
+    fn a_windows_app_control_block_is_recognised_at_proxy_start() {
+        // Spanish Windows, verbatim from the event. Only "os error 4551"
+        // survives localization, so that is what has to carry the match.
+        let resume = "apply_client_setup: resume_runtime failed: starting headroom background \
+                      process: ~\\AppData\\Local\\Headroom\\headroom\\runtime\\venv\\Scripts\\headroom.exe \
+                      proxy --port 6768 --no-http2 --log-messages --no-ccr --learn \
+                      --no-memory-tools --no-memory-context --memory-db-path \
+                      ~\\AppData\\Local\\Headroom\\memory.db: Una directiva de Control de \
+                      aplicaciones bloqueó este archivo. (os error 4551)";
+        let autostart = "headroom auto-start failed after bootstrap: starting headroom \
+                         background process: ...: Una directiva de Control de aplicaciones \
+                         bloqueó este archivo. (os error 4551)";
+
+        assert!(is_endpoint_protection_signal(resume), "RUST-AD unmatched");
+        assert!(
+            is_endpoint_protection_signal(autostart),
+            "RUST-AC unmatched"
+        );
+
+        // A port conflict must NOT be swallowed by the new branch: it has its
+        // own fingerprint and its own remediation.
+        assert!(!is_endpoint_protection_signal(
+            "starting headroom background process: port 6768 is occupied by a \
+             non-headroom process"
         ));
     }
 

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -164,6 +164,98 @@ fn transport_level(err: &reqwest::Error) -> sentry::Level {
     }
 }
 
+/// Stable, low-cardinality name for the failure kind behind `transport_failure`.
+/// The prose in the message differs per kind, and Sentry groups on message
+/// text, so without this the same round trip splinters into one issue per
+/// phrase (RUST-7H "could not be reached" and RUST-8X "the request timed out"
+/// are one machine's one outage, filed twice).
+fn transport_failure_kind(err: &reqwest::Error) -> &'static str {
+    if err.is_timeout() {
+        "timeout"
+    } else if err.is_connect() {
+        "connect"
+    } else {
+        "request"
+    }
+}
+
+/// Consecutive-failure throttle for the activation transport capture. The
+/// window DOUBLES per consecutive capture up to the cap, and only a round trip
+/// that actually reached the server clears it (`note_activation_reachable`).
+static ACTIVATION_TRANSPORT_WARNED_AT: std::sync::Mutex<Option<(std::time::Instant, u32)>> =
+    std::sync::Mutex::new(None);
+const ACTIVATION_TRANSPORT_WARN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(900);
+const ACTIVATION_TRANSPORT_WARN_MAX_INTERVAL: std::time::Duration =
+    std::time::Duration::from_secs(6 * 3600);
+
+fn activation_transport_warn_interval(streak: u32) -> std::time::Duration {
+    ACTIVATION_TRANSPORT_WARN_INTERVAL
+        .saturating_mul(1u32 << streak.clamp(1, 6).saturating_sub(1))
+        .min(ACTIVATION_TRANSPORT_WARN_MAX_INTERVAL)
+}
+
+/// Clear the activation throttle: the server answered, whatever it answered.
+/// A 401 or a 500 is still proof the transport works, so the next outage warns
+/// immediately instead of inheriting a stale streak.
+fn note_activation_reachable() {
+    // Poison-tolerant like the other throttles in this file: a panic elsewhere
+    // must not turn an error-reporting path into a second crash.
+    *ACTIVATION_TRANSPORT_WARNED_AT
+        .lock()
+        .unwrap_or_else(|e| e.into_inner()) = None;
+}
+
+/// Advance the activation-failure throttle and say whether this failure earns a
+/// Sentry event. Split out from the capture so the state machine is testable
+/// without manufacturing a `reqwest::Error`.
+fn claim_activation_transport_warn_slot() -> bool {
+    let mut last = ACTIVATION_TRANSPORT_WARNED_AT
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let streak = match *last {
+        Some((at, streak)) => {
+            if at.elapsed() < activation_transport_warn_interval(streak) {
+                return false;
+            }
+            streak.saturating_add(1)
+        }
+        None => 1,
+    };
+    *last = Some((std::time::Instant::now(), streak));
+    true
+}
+
+/// Report an activation round trip that never produced a response.
+///
+/// The premise this path shipped with -- "sign-in runs ~15x/day fleet-wide, so
+/// capturing every failure at Warning costs little" -- was wrong about who
+/// calls it. Activation is driven by an effect that re-fires whenever runtime
+/// reachability flaps, so a single offline machine sent 187 events in 12 hours,
+/// two of them 3 seconds apart (RUST-7H/RUST-8X). The caller now backs off, but
+/// this is the backstop: no future caller can turn one user's dead network into
+/// a Sentry flood. A non-transport failure implies something wrong on our side
+/// and is never throttled.
+fn capture_activation_transport_failure(msg: &str, err: &reqwest::Error) {
+    if !is_transient_transport_error(err) {
+        sentry::capture_message(msg, sentry::Level::Error);
+        return;
+    }
+
+    if !claim_activation_transport_warn_slot() {
+        return;
+    }
+
+    let kind = transport_failure_kind(err);
+    sentry::with_scope(
+        |scope| {
+            scope.set_fingerprint(Some(&["activation-transport-failure", kind]));
+        },
+        || {
+            sentry::capture_message(msg, sentry::Level::Warning);
+        },
+    );
+}
+
 fn plan_tier_header_value(tier: &ClaudePlanTier) -> &'static str {
     match tier {
         ClaudePlanTier::Free => "free",
@@ -1374,9 +1466,13 @@ pub(crate) fn activate_account_with_base_url(
         .send()
         .map_err(|err| {
             let msg = transport_failure("activate Headroom desktop access", &err);
-            sentry::capture_message(&msg, transport_level(&err));
+            capture_activation_transport_failure(&msg, &err);
             msg
         })?;
+    // The server answered. Whatever the status, the transport is healthy, so
+    // the next outage gets a fresh (immediate) warn rather than inheriting the
+    // streak that a previous outage left behind.
+    note_activation_reachable();
 
     if response.status().as_u16() == 401 {
         clear_session_token()?;
@@ -5891,6 +5987,137 @@ mod tests {
     }
 
     // ── activate_account / create_checkout_session / get_billing_portal_url ─
+
+    // ── activation transport throttle (RUST-7H / RUST-8X) ──────────────────
+
+    /// Sole owner of ACTIVATION_TRANSPORT_WARNED_AT in the suite; reset both
+    /// ends so ordering against other tests cannot leak a streak in.
+    #[test]
+    fn activation_transport_throttle_suppresses_a_repeating_outage() {
+        use super::{
+            activation_transport_warn_interval, claim_activation_transport_warn_slot,
+            note_activation_reachable, ACTIVATION_TRANSPORT_WARNED_AT,
+        };
+
+        note_activation_reachable();
+
+        assert!(
+            claim_activation_transport_warn_slot(),
+            "the first failure of an outage must always report"
+        );
+        assert!(
+            !claim_activation_transport_warn_slot(),
+            "a second failure inside the window must be dropped -- this is the \
+             one that sent 187 events in 12 hours"
+        );
+
+        // Age the stamp past the streak-1 window: the next failure reports and
+        // the streak advances, widening the window.
+        {
+            let mut slot = ACTIVATION_TRANSPORT_WARNED_AT
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let (_, streak) = slot.expect("stamped by the first claim");
+            let stale = std::time::Instant::now()
+                .checked_sub(
+                    activation_transport_warn_interval(streak) + std::time::Duration::from_secs(1),
+                )
+                .expect("clock has enough history");
+            *slot = Some((stale, streak));
+        }
+        assert!(
+            claim_activation_transport_warn_slot(),
+            "a failure past the window must report again"
+        );
+        assert_eq!(
+            ACTIVATION_TRANSPORT_WARNED_AT
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .unwrap()
+                .1,
+            2,
+            "the streak must advance so the next window doubles"
+        );
+
+        note_activation_reachable();
+        assert!(
+            ACTIVATION_TRANSPORT_WARNED_AT
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .is_none(),
+            "a reachable server must clear the throttle"
+        );
+        assert!(
+            claim_activation_transport_warn_slot(),
+            "after recovery the next outage reports immediately"
+        );
+        note_activation_reachable();
+    }
+
+    #[test]
+    fn activation_transport_warn_interval_backs_off_and_caps() {
+        use super::{
+            activation_transport_warn_interval, ACTIVATION_TRANSPORT_WARN_INTERVAL,
+            ACTIVATION_TRANSPORT_WARN_MAX_INTERVAL,
+        };
+
+        assert_eq!(
+            activation_transport_warn_interval(1),
+            ACTIVATION_TRANSPORT_WARN_INTERVAL
+        );
+        assert_eq!(
+            activation_transport_warn_interval(2),
+            ACTIVATION_TRANSPORT_WARN_INTERVAL * 2
+        );
+        assert_eq!(
+            activation_transport_warn_interval(6),
+            ACTIVATION_TRANSPORT_WARN_MAX_INTERVAL
+        );
+        assert_eq!(
+            activation_transport_warn_interval(u32::MAX),
+            ACTIVATION_TRANSPORT_WARN_MAX_INTERVAL
+        );
+        // A streak of 0 is unreachable, but must not shift by -1.
+        assert_eq!(
+            activation_transport_warn_interval(0),
+            ACTIVATION_TRANSPORT_WARN_INTERVAL
+        );
+
+        // The bound that matters: 24h of unbroken failure, first warn at t=0.
+        let mut elapsed = std::time::Duration::ZERO;
+        let mut warns = 1u32;
+        while elapsed < std::time::Duration::from_secs(24 * 3600) {
+            elapsed += activation_transport_warn_interval(warns);
+            warns += 1;
+        }
+        assert!(
+            warns <= 10,
+            "an offline machine still floods Sentry: {warns} events/day"
+        );
+    }
+
+    /// The two phrases `transport_failure` produces for one dead network were
+    /// two Sentry issues (RUST-7H, RUST-8X). The kind tag is what regroups
+    /// them, so it must stay stable and distinct per class.
+    #[test]
+    fn transport_failure_kind_separates_connect_from_timeout() {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_millis(1))
+            .build()
+            .expect("build client");
+        // Nothing listens on port 1: a connect failure, not a timeout.
+        let err = client
+            .get("http://127.0.0.1:1/")
+            .send()
+            .expect_err("port 1 refuses");
+        assert_eq!(super::transport_failure_kind(&err), "connect");
+        assert!(super::is_transient_transport_error(&err));
+        assert!(
+            super::transport_failure("activate Headroom desktop access", &err)
+                .contains("the server could not be reached"),
+            "the RUST-7H phrase changed; the kind tag and the prose must agree"
+        );
+    }
 
     /// Snapshot HOME / XDG_DATA_HOME, redirect them at a fresh tempdir,
     /// ensure_data_dirs, and seed a session token in the (debug) keychain

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -5816,13 +5816,43 @@ impl HeadroomSavingsHistoryResponse {
 /// RUST-87 is a single mac whose 6767 belongs to another app, and the flat
 /// 15-minute window sent 96 identical events a day from that one host with no
 /// end state. A first failure still speaks immediately; only the repeats decay.
-/// A successful fetch clears the streak, so a condition that heals and comes
-/// back is loud again.
+/// A SUSTAINED run of successful fetches clears the streak, so a condition that
+/// heals and comes back is loud again. It has to be sustained: clearing on the
+/// first success made the backoff unreachable for the most common failure
+/// shape. `/stats` is a cold rebuild that finishes in ~3s idle but runs past
+/// the timeout while the proxy is busy serving a session, so a coding user
+/// alternates success, timeout, success, timeout -- and every timeout found an
+/// empty slot and warned immediately. That is RUST-86: 1066 events, no host
+/// ever reaching streak 2.
 /// ponytail: one global slot, not per-category -- a host has one cause at a
 /// time in practice; key it by category if that stops being true.
 const STATS_FETCH_WARN_INTERVAL: Duration = Duration::from_secs(900);
 const STATS_FETCH_WARN_MAX_INTERVAL: Duration = Duration::from_secs(6 * 3600);
 static STATS_FETCH_WARNED_AT: Mutex<Option<(Instant, u32)>> = Mutex::new(None);
+
+/// How long `/stats` must answer without a single failure before the backoff
+/// above is forgiven. One good poll proves nothing on a backend that only
+/// stalls under load; a clean quarter-hour means the stall is actually over.
+const STATS_FETCH_RECOVERY_WINDOW: Duration = STATS_FETCH_WARN_INTERVAL;
+/// When the current unbroken run of successful fetches began. `None` = the
+/// most recent fetch failed.
+static STATS_FETCH_HEALTHY_SINCE: Mutex<Option<Instant>> = Mutex::new(None);
+
+/// A `/stats` fetch succeeded. Clears the warn backoff only once the run of
+/// successes has lasted `STATS_FETCH_RECOVERY_WINDOW`.
+fn note_stats_fetch_ok() {
+    let mut healthy = STATS_FETCH_HEALTHY_SINCE.lock();
+    let since = *healthy.get_or_insert_with(Instant::now);
+    if since.elapsed() >= STATS_FETCH_RECOVERY_WINDOW {
+        *STATS_FETCH_WARNED_AT.lock() = None;
+    }
+}
+
+/// A `/stats` fetch failed. Breaks the healthy run whether or not the failure
+/// is loud enough to warn -- a suppressed failure is still a failure.
+fn note_stats_fetch_failed() {
+    *STATS_FETCH_HEALTHY_SINCE.lock() = None;
+}
 
 /// Window a warn must clear before the `streak`-th consecutive one may speak:
 /// 15m, 30m, 1h, 2h, 4h, then capped. `streak` is 1-based.
@@ -5858,6 +5888,7 @@ fn stats_fetch_failure_category(reason: &str) -> String {
 }
 
 fn warn_stats_fetch_failed(reason: &str) {
+    note_stats_fetch_failed();
     let mut last = STATS_FETCH_WARNED_AT.lock();
     let streak = match *last {
         Some((at, streak)) => {
@@ -5967,8 +5998,8 @@ fn fetch_headroom_dashboard_stats() -> Option<HeadroomDashboardStats> {
         };
 
         if let Some(parsed) = parse_headroom_stats_from_json(&body) {
-            // Recovery resets the backoff: the next outage warns immediately.
-            *STATS_FETCH_WARNED_AT.lock() = None;
+            // Sustained recovery resets the backoff; see note_stats_fetch_ok.
+            note_stats_fetch_ok();
             return Some(parsed);
         }
         last_failure = Some("payload had no recognised savings fields".to_string());
@@ -7460,6 +7491,65 @@ pub(crate) fn is_session_teardown_exit(code: i32) -> bool {
     )
 }
 
+/// Exit code the Windows sweep script uses for "the process enumeration itself
+/// failed" (WMI unavailable or access-denied), as opposed to powershell's own
+/// exit codes.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+const PS_SWEEP_ENUMERATION_FAILED: i32 = 3;
+
+/// Escape a value for use inside a single-quoted PowerShell `-like` pattern.
+/// `[`/`]` are wildcard metacharacters to `-like`, and an embedded `'` would
+/// close the string literal early -- a Windows username containing `'` could
+/// otherwise break out of it.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn escape_powershell_like(value: &str) -> String {
+    value
+        .replace('`', "``")
+        .replace('\'', "''")
+        .replace('[', "`[")
+        .replace(']', "`]")
+}
+
+/// The PowerShell one-liner that force-kills every process whose command line
+/// matches both the executable and the argument pattern.
+///
+/// `Win32_Process.CommandLine` wraps the executable in double quotes (e.g.
+/// `"C:\...\python.exe" -m headroom.proxy.server`), so matching
+/// "{exe} {args_pattern}" as one substring never hits -- the quote right after
+/// the exe breaks the adjacency. Match the exe and the args as two independent
+/// `-like` clauses instead.
+///
+/// Excluding our own PID matters: this powershell process's `CommandLine`
+/// embeds both `-like` patterns as literals, so without the guard it matches
+/// its own filter and force-kills itself mid-pipeline -- exit -1, and the real
+/// targets after it in the enumeration are never killed (RUST-6F/6G/6H: 44
+/// events on the first 0.7.7 Windows install).
+///
+/// The script reports its own verdict rather than letting powershell infer one.
+/// `powershell -Command` exits 1 whenever the last pipeline element left `$?`
+/// false, and `-ErrorAction SilentlyContinue` suppresses the message without
+/// clearing that flag -- so a `Stop-Process` against a pid that exited on its
+/// own between the enumeration and the kill (the common case here: we just
+/// asked the proxy to stop) made a fully successful sweep look like a failure.
+/// That is the second RUST-6F/RUST-6G wave: 22 warnings from a machine where
+/// nothing was wrong. `exit 0` means the sweep ran; `PS_SWEEP_ENUMERATION_FAILED`
+/// means the enumeration itself failed, which is the only outcome worth a
+/// report. A powershell that cannot start at all reaches neither and still
+/// surfaces through its own exit code (see `is_session_teardown_exit`).
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn windows_process_sweep_script(exe: &std::path::Path, args_pattern: &str) -> String {
+    let exe_pattern = escape_powershell_like(&exe.display().to_string());
+    let args_escaped = escape_powershell_like(args_pattern);
+    format!(
+        "try {{ Get-CimInstance Win32_Process -ErrorAction Stop \
+         | Where-Object {{ $_.ProcessId -ne $PID \
+         -and $_.CommandLine -like '*{exe_pattern}*' \
+         -and $_.CommandLine -like '*{args_escaped}*' }} \
+         | ForEach-Object {{ Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }} }} \
+         catch {{ exit {PS_SWEEP_ENUMERATION_FAILED} }}; exit 0"
+    )
+}
+
 fn kill_processes_by_command_pattern(exe: &std::path::Path, args_pattern: &str) -> Result<()> {
     // An unresolved runtime path degrades the pattern from "our backend at this
     // exact path" to a loose substring, and `pkill -f` applies it to every
@@ -7491,31 +7581,7 @@ fn kill_processes_by_command_pattern(exe: &std::path::Path, args_pattern: &str) 
 
     #[cfg(target_os = "windows")]
     {
-        // `Win32_Process.CommandLine` wraps the executable in double quotes
-        // (e.g. `"C:\...\python.exe" -m headroom.proxy.server`), so matching
-        // "{exe} {args_pattern}" as one substring never hits -- the quote
-        // right after the exe breaks the adjacency. Match the exe and the
-        // args as two independent `-like` clauses instead. Escape `[`/`]`
-        // (wildcard metacharacters to `-like`) and any embedded `'` (would
-        // otherwise close the single-quoted PowerShell literal early -- a
-        // Windows username containing `'` could break out of it).
-        fn escape_like(value: &str) -> String {
-            value
-                .replace('`', "``")
-                .replace('\'', "''")
-                .replace('[', "`[")
-                .replace(']', "`]")
-        }
-        let exe_pattern = escape_like(&exe.display().to_string());
-        let args_escaped = escape_like(args_pattern);
-        // Exclude our own PID: this powershell process's `CommandLine` embeds
-        // both `-like` patterns as literals, so without the guard it matches
-        // its own filter and force-kills itself mid-pipeline -- exit -1, and
-        // the real targets after it in the enumeration are never killed
-        // (RUST-6F/6G/6H: 44 events on the first 0.7.7 Windows install).
-        let script = format!(
-            "Get-CimInstance Win32_Process | Where-Object {{ $_.ProcessId -ne $PID -and $_.CommandLine -like '*{exe_pattern}*' -and $_.CommandLine -like '*{args_escaped}*' }} | ForEach-Object {{ Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }}"
-        );
+        let script = windows_process_sweep_script(exe, args_pattern);
         let status = crate::proc::command("powershell")
             .args(["-NoProfile", "-NonInteractive", "-Command", &script])
             .status()
@@ -7545,6 +7611,15 @@ fn kill_processes_by_command_pattern(exe: &std::path::Path, args_pattern: &str) 
                 exe.display()
             );
             return Ok(());
+        }
+
+        if status.code() == Some(PS_SWEEP_ENUMERATION_FAILED) {
+            return Err(anyhow!(
+                "powershell could not enumerate processes (Win32_Process query failed) \
+                 for exe '{}' args '{}'",
+                exe.display(),
+                args_pattern
+            ));
         }
 
         return Err(anyhow!(
@@ -8042,8 +8117,8 @@ mod tests {
         bootstrap_failed_state, classify_startup_error, cpu_time_advanced, drop_rollup_backfill,
         hf_cache_grew, intercept_bind_hint, lifetime_output_savings_usd,
         lifetime_token_milestones_crossed, log_mtime_advanced, merge_daily_savings,
-        merge_hourly_savings, most_recent_monday, parse_headroom_stats_from_json,
-        parse_headroom_stats_history_from_json, parse_ps_cpu_time,
+        merge_hourly_savings, most_recent_monday, note_stats_fetch_ok,
+        parse_headroom_stats_from_json, parse_headroom_stats_history_from_json, parse_ps_cpu_time,
         proxy_readyz_503_body_is_upstream_only, proxy_readyz_status_is_reachable,
         rebuild_persisted_savings_from_records, savings_rate_implausible, settle_rollup_backfill,
         stats_fetch_warn_interval, support_tier_for_platform, tcp_port_accepts_connection,
@@ -8051,8 +8126,8 @@ mod tests {
         BootValidationOutcome, ClaudeProjectScan, DailySavingsBucket, Duration,
         HeadroomDashboardStats, HeadroomSavingsHistoryPoint, Instant, OutputSampleBucket,
         PersistedSavingsState, RingStartTotals, SavingsObservation, SavingsRecord, SavingsTracker,
-        OUTPUT_SAMPLE_SERIES_VERSION, STATS_FETCH_WARNED_AT, STATS_FETCH_WARN_INTERVAL,
-        STATS_FETCH_WARN_MAX_INTERVAL,
+        OUTPUT_SAMPLE_SERIES_VERSION, STATS_FETCH_HEALTHY_SINCE, STATS_FETCH_RECOVERY_WINDOW,
+        STATS_FETCH_WARNED_AT, STATS_FETCH_WARN_INTERVAL, STATS_FETCH_WARN_MAX_INTERVAL,
     };
 
     #[test]
@@ -10666,11 +10741,146 @@ mod tests {
         assert!(parsed.output_reduction.is_none());
     }
 
+    /// RUST-86's actual shape: the backend answers when idle and stalls when
+    /// busy, so successes and timeouts alternate. Clearing the streak on the
+    /// first success made every timeout look like a fresh outage and warn
+    /// immediately -- 1066 events with no host ever reaching streak 2.
+    #[test]
+    fn a_single_good_fetch_does_not_forgive_the_stats_backoff() {
+        *STATS_FETCH_WARNED_AT.lock() = None;
+        *STATS_FETCH_HEALTHY_SINCE.lock() = None;
+
+        warn_stats_fetch_failed("timed out after 15s");
+        let (first, streak) = (*STATS_FETCH_WARNED_AT.lock()).expect("first failure warns");
+        assert_eq!(streak, 1);
+
+        // One success, then another timeout: the flapping pattern.
+        note_stats_fetch_ok();
+        warn_stats_fetch_failed("timed out after 15s");
+        assert_eq!(
+            (*STATS_FETCH_WARNED_AT.lock()).expect("still stamped").0,
+            first,
+            "one good poll must not re-arm the immediate warn"
+        );
+
+        // Even a long-looking run of successes is not enough while failures
+        // keep interrupting it: each failure restarts the recovery clock.
+        for _ in 0..50 {
+            note_stats_fetch_ok();
+            warn_stats_fetch_failed("timed out after 15s");
+        }
+        assert_eq!(
+            (*STATS_FETCH_WARNED_AT.lock()).expect("still stamped").0,
+            first,
+            "an alternating backend must stay throttled"
+        );
+
+        // A genuinely sustained recovery does forgive it.
+        if let Some(stale) =
+            Instant::now().checked_sub(STATS_FETCH_RECOVERY_WINDOW + Duration::from_secs(1))
+        {
+            *STATS_FETCH_HEALTHY_SINCE.lock() = Some(stale);
+            note_stats_fetch_ok();
+            assert!(
+                (*STATS_FETCH_WARNED_AT.lock()).is_none(),
+                "a clean recovery window must clear the backoff"
+            );
+        }
+
+        *STATS_FETCH_WARNED_AT.lock() = None;
+        *STATS_FETCH_HEALTHY_SINCE.lock() = None;
+    }
+
+    /// RUST-6F/RUST-6G, second wave: the sweep worked, but powershell exited 1
+    /// because a `Stop-Process` in the pipeline failed (the pid was already
+    /// gone -- we had just asked the proxy to stop), and `-ErrorAction
+    /// SilentlyContinue` hides the message without clearing `$?`. The script
+    /// must state its own verdict so a successful sweep cannot be read as a
+    /// failure, while a genuinely broken enumeration still is one.
+    #[test]
+    fn the_windows_sweep_script_reports_its_own_verdict() {
+        use super::{windows_process_sweep_script, PS_SWEEP_ENUMERATION_FAILED};
+        let script = windows_process_sweep_script(
+            std::path::Path::new(r"C:\Users\a\venv\Scripts\headroom.exe"),
+            "proxy --port",
+        );
+
+        assert!(
+            script.trim_end().ends_with("exit 0"),
+            "a sweep that ran must not inherit powershell's $?-derived exit code: {script}"
+        );
+        assert!(
+            script.contains(&format!("catch {{ exit {PS_SWEEP_ENUMERATION_FAILED} }}")),
+            "a failed enumeration must stay distinguishable: {script}"
+        );
+        assert!(
+            script.contains("-ErrorAction Stop"),
+            "without this the catch never fires and every failure looks clean: {script}"
+        );
+        // The self-kill guard this script already depended on (first RUST-6F
+        // wave) must survive the rewrite.
+        assert!(
+            script.contains("$_.ProcessId -ne $PID"),
+            "lost the self-kill guard: {script}"
+        );
+        // Stop-Process stays best-effort: one unkillable pid must not abort
+        // the sweep for the rest.
+        assert!(
+            script.contains("Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue"),
+            "the kill must stay best-effort: {script}"
+        );
+
+        // The script is built from a `\`-continued literal, which strips the
+        // newline AND the next line's indentation -- so a trailing space on the
+        // wrong side of the backslash silently glues two tokens together
+        // ("$PID-and"). This only ever runs on Windows, so a slip here is
+        // invisible until a user hits it.
+        assert!(
+            !script.contains('\n'),
+            "the script must stay a single -Command line: {script}"
+        );
+        for token in [
+            " | Where-Object ",
+            " | ForEach-Object ",
+            " -and $_.CommandLine ",
+        ] {
+            assert!(
+                script.contains(token),
+                "tokens got glued together around {token:?}: {script}"
+            );
+        }
+        assert_eq!(
+            script.matches('{').count(),
+            script.matches('}').count(),
+            "unbalanced braces: {script}"
+        );
+    }
+
+    /// A `'` in a Windows username would close the single-quoted `-like`
+    /// literal early, and `[`/`]` are wildcards to `-like`.
+    #[test]
+    fn the_windows_sweep_script_escapes_hostile_paths() {
+        use super::windows_process_sweep_script;
+        let script = windows_process_sweep_script(
+            std::path::Path::new(r"C:\Users\O'Brien [dev]\venv\Scripts\headroom.exe"),
+            "proxy --port",
+        );
+        assert!(script.contains("O''Brien"), "unescaped quote: {script}");
+        assert!(script.contains("`[dev`]"), "unescaped wildcard: {script}");
+        // Every `-like` literal must still be balanced after escaping.
+        assert_eq!(
+            script.matches('\'').count() % 2,
+            0,
+            "escaping left an unbalanced string literal: {script}"
+        );
+    }
+
     #[test]
     fn stats_fetch_warn_is_throttled_within_the_window() {
         // The dashboard retries /stats every 12s and this warn bridges to
         // Sentry, so only the first failure in a window may speak.
         *STATS_FETCH_WARNED_AT.lock() = None;
+        *STATS_FETCH_HEALTHY_SINCE.lock() = None;
 
         warn_stats_fetch_failed("timed out after 5s");
         let (first, streak) = (*STATS_FETCH_WARNED_AT.lock()).expect("first failure warns");

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -9678,12 +9678,37 @@ pub(crate) fn pip_index_fetch_failed(lower: &str) -> bool {
 /// regress the instant an unrelated cause reappeared (RUST-5Q). These classes
 /// match the buckets triage already sorts these into by hand.
 pub(crate) fn pip_failure_category(compact: &str) -> &'static str {
+    pip_failure_category_with_evidence(compact, compact)
+}
+
+/// pip's whole output for a failure, for the classifiers that need evidence
+/// `compact_pip_failure` throws away. That tail starts at pip's FIRST
+/// `ERROR:` line, and pip prints its `Could not fetch URL` / `Retrying`
+/// warnings well before that -- so a starved index arrives at
+/// `pip_failure_category` looking exactly like a bad pin. RUST-90 is the
+/// result: `colorama==0.4.6`, a wheel that exists for every platform we ship,
+/// filed under `no-matching-dist`, the bucket whose whole point is "a bad pin
+/// in *our* lock". Falls back to the compact string when the error carries no
+/// `CommandFailure` (spawn failure -- there was no pip output to read).
+pub(crate) fn pip_failure_evidence(err: &anyhow::Error, compact: &str) -> String {
+    match err.chain().find_map(|c| c.downcast_ref::<CommandFailure>()) {
+        Some(failure) => format!("{}\n{}", failure.stderr, failure.stdout),
+        None => compact.to_string(),
+    }
+}
+
+/// `pip_failure_category`, but with pip's full output available separately for
+/// the index-starvation check. `compact` still decides everything else, so the
+/// buckets keep matching the message text triage reads.
+pub(crate) fn pip_failure_category_with_evidence(compact: &str, evidence: &str) -> &'static str {
     let lower = compact.to_ascii_lowercase();
+    let evidence_lower = evidence.to_ascii_lowercase();
     if lower.contains("no module named pip") {
         "no-pip"
     } else if (lower.contains("no matching distribution found")
         || lower.contains("could not find a version that satisfies"))
         && !pip_index_fetch_failed(&lower)
+        && !pip_index_fetch_failed(&evidence_lower)
     {
         // Our lock asked for a version PyPI has no wheel for on that
         // interpreter/platform (RUST-6S: onnxruntime==1.27.0 on Intel macOS,
@@ -9750,6 +9775,11 @@ pub(crate) fn pip_failure_category(compact: &str) -> &'static str {
         || lower.contains("connection")
         || lower.contains("timed out")
         || lower.contains("temporary failure in name resolution")
+        // Same truncation as above, milder symptom: pip retried through a
+        // network fault, then printed an ERROR: line that names only the
+        // package. Read the evidence before shrugging it into `other`.
+        || evidence_lower.contains("temporary failure in name resolution")
+        || evidence_lower.contains("could not fetch url")
     {
         "network"
     } else {
@@ -9854,7 +9884,10 @@ where
                         // Explicit per-category fingerprint; the bridged warn is
                         // local-only (skip_sentry rule) so this doesn't double-
                         // report. See `pip_failure_category`.
-                        let category = pip_failure_category(&compact);
+                        let category = pip_failure_category_with_evidence(
+                            &compact,
+                            &pip_failure_evidence(&err, &compact),
+                        );
                         sentry::with_scope(
                             |scope| {
                                 scope.set_fingerprint(Some(&["pip-install-failed", category]));
@@ -14802,6 +14835,66 @@ exit 0
             &mut |_| {},
         )
         .expect("child that keeps talking must not be killed");
+    }
+
+    /// RUST-90: `colorama==0.4.6` -- a pure-python wheel that exists for every
+    /// platform we ship -- filed under `no-matching-dist`, the bucket reserved
+    /// for a bad pin in our own lock. The machine's index was unreachable; pip
+    /// said so, but `compact_pip_failure` tails from the first `ERROR:` line
+    /// and pip prints `Could not fetch URL` above it. Classify against pip's
+    /// whole output, not the tail that survives into the Sentry message.
+    #[test]
+    fn a_starved_index_is_not_blamed_on_our_lock() {
+        let stderr = concat!(
+            "WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) ",
+            "after connection broken by 'SSLError(SSLCertVerificationError(1, ",
+            "'[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed'))': /simple/colorama/\n",
+            "WARNING: Could not fetch URL https://pypi.org/simple/colorama/: ",
+            "There was a problem confirming the ssl certificate - skipping\n",
+            "ERROR: Could not find a version that satisfies the requirement colorama==0.4.6 ",
+            "(from versions: none)\n",
+            "ERROR: No matching distribution found for colorama==0.4.6\n",
+        );
+        let err = pip_failure(stderr);
+        let compact = compact_pip_failure(&err);
+
+        // The evidence really is gone from the message Sentry groups on --
+        // that is the whole bug, so pin it.
+        assert!(
+            !compact.to_ascii_lowercase().contains("could not fetch url"),
+            "test no longer reproduces the truncation: {compact}"
+        );
+        assert_eq!(
+            pip_failure_category(&compact),
+            "no-matching-dist",
+            "the tail alone is genuinely ambiguous; that is why evidence is needed"
+        );
+
+        let evidence = super::pip_failure_evidence(&err, &compact);
+        assert_eq!(
+            super::pip_failure_category_with_evidence(&compact, &evidence),
+            "network",
+            "a starved index must not be filed as a bad pin in our lock"
+        );
+    }
+
+    /// The counter-case the two-signal rule exists for (RUST-6S): a pin our
+    /// lock really did get wrong. pip reached the index and listed what it
+    /// found, so nothing here may be excused as a network fault.
+    #[test]
+    fn a_genuinely_bad_pin_keeps_its_verdict() {
+        let stderr = concat!(
+            "ERROR: Could not find a version that satisfies the requirement onnxruntime==1.27.0 ",
+            "(from versions: 1.13.1, 1.22.0, 1.23.2)\n",
+            "ERROR: No matching distribution found for onnxruntime==1.27.0\n",
+        );
+        let err = pip_failure(stderr);
+        let compact = compact_pip_failure(&err);
+        let evidence = super::pip_failure_evidence(&err, &compact);
+        assert_eq!(
+            super::pip_failure_category_with_evidence(&compact, &evidence),
+            "no-matching-dist"
+        );
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -630,6 +630,13 @@ const CANCELLATION_REASONS: { value: string; label: string }[] = [
 const authCodeExpiryFallbackSeconds = 900;
 const APP_UPDATE_BACKGROUND_INITIAL_DELAY_MS = 12_000;
 const APP_UPDATE_BACKGROUND_CHECK_INTERVAL_MS = 60 * 60 * 1000;
+// Desktop activation is a one-shot "this device is live" ping to headroom-web.
+// It is not worth an unbounded retry: a machine that is offline now is usually
+// offline for a while, and every attempt costs a Sentry warning. Five attempts
+// spread over ~8 minutes, then wait for the next launch.
+const DESKTOP_ACTIVATION_MAX_ATTEMPTS = 5;
+const DESKTOP_ACTIVATION_RETRY_BASE_MS = 30_000;
+const DESKTOP_ACTIVATION_RETRY_MAX_MS = 5 * 60 * 1000;
 
 async function loadDashboard(): Promise<DashboardState> {
   try {
@@ -1740,6 +1747,16 @@ export default function App() {
   const [showAllUpgradePlans, setShowAllUpgradePlans] = useState(false);
   const [checkoutPollingDeadline, setCheckoutPollingDeadline] = useState<number | null>(null);
   const desktopActivationSentRef = useRef(false);
+  // Activation retry bookkeeping. A failed attempt used to clear
+  // `desktopActivationSentRef` immediately, so the next flip of any dep below
+  // (runtime reachability flaps every time the proxy restarts) fired another
+  // attempt with no delay -- offline machines sent 187 activation failures to
+  // Sentry in 12 hours, two of them 3 seconds apart (RUST-7H/RUST-8X). Retry
+  // on a widening backoff instead, and stop after a handful: activation is
+  // best-effort, and the next app launch tries again from scratch.
+  const desktopActivationAttemptsRef = useRef(0);
+  const desktopActivationRetryTimerRef = useRef<number | undefined>(undefined);
+  const [desktopActivationRetry, setDesktopActivationRetry] = useState(0);
   // Persisted: pricing gates last days, and an app restart mid-gate used to
   // lose this set — the auto-disabled connectors then never re-enabled when
   // the gate reopened, leaving users silently unoptimized until a manual
@@ -2007,8 +2024,19 @@ export default function App() {
   useEffect(() => {
     if (!pricingStatus?.authenticated) {
       desktopActivationSentRef.current = false;
+      // Signing out and back in is an explicit user action: give it a full
+      // fresh budget rather than whatever the previous session burned.
+      desktopActivationAttemptsRef.current = 0;
+      window.clearTimeout(desktopActivationRetryTimerRef.current);
+      desktopActivationRetryTimerRef.current = undefined;
     }
   }, [pricingStatus?.authenticated]);
+
+  // Drop any pending activation retry when the app unmounts.
+  useEffect(
+    () => () => window.clearTimeout(desktopActivationRetryTimerRef.current),
+    []
+  );
 
   useEffect(() => {
     if (!pricingStatus) return;
@@ -3360,11 +3388,38 @@ export default function App() {
     }
     desktopActivationSentRef.current = true;
     void invoke<HeadroomPricingStatus>("activate_headroom_account")
-      .then((status) => setPricingStatus(status))
+      .then((status) => {
+        desktopActivationAttemptsRef.current = 0;
+        setPricingStatus(status);
+      })
       .catch(() => {
-        desktopActivationSentRef.current = false;
+        const attempts = (desktopActivationAttemptsRef.current += 1);
+        if (attempts >= DESKTOP_ACTIVATION_MAX_ATTEMPTS) {
+          // Leave the guard set: this launch is done trying. The machine is
+          // offline or headroom-web is down, and neither is something more
+          // requests fix.
+          return;
+        }
+        const delay = Math.min(
+          DESKTOP_ACTIVATION_RETRY_BASE_MS * 2 ** (attempts - 1),
+          DESKTOP_ACTIVATION_RETRY_MAX_MS
+        );
+        window.clearTimeout(desktopActivationRetryTimerRef.current);
+        desktopActivationRetryTimerRef.current = window.setTimeout(() => {
+          desktopActivationSentRef.current = false;
+          // The guard alone cannot restart the effect (no dep changed), so
+          // bump a counter the effect watches. Without it a cleared guard just
+          // waits for the next unrelated reachability flap.
+          setDesktopActivationRetry((n) => n + 1);
+        }, delay);
       });
-  }, [connectorPhase, pricingStatus?.authenticated, runtimeStatus?.proxyReachable, runtimeStatus?.running]);
+  }, [
+    connectorPhase,
+    desktopActivationRetry,
+    pricingStatus?.authenticated,
+    runtimeStatus?.proxyReachable,
+    runtimeStatus?.running,
+  ]);
 
   // While verifying, poll the proxy's /stats request counter and flip to
   // healthy when it ticks past the anchor we captured on the first reachable


### PR DESCRIPTION
Triage of the 21 Sentry issues with activity in the last 12 hours. Eight of them (five root causes) are fixed here. Each fix is at the emit site — none of them widens a throttle to hide a symptom.

All counts below are the issue's lifetime totals as of triage.

## RUST-7H / RUST-8X — activation retry storm (187 events, 6 users)

The activation effect in `App.tsx` cleared its "already sent" guard inside `.catch()`. Any dep flip re-fired it immediately, and runtime reachability flaps on every proxy restart, so one offline machine sent 187 events in 12 hours — two of them 3 seconds apart.

- Frontend: retry on a widening backoff (30s doubling to 5m, 5 attempts over ~8 minutes), then stop until the next launch. The guard now stays set through the backoff, and a state counter drives the retry so a cleared guard doesn't just wait for an unrelated reachability flap.
- Backend backstop: transient activation transport failures are throttled with the same doubling window `/stats` uses, and fingerprinted by failure kind. The two issues are one dead network filed twice, because `transport_failure` produces different prose per kind and Sentry groups on message text. Non-transport failures still report at Error, unthrottled.

The premise this path shipped with — "sign-in runs ~15x/day fleet-wide, so capturing every failure costs little" — was wrong about who calls it. `request_auth_code` and `verify_auth_code` are genuinely user-initiated and are left alone.

## RUST-86 — the `/stats` backoff was unreachable (1066 events)

The streak reset on the first successful fetch. But the common failure shape is a backend that answers in ~3s when idle and runs past the 15s timeout while serving a session, so successes and timeouts alternate — and every timeout found an empty slot and warned immediately. No host ever reached streak 2, which is why a 15m→6h backoff still produced 1066 events.

Recovery now has to be sustained for a full window before it forgives the backoff. A suppressed failure still breaks the healthy run.

## RUST-90 — a starved index blamed on our own lock

`compact_pip_failure` tails from pip's first `ERROR:` line, and pip prints its `Could not fetch URL` warnings above it — so the evidence that separates an unreachable index from a bad pin never reached the classifier. `colorama==0.4.6`, a pure-python wheel that exists for every platform we ship, was filed under `no-matching-dist`, the bucket whose stated meaning is "a bad pin in *our* lock".

Classification now reads pip's full output for the index-starvation and network checks; the compact tail still drives every other bucket, so the categories keep matching the message text triage reads. A genuinely bad pin (RUST-6S: pip reached the index and listed real versions) keeps its verdict — covered by a test.

The existing category name (`network`) is kept deliberately rather than introducing a new one, so no Sentry fingerprint is renamed.

## RUST-6F / RUST-6G — a successful sweep reported as a failure

`powershell -Command` exits 1 whenever the last pipeline element left `$?` false, and `-ErrorAction SilentlyContinue` suppresses the message without clearing the flag. So a `Stop-Process` against a pid that had already exited — the common case here, since we just asked the proxy to stop — made a fully successful sweep look broken. The Unix branch has always treated the equivalent `pkill` exit 1 as success.

The script now states its own verdict: `exit 0` when the sweep ran, a distinct code when the `Win32_Process` enumeration itself failed (WMI unavailable/denied), which is the only outcome worth reporting. A powershell that cannot start at all reaches neither and still surfaces through the existing session-teardown handling.

The script builder was hoisted out of the `cfg(windows)` block so it can be tested on Linux CI.

## RUST-AD / RUST-AC — one App Control block filed twice

A Windows Application Control policy (Smart App Control / WDAC / AppLocker) refusing to execute the runtime was captured at **Error** with no fingerprint, so Sentry grouped on a message embedding the proxy's full command line — the port and the user's home path. The two issues are the same host's same block, split only because the two call sites prefix it differently.

Nothing we ship changes a machine's security policy, and `classify_startup_error` already turns this into an actionable user-facing hint. It is now captured once per session at Warning under a stable fingerprint, with the error chain kept as an extra so the cohort stays countable.

`apply_client_setup`'s resume failure was the one start-failure site not going through the shared classifier (hence no port-conflict handling, no endpoint-protection handling, no structured extras). It now routes through `capture_headroom_start_failure` like its sibling, with the raw chain kept local-only.

## Triaged, not fixed

- **RUST-AA** (codex 404 on `/v1/responses`, 8 events, empty body) — already fully instrumented by the RUST-4V work. The tags needed to diagnose it are being collected; there is no code change to make until they say what the shape is. Most likely a third-party base URL that does not implement the endpoint.
- **RUST-91 / RUST-9Y** (bootstrap failed / abandoned at "Updating dependencies") — downstream of the RUST-90 pip failure. The classification fix should route these to the right cause rather than the `other` grab-bag; worth re-checking after this ships.
- The remaining issues in the window are already `ignored` or `resolved`, or are covered by fixes already sitting in staging (RUST-87, RUST-4V, RUST-7M, RUST-4H, RUST-5T).

## Testing

- `cargo test --lib`: **1050 passed**. Two pre-existing failures in `client_adapters` (`purge_dir_tolerantly_skips_past_an_undeletable_entry`, `remove_dir_all_retry_clears_readonly_instead_of_giving_up`) fail identically on unmodified `staging` — they assert a file is undeletable, which does not hold in a container running as root. Not related to this change.
- `npx tsc --noEmit`: clean (one pre-existing `tsconfig` deprecation notice, unchanged).
- `npm test`: **416 passed**, 23 files.
- `cargo fmt --check`: my code is clean. Nine pre-existing formatting diffs remain untouched — a global `cargo fmt` was reverted out of this diff so it carries no unrelated churn.
- `npm run check:colors`: 480 raw colors, baseline 480. No CSS touched.

New regression tests cover each fix. The `/stats` recovery test was mutation-checked: reverting the fix makes it fail with the intended message. The PowerShell script has structural tests (single line, balanced braces, no glued tokens across the `\`-continued literal, escaping intact) because it only ever runs on Windows, where a quoting slip is invisible until a user hits it.

Not verified in this environment: runtime behaviour on Windows and macOS, and dark mode (no visual changes in this diff).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVasWBM4kck5EQvjwYJ4Zr)_