### PR TITLE
fix(sentry): stop four issues from re-reporting conditions that cannot resolve

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2042,6 +2042,41 @@ pub(crate) fn is_port_conflict_failure(technical_err: &str) -> bool {
 /// contains a `HeadroomStartupFailure`, its log tail, log path, and invocation
 /// are sent as structured `extra` fields so we can see what Python printed
 /// before failing to bind the port.
+/// Coarse cause class for a managed-backend start failure, used as the Sentry
+/// fingerprint.
+///
+/// `HeadroomStartupFailure`'s `Display` embeds the program path, the full argv
+/// and the log tail, and Sentry groups an un-fingerprinted `capture_message` by
+/// its message text. So ONE condition -- the managed backend will not stay up --
+/// opened a fresh issue per command line and per exit code, none of them
+/// resolvable: RUST-9F/AF/AH/AJ/AK were all this failure wearing different
+/// argv. Same split as the pip (RUST-6M/6N/6P) and plugin (RUST-6K) captures.
+/// The variable detail still ships as `extra` on every event; only this bounded
+/// class reaches the fingerprint.
+fn headroom_start_failure_category(reason: &str) -> String {
+    if let Some(rest) = reason.strip_prefix("exited with status ") {
+        // `ExitStatus` renders as "exit code: 0xffffffff" (Windows),
+        // "exit status: 1" or "signal: 6 (SIGABRT)" (unix), followed by
+        // " before opening port N". Keep the status -- 0xffffffff is its own
+        // bug class, a native DLL init crash (RUST-9F/9T) -- drop the port.
+        let status = rest
+            .split(" before opening port")
+            .next()
+            .unwrap_or(rest)
+            .trim()
+            .trim_start_matches("exit code:")
+            .trim_start_matches("exit status:")
+            .trim();
+        format!("exited-{status}")
+    } else if reason.starts_with("wait check failed") {
+        "wait-check-failed".to_string()
+    } else if reason.starts_with("never opened port") {
+        "startup-timeout".to_string()
+    } else {
+        "other".to_string()
+    }
+}
+
 pub(crate) fn capture_headroom_start_failure(context: &str, err: &anyhow::Error) {
     let technical_err = format!("{err:#}");
 
@@ -2089,8 +2124,13 @@ pub(crate) fn capture_headroom_start_failure(context: &str, err: &anyhow::Error)
     }
 
     if let Some(failure) = startup_failure {
+        let category = headroom_start_failure_category(&failure.reason);
         sentry::with_scope(
             |scope| {
+                // `context` is a bounded set of call sites and keeps the
+                // launch/tray lifecycles apart; `category` is the cause class.
+                // Neither can fragment, unlike the argv in the message text.
+                scope.set_fingerprint(Some(&["headroom-start-failed", context, &category]));
                 scope.set_extra("program", failure.program.clone().into());
                 scope.set_extra("args", failure.args.join(" ").into());
                 scope.set_extra("log_path", failure.log_path.clone().into());
@@ -9717,6 +9757,43 @@ Some unrelated content.
             "venv interpreter exited with status 1"
         ));
         assert!(!is_port_conflict_failure(""));
+    }
+
+    #[test]
+    fn headroom_start_failure_category_collapses_the_argv_grab_bag() {
+        // RUST-9F/AF/AH/AJ/AK: one condition, five issues, because the
+        // un-fingerprinted message carried the program path and full argv.
+        use super::headroom_start_failure_category as cat;
+
+        // The exit status is the bug class and survives; the port does not.
+        assert_eq!(
+            cat("exited with status exit code: 0xffffffff before opening port 6768"),
+            "exited-0xffffffff"
+        );
+        assert_eq!(
+            cat("exited with status exit status: 1 before opening port 6768"),
+            "exited-1"
+        );
+        // A different port is the SAME bug -- this is what used to split.
+        assert_eq!(
+            cat("exited with status exit status: 1 before opening port 6767"),
+            "exited-1"
+        );
+        assert_eq!(
+            cat("exited with status signal: 6 (SIGABRT) before opening port 6768"),
+            "exited-signal: 6 (SIGABRT)"
+        );
+        // The two non-exit shapes stay separate: a wedged start and a crashed
+        // one are different bugs.
+        assert_eq!(
+            cat("never opened port 6768 within 45000ms"),
+            "startup-timeout"
+        );
+        assert_eq!(
+            cat("wait check failed: No child processes (os error 10)"),
+            "wait-check-failed"
+        );
+        assert_eq!(cat("something upstream changed"), "other");
     }
 
     #[test]

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -377,6 +377,33 @@ fn skip_sentry(target: &str, msg: &str) -> bool {
     {
         return true;
     }
+    // Routing a missing managed runtime back to setup is the RECOVERY path, and
+    // the emit site says so: `ensure_runtime_ready_for_tray` deliberately logs
+    // instead of calling `capture_headroom_start_failure`, because capturing a
+    // not-installed runtime as a startup crash was misleading noise (RUST-1M).
+    // The log bridge defeated that intent -- the warn reached Sentry anyway as
+    // RUST-8W, and because it interpolates `{err:#}` (program, full argv, log
+    // tail) it fragmented per command line on top. The app re-runs bootstrap
+    // from the setup window, so there is no failure left to report.
+    if target.starts_with("headroom_desktop_lib")
+        && msg.starts_with("ensure_runtime_ready_for_tray: managed runtime missing")
+    {
+        return true;
+    }
+    // The detached-proxy sweep in `stop_headroom` is best-effort teardown. On
+    // unix a `pkill` that matched nothing (exit 1) is already treated as
+    // success; the Windows branch has no such carve-out, so a PowerShell that
+    // exits non-zero -- matched nothing, or WMI hiccuped -- surfaced as a
+    // warning per command pattern (RUST-6F/6G, one issue each for
+    // `-m headroom.proxy.server` and `proxy --port`). Nothing is actionable:
+    // the app is stopping, and the next launch's `reclaim_orphan_proxy` reaps
+    // whatever survived, which is the same reasoning that made the
+    // session-teardown exit codes an info log (RUST-7N). Keep the local log.
+    if target.starts_with("headroom_desktop_lib::state")
+        && msg.starts_with("failed to clean detached headroom proxy processes")
+    {
+        return true;
+    }
     // Stopping without the lifecycle lock is the DESIGNED path, not a failure:
     // `stop_headroom` deliberately caps its wait so a quit racing a launch can
     // never hang the app with the window stuck on "Restarting...". The pkill
@@ -792,6 +819,43 @@ mod tests {
         assert!(!skip_sentry(
             "headroom_desktop_lib::state",
             "WebView2 error: something we emitted ourselves"
+        ));
+    }
+
+    #[test]
+    fn skips_tray_missing_runtime_route_to_setup() {
+        // RUST-8W: the emit site already decided this is a recovery, not a
+        // crash (RUST-1M); the log bridge sent it to Sentry regardless, with
+        // the whole argv inlined so it fragmented per command line too.
+        assert!(skip_sentry(
+            "headroom_desktop_lib",
+            "ensure_runtime_ready_for_tray: managed runtime missing; routing to setup: unable to keep headroom running in background (prior attempts: ~\\AppData\\Local\\Headroom\\headroom\\runtime\\venv\\Scripts\\headroom.exe proxy --port 6768 exited with status exit code: 1)"
+        ));
+        // A real tray-path start failure still reports.
+        assert!(!skip_sentry(
+            "headroom_desktop_lib",
+            "ensure_runtime_ready_for_tray failed: unable to keep headroom running in background"
+        ));
+    }
+
+    #[test]
+    fn skips_detached_proxy_sweep_failures() {
+        // RUST-6F/6G: one issue per command pattern, from a best-effort sweep
+        // during teardown that unix already treats as success when it matches
+        // nothing.
+        assert!(skip_sentry(
+            "headroom_desktop_lib::state",
+            "failed to clean detached headroom proxy processes: powershell exited with status Some(1) for exe '~\\AppData\\Local\\Headroom\\headroom\\runtime\\venv\\Scripts\\python.exe' args '-m headroom.proxy.server'"
+        ));
+        assert!(skip_sentry(
+            "headroom_desktop_lib::state",
+            "failed to clean detached headroom proxy processes: powershell exited with status Some(1) for exe '~\\AppData\\Local\\Headroom\\headroom\\runtime\\venv\\Scripts\\headroom.exe' args 'proxy --port'"
+        ));
+        // The refusal guard is a real bug (an unresolved runtime path would
+        // turn the sweep into a loose substring kill), so it must still report.
+        assert!(!skip_sentry(
+            "headroom_desktop_lib::state",
+            "refusing to pkill with an unresolved executable path \"\""
         ));
     }
 

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -164,6 +164,45 @@ fn transport_level(err: &reqwest::Error) -> sentry::Level {
     }
 }
 
+/// Actions that have already reported a TRANSIENT transport failure this
+/// session, so the repeats can be dropped.
+static TRANSIENT_TRANSPORT_REPORTED: std::sync::Mutex<
+    Option<std::collections::HashSet<&'static str>>,
+> = std::sync::Mutex::new(None);
+
+/// Build the user-facing message for a failed round trip and report it, with
+/// the transient class capped at ONE event per action per session.
+///
+/// Issue #58 wants the user count, and capturing every transient failure did
+/// deliver it -- then kept charging for it. The desktop-activation effect
+/// re-fires whenever the runtime-health signal flaps (a 3s poll drives it), so
+/// four persistently-offline machines produced RUST-7H: 229 events in 4 days,
+/// all of them the same four users re-reporting a captive portal. Sign-in code
+/// verification is the same shape (RUST-AM).
+///
+/// The first failure per action still speaks, so `users_impacted` -- the number
+/// issue #58 actually asked for -- is unchanged; only the per-host repetition
+/// goes. A NON-transport failure implies something wrong on our side, so it is
+/// never gated and still reports every time.
+fn report_transport_failure(action: &'static str, err: &reqwest::Error) -> String {
+    let msg = transport_failure(action, err);
+    if is_transient_transport_error(err) {
+        let mut seen = TRANSIENT_TRANSPORT_REPORTED.lock().unwrap_or_else(|e| {
+            // A poisoned lock must not silence reporting outright.
+            TRANSIENT_TRANSPORT_REPORTED.clear_poison();
+            e.into_inner()
+        });
+        if !seen
+            .get_or_insert_with(std::collections::HashSet::new)
+            .insert(action)
+        {
+            return msg;
+        }
+    }
+    sentry::capture_message(&msg, transport_level(err));
+    msg
+}
+
 fn plan_tier_header_value(tier: &ClaudePlanTier) -> &'static str {
     match tier {
         ClaudePlanTier::Free => "free",
@@ -1229,11 +1268,7 @@ pub(crate) fn request_auth_code_with_base_url(
             identity: IdentityPayload::for_state(state),
         })
         .send()
-        .map_err(|err| {
-            let msg = transport_failure("request a sign-in code", &err);
-            sentry::capture_message(&msg, transport_level(&err));
-            msg
-        })?;
+        .map_err(|err| report_transport_failure("request a sign-in code", &err))?;
 
     if !response.status().is_success() {
         let status = response.status().as_u16();
@@ -1292,11 +1327,7 @@ pub(crate) fn verify_auth_code_with_base_url(
             identity: IdentityPayload::for_state(state),
         })
         .send()
-        .map_err(|err| {
-            let msg = transport_failure("verify your sign-in code", &err);
-            sentry::capture_message(&msg, transport_level(&err));
-            msg
-        })?;
+        .map_err(|err| report_transport_failure("verify your sign-in code", &err))?;
 
     if !response.status().is_success() {
         return Err(format!(
@@ -1372,11 +1403,7 @@ pub(crate) fn activate_account_with_base_url(
         .apply_headers(builder)
         .json(&serde_json::json!({ "lifetime_tokens_saved": lifetime_tokens_saved }))
         .send()
-        .map_err(|err| {
-            let msg = transport_failure("activate Headroom desktop access", &err);
-            sentry::capture_message(&msg, transport_level(&err));
-            msg
-        })?;
+        .map_err(|err| report_transport_failure("activate Headroom desktop access", &err))?;
 
     if response.status().as_u16() == 401 {
         clear_session_token()?;

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -5816,13 +5816,29 @@ impl HeadroomSavingsHistoryResponse {
 /// RUST-87 is a single mac whose 6767 belongs to another app, and the flat
 /// 15-minute window sent 96 identical events a day from that one host with no
 /// end state. A first failure still speaks immediately; only the repeats decay.
-/// A successful fetch clears the streak, so a condition that heals and comes
-/// back is loud again.
+/// A SUSTAINED run of successes clears the streak, so a condition that truly
+/// heals and comes back is loud again. One success is NOT enough: the common
+/// starved-backend shape flaps -- a cold `/stats` rebuild crosses 15s only
+/// while the proxy is busy serving a session -- so clearing on the first
+/// success reset the backoff between every pair of timeouts and the streak
+/// never reached 2. That is how RUST-86 sent 97 events in 2 days from a single
+/// host: the flat-window volume this backoff exists to prevent. The streak
+/// clears only after `STATS_FETCH_RECOVERY_WINDOW` of unbroken successes; any
+/// failure restarts that run.
 /// ponytail: one global slot, not per-category -- a host has one cause at a
 /// time in practice; key it by category if that stops being true.
 const STATS_FETCH_WARN_INTERVAL: Duration = Duration::from_secs(900);
 const STATS_FETCH_WARN_MAX_INTERVAL: Duration = Duration::from_secs(6 * 3600);
+/// How long `/stats` must fetch cleanly before a recovery counts as real. The
+/// dashboard polls every 12s, so this is ~25 consecutive good fetches -- long
+/// enough that a busy-proxy flap cannot span it, short enough that a genuine
+/// fix is loud again within one sitting.
+const STATS_FETCH_RECOVERY_WINDOW: Duration = Duration::from_secs(300);
 static STATS_FETCH_WARNED_AT: Mutex<Option<(Instant, u32)>> = Mutex::new(None);
+/// When the current unbroken run of successful fetches began; `None` when the
+/// last fetch failed or nothing has failed yet.
+/// Lock order: take `STATS_FETCH_WARNED_AT` before this one.
+static STATS_FETCH_RECOVERED_AT: Mutex<Option<Instant>> = Mutex::new(None);
 
 /// Window a warn must clear before the `streak`-th consecutive one may speak:
 /// 15m, 30m, 1h, 2h, 4h, then capped. `streak` is 1-based.
@@ -5859,6 +5875,9 @@ fn stats_fetch_failure_category(reason: &str) -> String {
 
 fn warn_stats_fetch_failed(reason: &str) {
     let mut last = STATS_FETCH_WARNED_AT.lock();
+    // Any failure breaks the recovery run -- including one this window
+    // throttles, which is still evidence the condition has not healed.
+    *STATS_FETCH_RECOVERED_AT.lock() = None;
     let streak = match *last {
         Some((at, streak)) => {
             if at.elapsed() < stats_fetch_warn_interval(streak) {
@@ -5914,6 +5933,35 @@ fn warn_stats_fetch_failed(reason: &str) {
     log::warn!("{message}");
 }
 
+/// Record a successful `/stats` fetch, clearing the warn backoff only once the
+/// successes have been unbroken for `STATS_FETCH_RECOVERY_WINDOW`.
+///
+/// The window is what makes the backoff hold under a FLAPPING cause. Resetting
+/// on the first success meant a host alternating timeout/success re-armed an
+/// immediate warn every poll, so the streak never advanced past 1 and the
+/// 15m..6h decay never applied (RUST-86).
+fn note_stats_fetch_success() {
+    let mut warned = STATS_FETCH_WARNED_AT.lock();
+    let mut recovered = STATS_FETCH_RECOVERED_AT.lock();
+    if warned.is_none() {
+        // No outage to recover from; keep the marker clear so the next
+        // failure's first warn still speaks immediately.
+        *recovered = None;
+        return;
+    }
+    match *recovered {
+        // The run has spanned the window: the cause is really gone.
+        Some(since) if since.elapsed() >= STATS_FETCH_RECOVERY_WINDOW => {
+            *warned = None;
+            *recovered = None;
+        }
+        // Run in progress but too short to trust yet.
+        Some(_) => {}
+        // First success after a failure: start timing the run.
+        None => *recovered = Some(Instant::now()),
+    }
+}
+
 fn fetch_headroom_dashboard_stats() -> Option<HeadroomDashboardStats> {
     if !is_headroom_proxy_reachable() {
         return None;
@@ -5967,8 +6015,9 @@ fn fetch_headroom_dashboard_stats() -> Option<HeadroomDashboardStats> {
         };
 
         if let Some(parsed) = parse_headroom_stats_from_json(&body) {
-            // Recovery resets the backoff: the next outage warns immediately.
-            *STATS_FETCH_WARNED_AT.lock() = None;
+            // Only a SUSTAINED recovery resets the backoff; a lone success
+            // between two timeouts must not (see STATS_FETCH_RECOVERY_WINDOW).
+            note_stats_fetch_success();
             return Some(parsed);
         }
         last_failure = Some("payload had no recognised savings fields".to_string());
@@ -8042,8 +8091,8 @@ mod tests {
         bootstrap_failed_state, classify_startup_error, cpu_time_advanced, drop_rollup_backfill,
         hf_cache_grew, intercept_bind_hint, lifetime_output_savings_usd,
         lifetime_token_milestones_crossed, log_mtime_advanced, merge_daily_savings,
-        merge_hourly_savings, most_recent_monday, parse_headroom_stats_from_json,
-        parse_headroom_stats_history_from_json, parse_ps_cpu_time,
+        merge_hourly_savings, most_recent_monday, note_stats_fetch_success,
+        parse_headroom_stats_from_json, parse_headroom_stats_history_from_json, parse_ps_cpu_time,
         proxy_readyz_503_body_is_upstream_only, proxy_readyz_status_is_reachable,
         rebuild_persisted_savings_from_records, savings_rate_implausible, settle_rollup_backfill,
         stats_fetch_warn_interval, support_tier_for_platform, tcp_port_accepts_connection,
@@ -8051,8 +8100,8 @@ mod tests {
         BootValidationOutcome, ClaudeProjectScan, DailySavingsBucket, Duration,
         HeadroomDashboardStats, HeadroomSavingsHistoryPoint, Instant, OutputSampleBucket,
         PersistedSavingsState, RingStartTotals, SavingsObservation, SavingsRecord, SavingsTracker,
-        OUTPUT_SAMPLE_SERIES_VERSION, STATS_FETCH_WARNED_AT, STATS_FETCH_WARN_INTERVAL,
-        STATS_FETCH_WARN_MAX_INTERVAL,
+        OUTPUT_SAMPLE_SERIES_VERSION, STATS_FETCH_RECOVERED_AT, STATS_FETCH_RECOVERY_WINDOW,
+        STATS_FETCH_WARNED_AT, STATS_FETCH_WARN_INTERVAL, STATS_FETCH_WARN_MAX_INTERVAL,
     };
 
     #[test]
@@ -10667,6 +10716,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(stats_fetch_warn)]
     fn stats_fetch_warn_is_throttled_within_the_window() {
         // The dashboard retries /stats every 12s and this warn bridges to
         // Sentry, so only the first failure in a window may speak.
@@ -10710,6 +10760,62 @@ mod tests {
         }
 
         *STATS_FETCH_WARNED_AT.lock() = None;
+    }
+
+    #[test]
+    #[serial_test::serial(stats_fetch_warn)]
+    fn a_lone_success_between_failures_does_not_reset_the_backoff() {
+        // RUST-86: a starved backend flaps -- /stats times out only while the
+        // proxy is busy -- so timeout/success/timeout was the common shape.
+        // Clearing the streak on the FIRST success re-armed an immediate warn
+        // every poll, so the streak never advanced past 1 and the 15m..6h
+        // decay never applied: 97 events in 2 days from one host.
+        *STATS_FETCH_WARNED_AT.lock() = None;
+        *STATS_FETCH_RECOVERED_AT.lock() = None;
+
+        warn_stats_fetch_failed("timed out after 15s");
+        let (_, streak) = (*STATS_FETCH_WARNED_AT.lock()).expect("first failure warns");
+        assert_eq!(streak, 1);
+
+        // One good poll starts a recovery run but must NOT clear the streak.
+        note_stats_fetch_success();
+        let (stamped, streak) = (*STATS_FETCH_WARNED_AT.lock()).expect("streak survives");
+        assert_eq!(streak, 1, "a lone success must not clear the backoff");
+        assert!(
+            (*STATS_FETCH_RECOVERED_AT.lock()).is_some(),
+            "the success starts timing a recovery run"
+        );
+
+        // The next failure warns only when the window has elapsed, and it
+        // breaks the recovery run.
+        warn_stats_fetch_failed("timed out after 15s");
+        assert_eq!(
+            (*STATS_FETCH_WARNED_AT.lock()).expect("still stamped").0,
+            stamped,
+            "the flap must stay throttled, not warn again immediately"
+        );
+        assert!(
+            (*STATS_FETCH_RECOVERED_AT.lock()).is_none(),
+            "a failure restarts the recovery run"
+        );
+
+        // A run that spans the window is a real recovery: the streak clears
+        // and the next outage is loud again.
+        if let Some(stale) = Instant::now().checked_sub(STATS_FETCH_RECOVERY_WINDOW) {
+            *STATS_FETCH_RECOVERED_AT.lock() = Some(stale);
+            note_stats_fetch_success();
+            assert!(
+                (*STATS_FETCH_WARNED_AT.lock()).is_none(),
+                "a sustained recovery clears the backoff"
+            );
+
+            warn_stats_fetch_failed("timed out after 15s");
+            let (_, streak) = (*STATS_FETCH_WARNED_AT.lock()).expect("loud again");
+            assert_eq!(streak, 1, "a healed-then-broken cause warns immediately");
+        }
+
+        *STATS_FETCH_WARNED_AT.lock() = None;
+        *STATS_FETCH_RECOVERED_AT.lock() = None;
     }
 
     #[test]


### PR DESCRIPTION
Triage of the last 36 hours of Sentry issues (20 unresolved in the window). Every fix here targets a **reporting** defect - a condition that re-reports without ever reaching an end state, or one condition fragmented across many un-resolvable issues. No user-facing behaviour changes.

## Fixes

### RUST-86 - `/stats` fetch timeout, 1330 events (highest volume in the window)

The warn backoff decays 15m -> 6h and is well tested, but a **single** successful poll cleared the streak. The dominant failure shape flaps: a cold `/stats` rebuild crosses 15s only while the proxy is busy serving a session, so `timeout/success/timeout` reset the backoff between every pair of failures and the streak never advanced past 1. The decay never applied.

Evidence: 97 events in 2 days from one host (`Bens-MacBook-Pro.local`); a working 6h-capped backoff caps that at ~8. That is the flat-window volume the backoff exists to prevent.

The streak now clears only after `STATS_FETCH_RECOVERY_WINDOW` (300s, ~25 consecutive good fetches) of unbroken successes; any failure restarts the run. A genuinely healed cause is still loud again within one sitting.

### RUST-9F / AF / AH / AJ / AK - one condition, five issues

`capture_headroom_start_failure` fingerprints its port-conflict branch but not the common one, which therefore grouped on a message embedding the program path, the full argv and the exit status. One condition - the managed backend will not stay up - opened a fresh issue per command line, none of them resolvable.

Now fingerprinted on the call site plus a bounded cause class (`exited-<status>` / `startup-timeout` / `wait-check-failed`). The exit status is kept because `0xffffffff` is its own bug class (a native DLL init crash); the port number and argv are not. All the variable detail still ships as event extras. Same split already applied to the pip (RUST-6M/6N/6P) and plugin (RUST-6K) captures.

### RUST-8W - the log bridge defeated a deliberate decision not to report

`ensure_runtime_ready_for_tray` deliberately logs instead of capturing, because a missing managed runtime is a recovery path, not a startup crash - that is the documented RUST-1M fix. The log bridge sent it to Sentry anyway, and because it interpolates `{err:#}` it fragmented per command line on top. Skipped at the bridge; the local log stays.

### RUST-6F / 6G - best-effort teardown reported as failure

The detached-proxy sweep in `stop_headroom` is best-effort. On unix a `pkill` that matched nothing (exit 1) is already treated as success; the Windows branch has no such carve-out, so PowerShell exiting non-zero warned once per command pattern. The app is stopping and the next launch's `reclaim_orphan_proxy` reaps survivors - the same reasoning that already made the session-teardown exit codes an info log (RUST-7N).

### RUST-7H / AM - activation and sign-in transport failures, 229 events / 4 users

Transient transport failures are captured on every attempt to preserve the user count from issue #58. That assumed sign-in runs "~15x/day fleet-wide"; the desktop-activation effect re-fires whenever the runtime-health signal flaps (a 3s poll drives it), so four persistently-offline machines produced 229 events in 4 days - the same four users re-reporting a captive portal.

The transient class is now capped at one event per action per session. `users_impacted` - the number issue #58 actually asked for - is unchanged, since a user who hits it at all still reports once. Non-transport failures imply something wrong on our side and are never gated.

## Investigated, no change needed

- **RUST-9A** (WebView2 `0x8007139F`, 1000 events) - already fixed. 995 of 1000 events are release `0.8.5`; the suppression landed in `0.8.6-rc.2`. These are old clients that have not updated, not a live defect.
- **RUST-7M** (`proxy_intercept` bind 10048) - working as designed. The `reported_errors` set gates one capture per process per error key, so 15 events is 15 launches, not a flood. `staging` also already has RUST-7M work in 43508b0.
- **RUST-A0 / AN** (`bootstrap_failed`, `ssl_library_conflict`) - already well instrumented (`failure_kind`, `openssl_dirs_on_path`, `endpoint_protection_suspected`), and already addressed on `staging` in 0d5ce98. A third-party OpenSSL DLL injected into the process; correctly reported and environmental.
- **RUST-90 / 6S / AE / AG** - pip and plugin install failures. Already carry per-category fingerprints, and all are environmental (offline index, AV file locks, Application Control policy).

## Rebase note

This branch was rebased onto `staging`, which already carried related Sentry work. Two overlaps were resolved by dropping my versions in favour of what `staging` had first:

- **RUST-A3** (ENFILE on `usage-counters.json`) - `staging` landed an identical fix as `is_system_fd_exhaustion`, including the same deliberate ENFILE-only scope (EMFILE stays reportable because that one can be our own descriptor leak). My duplicate predicate and test were removed.
- The `skip_sentry` insertion point collided with `staging`'s new zero-savings-canary rule; both rules are kept.

The `capture_headroom_start_failure` fingerprint here is unrelated to the "split fingerprint" in 0d5ce98, which covers a CLI-path fingerprint.

## Testing

- `cargo test --manifest-path src-tauri/Cargo.toml --lib` - **1045 passed, 2 failed**.
- Both failures (`purge_dir_tolerantly_skips_past_an_undeletable_entry`, `remove_dir_all_retry_clears_readonly_instead_of_giving_up`) are **pre-existing and environmental**, confirmed failing identically on a clean `origin/staging` checkout. They assert that a read-only tree blocks deletion, which does not hold for uid 0; this container runs as root.
- New regression tests: `a_lone_success_between_failures_does_not_reset_the_backoff` (asserts the exact flap that produced RUST-86), `headroom_start_failure_category_collapses_the_argv_grab_bag`, `skips_tray_missing_runtime_route_to_setup`, `skips_detached_proxy_sweep_failures`. The two tests that mutate the shared `/stats` throttle statics are serialized with `serial_test` to keep them from racing.
- `cargo fmt --check` reports 9 pre-existing diffs, the same 9 present on `origin/staging`; none are introduced here.
- No frontend files changed, so `tsc`/Vitest were not run.

I could not verify the Sentry volume drop directly - that only shows up once a release carrying this reaches the affected hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KyUVjjBcsKEF5kKVXtHps4)_