### PR TITLE
Release 0.9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Website](https://img.shields.io/badge/extraheadroom.com-website-blue?style=for-the-badge)](https://extraheadroom.com)&nbsp;&nbsp;[![Download](https://img.shields.io/github/v/release/gglucass/headroom-desktop?label=Download&style=for-the-badge&color=000000)](https://github.com/gglucass/headroom-desktop/releases/latest)
 
-> **macOS:** 14 (Sonoma) or later on Apple Silicon (M1 or later)
+> **macOS:** 14 (Sonoma) or later, Apple Silicon or Intel (universal build)
 >
 > **Windows:** Windows 10 or later, x64
 >
@@ -23,7 +23,7 @@ brew install --cask headroom
 **Option B - manual download:**
 
 1. Go to the [latest release](https://github.com/gglucass/headroom-desktop/releases/latest)
-2. **macOS:** download the `.dmg` (for example `Headroom_0.8.9_mac.dmg`), open it, drag **Headroom** to Applications
+2. **macOS:** download the `.dmg` (for example `Headroom_0.9.3_mac.dmg`), open it, drag **Headroom** to Applications
 3. **Windows:** download and run the `_x64-setup.exe` installer
 4. **Linux:** download the `.AppImage` (has the built-in updater) or the `.deb` (same build, updates only by downloading a newer one)
 5. Launch Headroom - it appears in your menu bar / system tray and walks you through setup
@@ -91,7 +91,7 @@ Full disclosure of every location Headroom writes to, so you can decide before i
 
 **On install:**
 
-- Downloads a self-contained Python runtime (~2 GB) under `~/Library/Application Support/Headroom`. Your system Python is untouched.
+- Downloads a self-contained Python runtime (~3 GB on disk) under `~/Library/Application Support/Headroom`. Your system Python is untouched.
 - Adds a `PreToolUse` hook to `~/.claude/settings.json` and a script at `~/.claude/hooks/headroom-rtk-rewrite.sh` so Claude Code routes through Headroom. A timestamped backup of `settings.json` is written before any edit.
 - For Codex, adds a Headroom provider block to `~/.codex/config.toml` and an `OPENAI_BASE_URL` export to your managed shell block so the Codex CLI and desktop app route through the local proxy. The TOML block is fenced with `# >>> headroom:... >>>` markers, a backup is written before any edit, and existing Codex threads are retagged to the managed provider.
 - For OpenCode, points the anthropic and openai provider base URLs in OpenCode's config at the local proxy and installs a small transport plugin. A backup is written before any edit.
@@ -124,7 +124,7 @@ If the proxy dies unexpectedly, a watchdog restarts it; after repeated failures 
 
 ## Compression benchmarks
 
-Numbers from the [headroom](https://github.com/chopratejas/headroom) open-source library that powers the optimization pipeline, summarized from the current published benchmarks page.
+Numbers from the [headroom](https://github.com/headroomlabs-ai/headroom) open-source library that powers the optimization pipeline, summarized from the current published benchmarks page.
 
 ### Current benchmark summary
 
@@ -161,7 +161,7 @@ Numbers from the [headroom](https://github.com/chopratejas/headroom) open-source
 - **Text compression (LLMLingua) adds latency.** It requires a ~2 GB model download on first use and doesn't break even on fast models. Useful for cost reduction, not speed.
 - **Plain-text RAG results pass through.** Compression targets tool outputs and JSON; plain text in user messages is not compressed.
 
-Full methodology and reproducible benchmarks: [chopratejas/headroom benchmarks](https://chopratejas.github.io/headroom/benchmarks/) · [limitations](https://chopratejas.github.io/headroom/LIMITATIONS/)
+Full methodology and reproducible benchmarks: [headroom benchmarks](https://docs.headroomlabs.ai/docs/benchmarks) · [limitations](https://docs.headroomlabs.ai/docs/limitations)
 
 ## Interesting design decisions
 
@@ -191,7 +191,7 @@ See [`docs/macos-release.md`](docs/macos-release.md) for the full release setup.
 
 ### Branching and versioning
 
-Use `./scripts/bump-version.sh <version>` to update all four version files at once (`package.json`, `package-lock.json`, `src-tauri/tauri.conf.json`, `Cargo.toml`). Accepts `X.Y.Z` or `X.Y.Z-rc.N` (leading `v` is stripped).
+Use `./scripts/bump-version.sh <version>` to update all five version files at once (`package.json`, `package-lock.json`, `src-tauri/tauri.conf.json`, `Cargo.toml`, `Cargo.lock`). Accepts `X.Y.Z` or `X.Y.Z-rc.N` (leading `v` is stripped).
 
 Two release channels are wired into CI:
 
@@ -203,7 +203,7 @@ Work happens on `feature/*` branches, which merge into `staging` for testing. St
 **Release candidate flow:**
 
 1. Merge work from a feature branch into `staging`.
-2. Bump `package.json` + `src-tauri/tauri.conf.json` to `X.Y.Z-rc.N` (e.g. `0.2.44-rc.1`) and push. `.github/workflows/release-macos-staging.yml` publishes a versioned prerelease tag `vX.Y.Z-rc.N` and mirrors the artifacts to the rolling `staging` release.
+2. Bump `package.json` + `src-tauri/tauri.conf.json` to `X.Y.Z-rc.N` (e.g. `0.9.4-rc.1`) and push. `.github/workflows/release-macos-staging.yml` publishes a versioned prerelease tag `vX.Y.Z-rc.N` and mirrors the artifacts to the rolling `staging` release.
 3. The staging test machine auto-updates (it has both endpoints baked in and routes itself to the staging endpoint because its installed version has an `-rc` suffix).
 4. If something is wrong, bump to `rc.2` and push again. Repeat until the build is good.
 
@@ -263,7 +263,7 @@ cargo clean --manifest-path src-tauri/Cargo.toml
 
 Three constants in [`src-tauri/src/tool_manager.rs`](src-tauri/src/tool_manager.rs) control the pin:
 
-- `HEADROOM_PINNED_VERSION` - the version string (e.g. `"0.8.2"`). Must match the wheel URL.
+- `HEADROOM_PINNED_VERSION` - the version string (e.g. `"0.37.0"`). Must match the wheel URL.
 - `HEADROOM_PINNED_WHEEL_URL` - the exact PyPI wheel URL to download.
 - `HEADROOM_PINNED_SHA256` - the wheel's SHA-256, verified after download.
 

--- a/docs/beta-smoke-test.md
+++ b/docs/beta-smoke-test.md
@@ -161,19 +161,15 @@ grep -c 'ccr_streaming_retrieve_buffered[^ ]* source=passthrough' \
 ```
 Expect: `0`. Anything above zero means a streaming CCR request forwarded `stream:true` bytes on a buffered path, and the client is about to receive an unparseable, unretryable 200. Verified discriminating: `0` on the current log, `6` across the pre-fix rotated logs.
 
-**11b. General discard rate (regression watch, not yet a FAIL).**
+**11b. General discard rate (hard FAIL since the headroom-ai 0.37.0 wheel).**
 ```bash
 grep -c 'body_mutated=true.*source=passthrough' ~/.headroom/logs/proxy.log
 grep 'body_mutated=true.*source=passthrough' ~/.headroom/logs/proxy.log \
   | sed -n 's/.*mutation_reasons=\([^ ]*\).*/\1/p' | tr ',' '\n' | sort | uniq -c
 ```
-Expect *today*: non-zero, listing only `output_shaper`, `image_compression`, and/or `structural_diff_vs_original`. That is upstream #2990 - on any turn whose history carries a signed `thinking` block, `select_outbound_body` forwards client bytes and discards every mutation, while PERF still counts them as delivered. Baseline observed on 0.8.1-rc.1 / headroom-ai 0.35.0: ~2,900 `output_shaper` and ~765 `image_compression` discards across ~6,400 outbound requests.
+Expect: `0` on the current wheel - the signed-thinking discard fix (upstream #3015, merged upstream in v0.36.0) ships here since the headroom-ai 0.37.0 bump in 0.9.4-rc.1. Scope the count to lines timestamped after the current backend booted: `proxy.log` persists across backend restarts, so pre-bump history keeps the whole-file grep non-zero forever (observed on the 0.9.4-rc.1 pass: 148 `output_shaper` discards from the same morning's 0.35.0 run, 0 since the rc boot). Boot time via `ps -o lstart= -p $(lsof -ti TCP:6768 -sTCP:LISTEN | head -1)`, then filter on the log timestamp before counting.
 
 `structural_diff_vs_original` is the one to read first, not last. The core compression pipeline never calls `mark_mutated` - grep the package and the reason vocabulary has no entry for it - so compression is only ever noticed by the structural safety net at the end of `handle_anthropic_messages`, which fires when no transform reported a mutation but the final body differs from the parsed original bytes. That makes this reason the label core compression lands under by omission, and a discard under it is the pipeline's own work being thrown away, which costs more than losing a shaping pass. It also means the share is not fixed: measured 7.6%-60% of mutated requests across six logs on 0.8.5-rc.1, tracking how much real compression happened. Do not read a ~3% reading as the `HEADROOM_OUTPUT_HOLDOUT=0.03` control arm - the arm gate and this one are unrelated, and the resemblance is a coincidence of whichever subset you counted.
-
-Two things make this a FAIL rather than a known-issue note:
-- any reason appearing that is **not** `output_shaper` / `image_compression` / `structural_diff_vs_original` - a new transform just joined the silent-discard set;
-- a **non-zero count at all**, once a wheel bump lands upstream PR #3015. Delete this paragraph and promote 11b to "expect `0`" at that bump.
 
 Do not try to derive this from PERF `transforms=` instead. That field includes detector-only and no-op entries (`router:noop`, `router:protected:error_output`), so joining it against `source=` reports ~1,100 false positives per log file. `mutation_reasons` is only written when the body actually changed.
 

--- a/docs/macos-release.md
+++ b/docs/macos-release.md
@@ -199,7 +199,7 @@ It:
 
 - runs on manual dispatch
 - also runs automatically when a version bump to `package.json` / `src-tauri/tauri.conf.json` is pushed to `main`
-- builds the Apple Silicon (`aarch64-apple-darwin`) release bundle
+- builds the universal macOS (`universal-apple-darwin`, Apple Silicon + Intel) release bundle
 - signs and notarizes the app
 - uploads updater artifacts and `latest.json` to the GitHub Release
 

--- a/docs/windows-smoke-test.md
+++ b/docs/windows-smoke-test.md
@@ -140,7 +140,7 @@ echo "zero-output claude 200s: $(grep -c 'PERF model=claude-[^ ]* .*tok_out=0 ' 
 echo "cache store refusals: $(grep -c 'response_cache_store_refused' "$L")"
 ```
 
-Expect: `empty-200 class` and `cache store refusals` `0` - non-zero is a hard FAIL. `zero-output claude 200s` should also be `0`, but a non-zero count is a tripwire, not yet a verdict: the PERF line carries no status, and an upstream error passed through produces the same shape (a session-start 429 logged `tok_out=0 ttfb_ms=0` on the 0.9.3-rc.5 pass). For each matching PERF line, find the `event=proxy_inbound_response ... path=/v1/messages status=` line at the same timestamp (its `duration_ms` tracks the PERF `total_ms`; the `hr_...` and `id=inbound-...` id namespaces never join, so the timestamp is the key). `status=200` there is the bug class and a hard FAIL; a 4xx/5xx is benign. `discards` may be non-zero on the current wheel pin: FAIL only if a reason other than `output_shaper` / `image_compression` / `structural_diff_vs_original` appears (a new transform joined the silent-discard set). Promote `discards` to "expect 0" at the wheel bump that lands upstream #3015, exactly as in the beta doc; the deeper poisoned-replay probe also lives there.
+Expect: `empty-200 class` and `cache store refusals` `0` - non-zero is a hard FAIL. `zero-output claude 200s` should also be `0`, but a non-zero count is a tripwire, not yet a verdict: the PERF line carries no status, and an upstream error passed through produces the same shape (a session-start 429 logged `tok_out=0 ttfb_ms=0` on the 0.9.3-rc.5 pass). For each matching PERF line, find the `event=proxy_inbound_response ... path=/v1/messages status=` line at the same timestamp (its `duration_ms` tracks the PERF `total_ms`; the `hr_...` and `id=inbound-...` id namespaces never join, so the timestamp is the key). `status=200` there is the bug class and a hard FAIL; a 4xx/5xx is benign. `discards` expects `0` since the 0.37.0 wheel (upstream #3015 landed with the 0.9.4 bump; verified 0 on the 0.9.4-rc.1 pass) - any non-zero count is a FAIL naming the regressed transform in `mutation_reasons`. The deeper poisoned-replay probe lives in the beta doc.
 
 ### 14. User state survived the upgrade
 
@@ -192,6 +192,30 @@ print('corrupt files:', sum(f.endswith('.corrupt') for f in os.listdir(S)))
 The script's snapshot-newer-than-binary guard applies to the **manual** snapshot only. The auto-snapshot in `config\pre-update\` is written on first launch of the new build, so it always postdates the install by construction - its validity check is `meta.json`'s versions, never its mtime.
 
 Expect: three `OK` lines and `corrupt files: 0`. Only `first_seen_at`, the two key sets, and the two activity-facts fields are compared - `paywall_first` (server-owned) and a `schemaVersion` tile reset may legitimately change. The snapshot dir survives across rcs, so check its mtimes first: if they predate the build you just replaced, say so in the report rather than claiming this rc preserved state.
+
+### 15. WinINET registry proxy override (RUST-AY / RUST-B3)
+
+Windows-only code path: a WinINET registry proxy with a scheme httpx cannot parse used to kill backend boot (exit 3 before opening 6768). The desktop now mirrors urllib's `ProxyServer` expansion - including CPython's backfill of missing http/https keys from a keyed `socks=` entry as `socks4://` (the RUST-B3 shape) - and overrides the child env. Three states; for each: quit Headroom, set the registry, relaunch, verify, then continue. Measurement rules learned the hard way on the 0.9.4-rc.1 pass:
+
+- The override line is written by the Rust app to `%LOCALAPPDATA%\Headroom\headroom-desktop.log` - NOT to `%LOCALAPPDATA%\Headroom\headroom\logs\` (those are the Python backend's logs).
+- Never probe with `Invoke-WebRequest`/`curl` while a registry proxy is set - they honor WinINET. Probe 6768 with a raw TCP connect via the bundled Python. 6767 is the intercept and answers even with the backend dead.
+- Expect the 6768 listener to be `runtime\python\python.exe` (the venv `Scripts` launcher spawns the base interpreter) - identity-verify against that path before killing anything.
+
+```powershell
+reg add 'HKCU\Software\Microsoft\Windows\CurrentVersion\Internet Settings' /v ProxyEnable /t REG_DWORD /d 1 /f
+# State A: reg add ... /v ProxyServer /t REG_SZ /d "socks4://127.0.0.1:10808" /f   -> boots, override line (NO_PROXY)
+# State B: reg add ... /v ProxyServer /t REG_SZ /d "http=127.0.0.1:8888;socks=127.0.0.1:1080" /f   -> boots, override line (http_proxy). Boot only - the http address is fake.
+# State C: reg add ... /v ProxyServer /t REG_SZ /d "socks=127.0.0.1:1080" /f   -> boots, override line (NO_PROXY)
+```
+
+Expect per state: backend accepting on 6768 within 90s and the log line `WinINET registry proxy carries a scheme httpx cannot parse; overriding N child proxy env var(s)` in the tail written since relaunch. MANDATORY cleanup, even on failure - the box must not keep a bogus system proxy:
+
+```powershell
+reg add 'HKCU\Software\Microsoft\Windows\CurrentVersion\Internet Settings' /v ProxyEnable /t REG_DWORD /d 0 /f
+reg delete 'HKCU\Software\Microsoft\Windows\CurrentVersion\Internet Settings' /v ProxyServer /f
+```
+
+Then relaunch once more and prove the end state with `reg query` on both values.
 
 ## Codex checks (Codex pass)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.4-rc.2",
+  "version": "0.9.4-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.4-rc.2",
+      "version": "0.9.4-rc.3",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.4-rc.5",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.4-rc.5",
+      "version": "0.9.4",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.4-rc.4",
+  "version": "0.9.4-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.4-rc.4",
+      "version": "0.9.4-rc.5",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.4-rc.3",
+  "version": "0.9.4-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.4-rc.3",
+      "version": "0.9.4-rc.4",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.3-rc.8",
+  "version": "0.9.4-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.3-rc.8",
+      "version": "0.9.4-rc.1",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.4-rc.1",
+  "version": "0.9.4-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.4-rc.1",
+      "version": "0.9.4-rc.2",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.4-rc.1",
+  "version": "0.9.4-rc.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.4-rc.3",
+  "version": "0.9.4-rc.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.4-rc.2",
+  "version": "0.9.4-rc.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.4-rc.4",
+  "version": "0.9.4-rc.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.4-rc.5",
+  "version": "0.9.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.3-rc.8",
+  "version": "0.9.4-rc.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.4-rc.2"
+version = "0.9.4-rc.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.4-rc.3"
+version = "0.9.4-rc.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.3-rc.8"
+version = "0.9.4-rc.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.4-rc.5"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.4-rc.4"
+version = "0.9.4-rc.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.4-rc.1"
+version = "0.9.4-rc.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.3-rc.8"
+version = "0.9.4-rc.1"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.4-rc.1"
+version = "0.9.4-rc.2"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.4-rc.3"
+version = "0.9.4-rc.4"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.4-rc.4"
+version = "0.9.4-rc.5"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.4-rc.5"
+version = "0.9.4"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.4-rc.2"
+version = "0.9.4-rc.3"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/src/analytics.rs
+++ b/src-tauri/src/analytics.rs
@@ -31,6 +31,12 @@ const ALLOWED_EVENTS: &[&str] = &[
     // At most once per install (persisted flag); measures how many users hit
     // the "setup finished but no traffic ever" state.
     "onboarding_recovery_nudge_shown",
+    // Emitted by the apply_client_setup command / watchdog repair since 0.8.x
+    // but missing here, so they were silently dropped by the gate below.
+    // Carries client_id + verified + proxy_reachable: the per-OS
+    // "applied but never verified/used" slice.
+    "client_setup_applied",
+    "client_setup_auto_repaired",
     // Addon adoption (one event per addon, fired from install/enable/uninstall).
     "markitdown_installed",
     "markitdown_enabled",

--- a/src-tauri/src/claude_cli.rs
+++ b/src-tauri/src/claude_cli.rs
@@ -32,6 +32,9 @@ fn detect_cli(name: &str) -> Option<PathBuf> {
     if let Some(path) = probe_on_path(name) {
         return Some(path);
     }
+    if let Some(path) = probe_version_manager_dirs(name) {
+        return Some(path);
+    }
     probe_via_login_shell(name)
 }
 
@@ -77,6 +80,78 @@ fn known_path_candidates_for_platform(home: PathBuf, name: &str, windows: bool) 
         candidates.push(path);
     }
     candidates
+}
+
+/// Version-managed node trees (nvm/mise/fnm) keep binaries under
+/// per-version dirs no static candidate list can name
+/// (`~/.nvm/versions/node/v22.1.0/bin/claude`). GUI launches inherit
+/// launchd's bare PATH and the login-shell probe is a coin flip against a
+/// noisy rc file (RUST-AZ: learn ran with no usable `claude` on a machine
+/// that has one) -- so enumerate the version dirs directly, newest first,
+/// and smoke-test like every other candidate.
+fn probe_version_manager_dirs(name: &str) -> Option<PathBuf> {
+    first_runnable(version_manager_candidates(home_dir(), name).into_iter())
+}
+
+fn version_manager_candidates(home: PathBuf, name: &str) -> Vec<PathBuf> {
+    let roots = [
+        (
+            home.join(".nvm").join("versions").join("node"),
+            PathBuf::from("bin"),
+        ),
+        (
+            home.join(".local")
+                .join("share")
+                .join("mise")
+                .join("installs")
+                .join("node"),
+            PathBuf::from("bin"),
+        ),
+        (
+            home.join(".fnm").join("node-versions"),
+            PathBuf::from("installation").join("bin"),
+        ),
+    ];
+    let mut candidates = Vec::new();
+    for (root, bin) in roots {
+        let Ok(entries) = std::fs::read_dir(&root) else {
+            continue;
+        };
+        let mut versions: Vec<String> = entries
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.path().is_dir())
+            .filter_map(|entry| entry.file_name().into_string().ok())
+            .collect();
+        sort_versions_newest_first(&mut versions);
+        for version in versions {
+            candidates.push(root.join(version).join(&bin).join(name));
+        }
+    }
+    candidates
+}
+
+/// Descending by the numeric runs in the name ("v10.1.0" above "v9.9.9",
+/// which plain string order gets backwards). Ties and non-numeric names sort
+/// arbitrarily but deterministically -- every candidate is smoke-tested
+/// anyway, order only decides which working install wins.
+fn sort_versions_newest_first(versions: &mut [String]) {
+    fn numeric_key(version: &str) -> Vec<u64> {
+        let mut nums = Vec::new();
+        let mut current = String::new();
+        for ch in version.chars() {
+            if ch.is_ascii_digit() {
+                current.push(ch);
+            } else if !current.is_empty() {
+                nums.push(current.parse().unwrap_or(0));
+                current.clear();
+            }
+        }
+        if !current.is_empty() {
+            nums.push(current.parse().unwrap_or(0));
+        }
+        nums
+    }
+    versions.sort_by(|a, b| numeric_key(b).cmp(&numeric_key(a)));
 }
 
 fn first_runnable<I: Iterator<Item = PathBuf>>(candidates: I) -> Option<PathBuf> {
@@ -420,6 +495,42 @@ mod tests {
 
         let candidates = vec![tmp.path().join("missing"), broken];
         assert!(first_runnable(candidates.into_iter()).is_none());
+    }
+
+    #[test]
+    fn version_sort_is_numeric_not_lexicographic() {
+        let mut versions = vec![
+            "v9.9.9".to_string(),
+            "v22.1.0".to_string(),
+            "v10.0.0".to_string(),
+        ];
+        sort_versions_newest_first(&mut versions);
+        assert_eq!(versions, ["v22.1.0", "v10.0.0", "v9.9.9"]);
+    }
+
+    #[test]
+    fn version_manager_candidates_walk_nvm_newest_first() {
+        let dir = ScopedTempDir::new("vm-candidates");
+        let home = dir.path().to_path_buf();
+        for version in ["v9.0.0", "v22.1.0"] {
+            std::fs::create_dir_all(
+                home.join(".nvm")
+                    .join("versions")
+                    .join("node")
+                    .join(version)
+                    .join("bin"),
+            )
+            .unwrap();
+        }
+        let candidates = version_manager_candidates(home.clone(), "claude");
+        let nvm = home.join(".nvm").join("versions").join("node");
+        assert_eq!(
+            candidates,
+            [
+                nvm.join("v22.1.0").join("bin").join("claude"),
+                nvm.join("v9.0.0").join("bin").join("claude"),
+            ]
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4223,6 +4223,11 @@ async fn apply_client_setup(
     }
     match client_adapters::apply_client_setup(&client_id) {
         Ok(result) => {
+            // Funnel beacon lives here (not the launcher UI) so every apply
+            // path counts: launcher auto-configure, the manual client-setup
+            // screen, and the dashboard connector toggle. First-write-wins
+            // server-side, so post-onboarding re-applies are no-ops.
+            pricing::report_funnel_step(&state, "client_setup_applied");
             analytics::track_event(
                 &app,
                 "client_setup_applied",
@@ -4293,6 +4298,11 @@ async fn apply_client_setup(
                     },
                 );
             }
+            // Unlike the Sentry capture above, the funnel beacon has no
+            // exclusions: permission-denied and disk-full are environmental,
+            // but the per-OS funnel still needs them counted as "setup was
+            // attempted and did not stick" (invisible on Windows otherwise).
+            pricing::report_funnel_step(&state, "client_setup_failed");
             Err(msg)
         }
     }

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -138,6 +138,22 @@ fn skip_sentry(target: &str, msg: &str) -> bool {
     if is_disk_full(msg) || is_system_fd_exhaustion(msg) {
         return true;
     }
+    // A line announcing that a Sentry capture was skipped must never itself be
+    // captured -- the bridge forwarding it re-created exactly the event the
+    // skip existed to prevent, minus all its structure (RUST-AR: the
+    // bootstrap_failed ENOSPC skip filed 7 events). Target-agnostic on
+    // purpose: every capture site uses this phrasing.
+    if msg.starts_with("skipping Sentry capture for") {
+        return true;
+    }
+    // tiktoken prefetch is best-effort warm-up, same contract as the kompress
+    // prefetch below: the proxy lazy-loads the tokenizer on first request if
+    // the prefetch fails, and the dominant failure is the host's own
+    // network/proxy environment (RUST-AP). Local log only; the repeat
+    // suppression at the emit site already demotes follow-ups to info.
+    if target.starts_with("headroom_desktop_lib") && msg.starts_with("tiktoken prefetch failed") {
+        return true;
+    }
     if target.starts_with("tauri_plugin_updater") {
         return is_transient_transport_error(msg) || is_updater_endpoint_error(msg);
     }
@@ -598,6 +614,29 @@ pub(crate) fn log_path() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::skip_sentry;
+
+    #[test]
+    fn skips_capture_skip_announcements_and_tiktoken_prefetch() {
+        // RUST-AR: the skip announcement itself was bridged to Sentry.
+        assert!(skip_sentry(
+            "headroom_desktop_lib",
+            "skipping Sentry capture for bootstrap_failed (other): disk full (ENOSPC)"
+        ));
+        assert!(skip_sentry(
+            "headroom_desktop_lib",
+            "skipping Sentry capture for runtime_upgrade_failed (install): disk full (ENOSPC)"
+        ));
+        // RUST-AP: best-effort prefetch, lazy-load fallback exists.
+        assert!(skip_sentry(
+            "headroom_desktop_lib",
+            "tiktoken prefetch failed: tiktoken prefetch exited with exit code: 1"
+        ));
+        // A real bootstrap failure capture is not the skip announcement.
+        assert!(!skip_sentry(
+            "headroom_desktop_lib",
+            "bootstrap_failed (install_runtime)"
+        ));
+    }
 
     #[test]
     fn skips_updater_transport_errors() {

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -795,6 +795,9 @@ pub enum ClaudePlanTier {
     Pro,
     Max5x,
     Max20x,
+    /// Anthropic API console org (`api_individual` and friends): pay-per-token
+    /// billing, no Claude subscription plan to mirror.
+    Api,
     Unknown,
 }
 
@@ -831,6 +834,12 @@ pub fn headroom_tier_for_claude_plan(plan: &ClaudePlanTier) -> Option<HeadroomSu
         // in `pricing::detect_tier_mismatch`. The pricing gate's separate
         // Unknown -> Max x20 *threshold* fallback is unaffected.
         ClaudePlanTier::Unknown => None,
+        // API-billed org: no subscription to mirror. The server's usage-band
+        // pitch (account.recommended_tier, computed from user_daily_savings
+        // with the >=5:1 savings ROI clamp) drives the recommendation; a local
+        // guess would overpitch light API users. None also keeps
+        // detect_tier_mismatch quiet, same contract as Unknown.
+        ClaudePlanTier::Api => None,
         ClaudePlanTier::Free => None,
     }
 }
@@ -1141,6 +1150,12 @@ pub struct HeadroomAccountProfile {
     /// None for everyone else, keeping normal routing.
     #[serde(default)]
     pub upgrade_action: Option<String>,
+    /// Server-computed pitch tier for API-billed orgs: their usage band mapped
+    /// onto subscriber plans (>=5:1 savings ROI clamp), from
+    /// user_daily_savings. None for everyone else - local recommendation
+    /// logic applies unchanged.
+    #[serde(default)]
+    pub recommended_tier: Option<HeadroomSubscriptionTier>,
     // Early adopters whose earliest trial identity predates the paywall keep a
     // capped free tier instead of the post-trial hard block. serde default so
     // older cached payloads (no field) still deserialize.

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -253,6 +253,7 @@ fn plan_tier_header_value(tier: &ClaudePlanTier) -> &'static str {
         ClaudePlanTier::Pro => "pro",
         ClaudePlanTier::Max5x => "max5x",
         ClaudePlanTier::Max20x => "max20x",
+        ClaudePlanTier::Api => "api",
         ClaudePlanTier::Unknown => "unknown",
     }
 }
@@ -699,6 +700,8 @@ struct RemoteAccountResponse {
     invite_bonus_percent: f64,
     #[serde(default)]
     upgrade_action: Option<String>,
+    #[serde(default)]
+    recommended_tier: Option<HeadroomSubscriptionTier>,
     #[serde(default)]
     grandfathered: bool,
 }
@@ -2245,6 +2248,18 @@ fn evaluate_pricing_status_with_mismatch(
                 .into();
     }
 
+    // Server-computed usage-band pitch for API-billed orgs: the server fills
+    // account.recommendedTier only for api_* organizations (band over
+    // user_daily_savings at subscriber-typical thresholds, >=5:1 savings ROI
+    // clamp). It outranks every local guess - the Api gate policy's Max
+    // ceiling would otherwise pitch Max20x at a light API user.
+    if let Some(tier) = account
+        .as_ref()
+        .and_then(|account| account.recommended_tier)
+    {
+        recommended_subscription_tier = Some(tier);
+    }
+
     HeadroomPricingStatus {
         authenticated,
         local_grace_started_at,
@@ -3083,6 +3098,19 @@ fn detect_plan_tier_from_profile(profile: &ClaudeOauthProfile) -> (ClaudePlanTie
                 Some("oauth_profile.organization.organizationType".into()),
             );
         }
+        // Anthropic API console orgs (api_individual, api_*): pay-per-token
+        // accounts, not Claude subscriptions. Both observed shapes land here:
+        // prepaid with subscription_created_at set (previously fell through to
+        // Unknown and fired plan_tier_unknown - RUST-B2) and
+        // auto_api_evaluation without subscription_created_at (previously
+        // misread as Free). The server prices these by usage band; see
+        // HeadroomAccountProfile::recommended_tier.
+        if normalized.starts_with("api") {
+            return (
+                ClaudePlanTier::Api,
+                Some("oauth_profile.organization.organizationType".into()),
+            );
+        }
         if normalized == "claude_free" || normalized == "free" {
             return (
                 ClaudePlanTier::Free,
@@ -3214,6 +3242,7 @@ fn remote_account_to_profile(value: RemoteAccountResponse) -> HeadroomAccountPro
         accepted_invites_count: value.accepted_invites_count,
         invite_bonus_percent: value.invite_bonus_percent.min(50.0).max(0.0),
         upgrade_action: value.upgrade_action,
+        recommended_tier: value.recommended_tier,
         grandfathered: value.grandfathered,
     }
 }
@@ -3778,6 +3807,12 @@ fn pricing_policy_for_plan(plan: &ClaudePlanTier) -> Option<PricingPolicy> {
         ClaudePlanTier::Pro => Some(policy_for_paid_tier(HeadroomSubscriptionTier::Pro)),
         ClaudePlanTier::Max5x => Some(policy_for_paid_tier(HeadroomSubscriptionTier::Max5x)),
         ClaudePlanTier::Max20x => Some(policy_for_paid_tier(HeadroomSubscriptionTier::Max20x)),
+        // API-billed org: metered at the Max ceiling like Unknown - per-token
+        // billing carries no weekly quota to key a softer ladder off, and the
+        // ceiling stops an API org from riding free. The PITCHED tier comes
+        // from the server usage band (account.recommended_tier), not this
+        // policy's recommended_tier.
+        ClaudePlanTier::Api => Some(policy_for_paid_tier(HeadroomSubscriptionTier::Max20x)),
         // Undecodable plan is metered at the Max ceiling (25%) rather than left
         // ungated, so an obscured plan can't buy unlimited free optimization.
         ClaudePlanTier::Unknown => Some(policy_for_paid_tier(HeadroomSubscriptionTier::Max20x)),
@@ -3999,6 +4034,7 @@ mod tests {
             accepted_invites_count: 2,
             invite_bonus_percent: 10.0,
             upgrade_action: None,
+            recommended_tier: None,
             grandfathered: false,
         }
     }
@@ -4538,6 +4574,7 @@ mod tests {
             accepted_invites_count: 0,
             invite_bonus_percent: 0.0,
             upgrade_action: None,
+            recommended_tier: None,
             grandfathered: false,
         }
     }
@@ -4567,6 +4604,7 @@ mod tests {
             accepted_invites_count: 0,
             invite_bonus_percent: invite_bonus,
             upgrade_action: None,
+            recommended_tier: None,
             grandfathered: false,
         }
     }
@@ -4576,6 +4614,7 @@ mod tests {
     fn grandfathered_account() -> HeadroomAccountProfile {
         HeadroomAccountProfile {
             upgrade_action: None,
+            recommended_tier: None,
             grandfathered: true,
             ..expired_account(0.0)
         }
@@ -5196,6 +5235,42 @@ mod tests {
         ));
     }
 
+    /// RUST-B2 shape: prepaid API console org with subscription_created_at
+    /// set. Previously fell through to Unknown and fired plan_tier_unknown.
+    #[test]
+    fn detect_plan_tier_api_org_with_subscription_is_api() {
+        let p = oauth_profile(
+            Some("auto_trust_tier_c"),
+            Some("api_individual"),
+            Some(Utc::now()),
+        );
+        assert!(matches!(
+            detect_plan_tier_from_profile(&p).0,
+            ClaudePlanTier::Api
+        ));
+    }
+
+    /// The other observed shape (user 1208): auto_api_evaluation without
+    /// subscription_created_at. Previously misread as Free.
+    #[test]
+    fn detect_plan_tier_api_org_without_subscription_is_api_not_free() {
+        let p = oauth_profile(Some("auto_api_evaluation"), Some("api_individual"), None);
+        assert!(matches!(
+            detect_plan_tier_from_profile(&p).0,
+            ClaudePlanTier::Api
+        ));
+    }
+
+    #[test]
+    fn api_plan_tier_is_ceiling_metered_and_server_pitched() {
+        // Gate: Max ceiling like Unknown.
+        let policy = super::pricing_policy_for_plan(&ClaudePlanTier::Api).unwrap();
+        assert_eq!(policy.disable_threshold_percent, 25.0);
+        // No local pitch: the server usage band owns the recommendation.
+        assert!(crate::models::headroom_tier_for_claude_plan(&ClaudePlanTier::Api).is_none());
+        assert_eq!(super::plan_tier_header_value(&ClaudePlanTier::Api), "api");
+    }
+
     #[test]
     fn remote_account_clamps_invite_bonus_to_50() {
         let raw = RemoteAccountResponse {
@@ -5222,6 +5297,7 @@ mod tests {
             accepted_invites_count: 0,
             invite_bonus_percent: 999.0,
             upgrade_action: None,
+            recommended_tier: None,
             grandfathered: false,
         };
         assert_eq!(remote_account_to_profile(raw).invite_bonus_percent, 50.0);
@@ -5253,6 +5329,7 @@ mod tests {
             accepted_invites_count: 0,
             invite_bonus_percent: -10.0,
             upgrade_action: None,
+            recommended_tier: None,
             grandfathered: false,
         };
         assert_eq!(remote_account_to_profile(raw).invite_bonus_percent, 0.0);

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -2121,6 +2121,9 @@ impl AppState {
                     ) | (
                         crate::models::ClaudePlanTier::Max20x,
                         crate::models::ClaudePlanTier::Max20x
+                    ) | (
+                        crate::models::ClaudePlanTier::Api,
+                        crate::models::ClaudePlanTier::Api
                     )
                 ) {
                     return;

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -2560,7 +2560,9 @@ impl AppState {
         // show. It renders in the drill-down as "Additional costs saved".
         let lifetime_estimated_savings_usd =
             lifetime_compression_savings_usd + lifetime_output_savings_usd;
-        warn_once_if_savings_rate_implausible(&daily_savings);
+        warn_once_if_savings_rate_implausible(&daily_savings, || {
+            self.tool_manager.installed_headroom_version()
+        });
         // Tokens stay input-only: the card is labelled "Total input tokens
         // saved", and this total also drives the milestone notifications, which
         // must not jump when a new savings layer starts reporting.
@@ -7845,15 +7847,26 @@ fn savings_rate_implausible(daily_savings: &[DailySavingsPoint]) -> Option<f64> 
 /// Warn-only canary, once per process: a contaminated rate silently corrected
 /// is worse than a loud one, so nothing is clamped -- the warn reaches Sentry
 /// through the log bridge and the numbers keep rendering as reported.
-fn warn_once_if_savings_rate_implausible(daily_savings: &[DailySavingsPoint]) {
+fn warn_once_if_savings_rate_implausible(
+    daily_savings: &[DailySavingsPoint],
+    installed_wheel: impl FnOnce() -> Option<String>,
+) {
     static WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
     if WARNED.load(std::sync::atomic::Ordering::Relaxed) {
         return;
     }
     if let Some(savings_per_m) = savings_rate_implausible(daily_savings) {
         WARNED.store(true, std::sync::atomic::Ordering::Relaxed);
+        // The raw sums and wheel version make the event self-diagnosing: a
+        // legit expensive-model mix, a foreign backend on 6767, and real
+        // contamination are indistinguishable from the rate alone (RUST-89,
+        // 2026-09-01: $93.70/M on a 0.35.0-pinned install, undecidable).
+        let saved_usd: f64 = daily_savings.iter().map(|p| p.estimated_savings_usd).sum();
+        let saved_tokens: u64 = daily_savings.iter().map(|p| p.estimated_tokens_saved).sum();
+        let wheel = installed_wheel().unwrap_or_else(|| "unknown".into());
         log::warn!(
-            "savings rate implausible: buckets imply ${savings_per_m:.2}/M saved, above the \
+            "savings rate implausible: buckets imply ${savings_per_m:.2}/M saved (${saved_usd:.2} \
+             across {saved_tokens} tokens, wheel {wheel}), above the \
              ${MAX_PLAUSIBLE_INPUT_USD_PER_M:.2}/M ceiling for an input token; upstream savings \
              semantics likely changed under the pinned wheel"
         );

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -328,9 +328,10 @@ _compact_json_bytes for the duration of each overlay call, restoring
 0.35.0's byte-identical replay. The desktop backend serves proxy-mode
 traffic only, whose snapshots refresh from every provider response, so
 byte-identical replay is always the cheaper request here. Gated on the
-runtime NOT having the fix's enforce_non_inflation parameter, so the
-first wheel that ships it keeps its per-caller split and this block
-goes inert. Kill switch: HEADROOM_PREFIX_REPLAY_GUARD=0.
+runtime NOT having the fix's parameter (enforce_non_inflation in the
+first PR shape, confirmed_frozen_count in the reworked #3380 shape), so
+the first wheel that ships either keeps its own replay policy and this
+block goes inert. Kill switch: HEADROOM_PREFIX_REPLAY_GUARD=0.
 cc-switch Official-branch upstream reset (upstream PR #3166): the
 reconciler captures the third-party endpoint cc-switch selected (Kimi,
 DeepSeek, GLM) as this proxy's Anthropic upstream, but switching back to
@@ -908,19 +909,21 @@ if _hd_os.environ.get("HEADROOM_SDK") == "headroom-desktop-proxy":
     # restore around each call so any other caller of the helper stays
     # honest; overlay is synchronous on the proxy's single event loop, so the
     # swap cannot interleave with another request's overlay. Gated on the
-    # runtime NOT having the fix's enforce_non_inflation parameter, so the
-    # first wheel that ships it keeps its proper per-caller split and this
-    # block goes inert. Kill switch: HEADROOM_PREFIX_REPLAY_GUARD=0.
+    # runtime NOT having the fix's parameter under either name shipped on
+    # #3380 (enforce_non_inflation / confirmed_frozen_count), so the first
+    # wheel that ships the fix keeps its own replay policy and this block
+    # goes inert. Kill switch: HEADROOM_PREFIX_REPLAY_GUARD=0.
     try:
         if _hd_os.environ.get(
             "HEADROOM_PREFIX_REPLAY_GUARD", "1"
         ).strip().lower() not in ("0", "false", "no", "off"):
             import headroom.cache.prefix_tracker as _hd_pr_pt
 
-            if hasattr(_hd_pr_pt, "_compact_json_bytes") and (
-                "enforce_non_inflation"
-                not in _hd_pr_pt.overlay_cached_prefix.__code__.co_varnames
-            ):
+            _hd_pr_fixed = any(
+                name in _hd_pr_pt.overlay_cached_prefix.__code__.co_varnames
+                for name in ("enforce_non_inflation", "confirmed_frozen_count")
+            )
+            if hasattr(_hd_pr_pt, "_compact_json_bytes") and not _hd_pr_fixed:
                 _hd_pr_orig_overlay = _hd_pr_pt.overlay_cached_prefix
 
                 def _hd_pr_overlay(*args, **kwargs):
@@ -10975,9 +10978,11 @@ mod tests {
         let py = super::SITECUSTOMIZE_PY;
         assert!(py.contains("HEADROOM_PREFIX_REPLAY_GUARD"));
         assert!(py.contains("upstream issue #3379"));
-        // Gated on the fix's parameter being ABSENT, so a fixed wheel keeps
-        // its per-caller split.
-        assert!(py.contains("not in _hd_pr_pt.overlay_cached_prefix.__code__.co_varnames"));
+        // Gated on the fix's parameter being ABSENT under either name the
+        // upstream PR shipped (v1 flag, reworked floor), so a fixed wheel
+        // keeps its own replay policy.
+        assert!(py.contains("in _hd_pr_pt.overlay_cached_prefix.__code__.co_varnames"));
+        assert!(py.contains(r#""enforce_non_inflation", "confirmed_frozen_count""#));
         // Swap-and-restore of the sizing helper, never a permanent stub.
         assert!(py.contains(r#"_hd_pr_pt._compact_json_bytes = lambda value: b"""#));
         assert!(py.contains("_hd_pr_pt._compact_json_bytes = _hd_pr_saved"));

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -257,7 +257,7 @@ still compress -- so the flip stays. tool_result blocks compress
 regardless of this flag (the role gate only guards text blocks), so the
 coding token mass is unaffected.
 
-Also ports six fixes owed upstream (remove each once a wheel ships it),
+Also ports seven fixes owed upstream (remove each once a wheel ships it),
 gated on HEADROOM_SDK=headroom-desktop-proxy so only the backend process
 pays the proxy import cost:
 Context-limit guard (upstream PR #2942): compression under-reports
@@ -315,6 +315,22 @@ bailout (a heredoc body may contain ; or &&), and delegates each
 segment's program parsing to the original function so wrapper peeling,
 bash -c recursion and the lockfile carve-out stay upstream's. Kill
 switch: HEADROOM_READ_CHAIN_GUARD=0.
+Prefix-replay inflation-skip guard (upstream issue #3379): since the
+0.36.x non-inflation bound (#3052), overlay_cached_prefix declines to
+replay the previously-forwarded prefix whenever background compression
+lands a SMALLER form of already-forwarded history, so the forwarded
+bytes change mid-conversation and the provider prompt cache busts from
+the first changed byte -- measured 2026-09-01 as a 160-210k-token cache
+re-write every 1-2 requests, dollar cache-hit rate 90% -> 52%, billable
+input $/M up 2.2x, across the 0.35.0 -> 0.37.0 wheel swap. The guard
+neuters only the size bound (every alignment guard stays) by stubbing
+_compact_json_bytes for the duration of each overlay call, restoring
+0.35.0's byte-identical replay. The desktop backend serves proxy-mode
+traffic only, whose snapshots refresh from every provider response, so
+byte-identical replay is always the cheaper request here. Gated on the
+runtime NOT having the fix's enforce_non_inflation parameter, so the
+first wheel that ships it keeps its per-caller split and this block
+goes inert. Kill switch: HEADROOM_PREFIX_REPLAY_GUARD=0.
 cc-switch Official-branch upstream reset (upstream PR #3166): the
 reconciler captures the third-party endpoint cc-switch selected (Kimi,
 DeepSeek, GLM) as this proxy's Anthropic upstream, but switching back to
@@ -879,6 +895,43 @@ if _hd_os.environ.get("HEADROOM_SDK") == "headroom-desktop-proxy":
                 )
 
             _hd_rc_cr._is_read_command = _hd_rc_is_read
+    except Exception:
+        pass
+
+    # Prefix-replay inflation-skip guard (upstream issue #3379; remove once a
+    # wheel ships the fix -- see the module docstring for the cache-bust loop
+    # this prevents). overlay_cached_prefix's size bound reads
+    # _compact_json_bytes via module globals at call time; stubbing it to
+    # return equal-length bytes for both candidates makes the
+    # len(replayed) > len(optimized) comparison always false, so the replay
+    # proceeds while every alignment/append-only guard still runs. Swap and
+    # restore around each call so any other caller of the helper stays
+    # honest; overlay is synchronous on the proxy's single event loop, so the
+    # swap cannot interleave with another request's overlay. Gated on the
+    # runtime NOT having the fix's enforce_non_inflation parameter, so the
+    # first wheel that ships it keeps its proper per-caller split and this
+    # block goes inert. Kill switch: HEADROOM_PREFIX_REPLAY_GUARD=0.
+    try:
+        if _hd_os.environ.get(
+            "HEADROOM_PREFIX_REPLAY_GUARD", "1"
+        ).strip().lower() not in ("0", "false", "no", "off"):
+            import headroom.cache.prefix_tracker as _hd_pr_pt
+
+            if hasattr(_hd_pr_pt, "_compact_json_bytes") and (
+                "enforce_non_inflation"
+                not in _hd_pr_pt.overlay_cached_prefix.__code__.co_varnames
+            ):
+                _hd_pr_orig_overlay = _hd_pr_pt.overlay_cached_prefix
+
+                def _hd_pr_overlay(*args, **kwargs):
+                    _hd_pr_saved = _hd_pr_pt._compact_json_bytes
+                    _hd_pr_pt._compact_json_bytes = lambda value: b""
+                    try:
+                        return _hd_pr_orig_overlay(*args, **kwargs)
+                    finally:
+                        _hd_pr_pt._compact_json_bytes = _hd_pr_saved
+
+                _hd_pr_pt.overlay_cached_prefix = _hd_pr_overlay
     except Exception:
         pass
 
@@ -9591,12 +9644,15 @@ fn reg_dword_is_set(value: &str) -> bool {
 }
 
 /// urllib's `getproxies_registry` expansion of the `ProxyServer` string,
-/// restricted to the keys httpx mounts (http/https -- keyed socks entries
-/// never reach httpx and are harmless). A value without `=` applies to every
-/// protocol; `proto=addr` pairs are per-protocol; an address without a scheme
-/// inherits its protocol name as the scheme. Returns None when no override is
-/// needed (nothing mounted, or every mounted entry parses), otherwise the env
-/// vars to set on the child.
+/// restricted to the keys httpx mounts (http/https). A value without `=`
+/// applies to every protocol; `proto=addr` pairs are per-protocol; an address
+/// without a scheme inherits its protocol name as the scheme. A keyed
+/// `socks=` entry is NOT harmless: CPython backfills missing http/https keys
+/// with `socks4://addr` ("the default SOCKS proxy type of Windows is SOCKS4",
+/// urllib/request.py getproxies_registry) -- the RUST-B3 crash was exactly
+/// that backfill reaching httpx via the https mount. Returns None when no
+/// override is needed (nothing mounted, or every mounted entry parses),
+/// otherwise the env vars to set on the child.
 fn registry_proxy_env_overrides(proxy_server: &str) -> Option<Vec<(String, String)>> {
     let server = proxy_server.trim();
     if server.is_empty() {
@@ -9608,12 +9664,13 @@ fn registry_proxy_env_overrides(proxy_server: &str) -> Option<Vec<(String, Strin
         format!("http={server};https={server}")
     };
     let mut mounted: Vec<(String, String)> = Vec::new();
+    let mut socks_url: Option<String> = None;
     for pair in expanded.split(';') {
         let Some((proto, addr)) = pair.split_once('=') else {
             continue;
         };
         let proto = proto.trim().to_ascii_lowercase();
-        if proto != "http" && proto != "https" {
+        if proto != "http" && proto != "https" && proto != "socks" {
             continue;
         }
         let addr = addr.trim();
@@ -9630,7 +9687,26 @@ fn registry_proxy_env_overrides(proxy_server: &str) -> Option<Vec<(String, Strin
         } else {
             format!("{proto}://{addr}")
         };
-        mounted.push((proto, url));
+        if proto == "socks" {
+            // urllib's backfill rewrites a bare `socks://` to `socks4://`;
+            // an explicit scheme (e.g. socks5://) is kept as-is.
+            socks_url = Some(match url.strip_prefix("socks://") {
+                Some(rest) => format!("socks4://{rest}"),
+                None => url,
+            });
+        } else {
+            mounted.push((proto, url));
+        }
+    }
+    // CPython: `proxies['http'] = proxies.get('http') or socks_address` (same
+    // for https), so the socks entry becomes the mount wherever no explicit
+    // http/https pair exists.
+    if let Some(socks) = socks_url {
+        for proto in ["http", "https"] {
+            if !mounted.iter().any(|(p, _)| p == proto) {
+                mounted.push((proto.to_string(), socks.clone()));
+            }
+        }
     }
     if mounted.iter().all(|(_, url)| httpx_supports_proxy_url(url)) {
         return None;
@@ -10886,6 +10962,26 @@ mod tests {
         // rebind covers both in-module call sites via module globals.
         assert!(py.contains("_hd_rc_orig(first)"));
         assert!(py.contains("_hd_rc_cr._is_read_command = _hd_rc_is_read"));
+    }
+
+    #[test]
+    fn sitecustomize_ports_prefix_replay_guard() {
+        // Upstream issue #3379: the 0.36.x non-inflation bound declines the
+        // cached-prefix replay exactly when background compression shrinks
+        // already-forwarded history, busting the provider prompt cache every
+        // time kompress lands. The guard stubs the sizing helper per call so
+        // the bound never fires, and goes inert once a wheel ships the
+        // enforce_non_inflation parameter.
+        let py = super::SITECUSTOMIZE_PY;
+        assert!(py.contains("HEADROOM_PREFIX_REPLAY_GUARD"));
+        assert!(py.contains("upstream issue #3379"));
+        // Gated on the fix's parameter being ABSENT, so a fixed wheel keeps
+        // its per-caller split.
+        assert!(py.contains("not in _hd_pr_pt.overlay_cached_prefix.__code__.co_varnames"));
+        // Swap-and-restore of the sizing helper, never a permanent stub.
+        assert!(py.contains(r#"_hd_pr_pt._compact_json_bytes = lambda value: b"""#));
+        assert!(py.contains("_hd_pr_pt._compact_json_bytes = _hd_pr_saved"));
+        assert!(py.contains("_hd_pr_pt.overlay_cached_prefix = _hd_pr_overlay"));
     }
 
     #[test]
@@ -13316,13 +13412,43 @@ after
             super::registry_proxy_env_overrides("http=1.2.3.4:8080;https=1.2.3.4:8080"),
             None
         );
-        // Keyed socks entries never reach httpx's mounts.
+        // A keyed socks entry with an explicit httpx-supported scheme is kept
+        // verbatim by urllib's backfill, so both mounts parse: no override.
         assert_eq!(
-            super::registry_proxy_env_overrides("http=1.2.3.4:8080;socks=127.0.0.1:10808"),
+            super::registry_proxy_env_overrides("socks=socks5://127.0.0.1:1080"),
             None
         );
         assert_eq!(super::registry_proxy_env_overrides(""), None);
         assert_eq!(super::registry_proxy_env_overrides("   "), None);
+    }
+
+    /// RUST-B3: CPython backfills missing http/https keys from a keyed
+    /// `socks=` entry as `socks4://addr`, so `http=...;socks=...` mounts
+    /// socks4 on https and crashed the backend despite RUST-AY. The usable
+    /// http half survives as an explicit env var.
+    #[test]
+    fn registry_keyed_socks_backfills_and_overrides() {
+        assert_eq!(
+            super::registry_proxy_env_overrides("http=1.2.3.4:8080;socks=127.0.0.1:1080"),
+            Some(vec![(
+                "http_proxy".to_string(),
+                "http://1.2.3.4:8080".to_string()
+            )])
+        );
+        // socks alone backfills BOTH mounts with socks4: nothing usable.
+        assert_eq!(
+            super::registry_proxy_env_overrides("socks=127.0.0.1:1080"),
+            Some(vec![("NO_PROXY".to_string(), "*".to_string())])
+        );
+        // Explicit http/https pairs win over the backfill (CPython uses
+        // `proxies.get(proto) or socks`), so a fully-specified config with a
+        // stray socks entry keeps its usable halves.
+        assert_eq!(
+            super::registry_proxy_env_overrides(
+                "http=1.2.3.4:8080;https=1.2.3.4:8080;socks=127.0.0.1:1080"
+            ),
+            None
+        );
     }
 
     /// A corporate box with a usable http proxy next to a broken socks4

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -33,7 +33,7 @@ use crate::models::{ManagedTool, RtkTodayStats, ToolStatus};
 /// per-platform axis still matters, which `headroom_wheel_artifact` handles —
 /// when bumping this pin, re-pick every platform's wheel URL/sha256 from
 /// https://pypi.org/pypi/headroom-ai/<version>/json.
-pub(crate) const HEADROOM_PINNED_VERSION: &str = "0.35.0";
+pub(crate) const HEADROOM_PINNED_VERSION: &str = "0.37.0";
 const HEADROOM_SMOKE_TEST_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Kill the RUST-9F onnxruntime import probe after this long: a native
@@ -285,24 +285,22 @@ clamp optimized to 0 and record savings rates above 100% ("4,436 -> 0,
 request's tools schema once per compressed HTTP request and widens the
 recorded pair at the outcome funnel so original - optimized == saved.
 Kill switch: HEADROOM_RESPONSES_DENOMINATOR_GUARD=0.
-Codex additional_tools guard (upstream issue #3185): Codex CLI 0.149.0
-stopped sending a top-level tools array on /v1/responses for models its
-capability cache flags (gpt-5.6-sol, its default) -- tool definitions
-ride inside input as items of type "additional_tools". Every tools
-consumer in the proxy (tool_schema_compaction, the output-shaper
-stratum, the tools token counts, the denominator guard above) reads
-only payload["tools"], so those requests classify "notools" and record
-zero savings (2026-08-21: 0/13 afternoon signups and 42/54 active
-codex users with frozen savings). The guard lifts the items' tools into
-a top-level array before compression and puts the compacted definitions
-back into the carrier before the payload is forwarded. The lift is
-internal only: tools is a per-request parameter while additional_tools
-is an input item, so forwarding the lifted shape costs a stateful
-session (Codex TUI/app-server over WS) its whole tool surface after
-turn one -- upstream #3194, the 0.36.3 regression from the same lift.
-No version gate: it self-neutralizes when payload["tools"] is already
-present, and 0.36.2 has no additional_tools support either. Kill
-switch: HEADROOM_ADDITIONAL_TOOLS_GUARD=0.
+Tool-schema dollar unfold (upstream PR #3170): since the 0.36.0
+attribution unification, record_request folds the priced tool-schema
+bucket into compression_savings_usd (lifetime, display_session,
+per-model, per-project, and every history checkpoint) while the token
+fields beside them stay message-only, so any $/token read on the
+persisted state is inflated by 1 + tool/message -- 5.59x tool/message
+measured on one real install, an implied $32.88/M next to models that
+list at $10/M input. The desktop accumulates lifetime savings from
+these dollar fields, so the fold would contaminate the headline the
+product is trusted for (the savings-rate canary in state.rs is the
+runtime tripwire for exactly this). The guard zeroes the tool_schema
+bucket before the fold, restoring the 0.35.0 meaning of every
+persisted dollar field; tool-schema TOKENS are untouched and the
+desktop keeps pricing those itself at the cache-read rate.
+Self-neutralizes once a wheel ships #3170's disjoint fields. Kill
+switch: HEADROOM_SAVINGS_FOLD_GUARD=0.
 cc-switch Official-branch upstream reset (upstream PR #3166): the
 reconciler captures the third-party endpoint cc-switch selected (Kimi,
 DeepSeek, GLM) as this proxy's Anthropic upstream, but switching back to
@@ -781,165 +779,38 @@ if _hd_os.environ.get("HEADROOM_SDK") == "headroom-desktop-proxy":
     except Exception:
         pass
 
-    # Codex additional_tools guard (upstream issue #3185; remove once a wheel
-    # ships support -- see the module docstring for the failure mode). Applied
-    # AFTER the denominator guard so this wrapper is outermost: the lift runs
-    # first at runtime and every inner layer (denominator widening included)
-    # sees the classic top-level tools shape. Symmetric: the lift is in place
-    # for the compression pass only, and the carrier goes back on the wire
-    # before the payload is forwarded (see _hd_at_restore -- forwarding the
-    # lifted shape is upstream's 0.36.3 regression, #3194). Kill switch:
-    # HEADROOM_ADDITIONAL_TOOLS_GUARD=0.
+    # Tool-schema dollar unfold (upstream PR #3170; remove once a wheel ships
+    # it -- see the module docstring for the contamination this prevents). The
+    # wrapper strikes at the single choke point every caller funnels through:
+    # SavingsTracker.record_request is keyword-only, and the fold is
+    # priced["compression"] + priced["tool_schema"] inside it. Zeroing the
+    # tool_schema bucket on a COPY (the caller's mapping is never mutated)
+    # restores message-only dollars everywhere the tracker persists them,
+    # while tool_search_saved -- the token side -- passes through untouched.
+    # Gated on the runtime NOT having #3170's disjoint fields, so the first
+    # wheel that ships them keeps its proper split and this block goes inert.
+    # Kill switch: HEADROOM_SAVINGS_FOLD_GUARD=0.
     try:
         if _hd_os.environ.get(
-            "HEADROOM_ADDITIONAL_TOOLS_GUARD", "1"
+            "HEADROOM_SAVINGS_FOLD_GUARD", "1"
         ).strip().lower() not in ("0", "false", "no", "off"):
-            import logging as _hd_at_logging
+            import headroom.proxy.savings_tracker as _hd_sf_st
 
-            import headroom.proxy.handlers.openai as _hd_at_openai
+            if "tool_schema_savings_usd" not in _hd_sf_st._empty_display_session():
+                _hd_sf_orig_record = _hd_sf_st.SavingsTracker.record_request
 
-            _hd_at_log = _hd_at_logging.getLogger("headroom.proxy")
-            _hd_at_announced = False
-
-            _hd_at_warned = False
-
-            def _hd_at_lift(payload, plan):
-                # Lift additional_tools input items into a top-level tools
-                # array, in place, recording the carrier in `plan` so the
-                # forwarded payload can be put back the way Codex sent it.
-                # No-op (0) unless the request uses the Codex >= 0.149.0
-                # encoding and has no top-level tools.
-                global _hd_at_announced
-                if not isinstance(payload, dict) or payload.get("tools"):
-                    return 0
-                items = payload.get("input")
-                if not isinstance(items, list):
-                    return 0
-                lifted = []
-                kept = []
-                carrier = None
-                for item in items:
-                    if (
-                        isinstance(item, dict)
-                        and item.get("type") == "additional_tools"
-                        and isinstance(item.get("tools"), list)
-                        and item["tools"]
-                    ):
-                        if carrier is None:
-                            # Restore template: the carrier's own fields
-                            # minus the definitions, plus its position among
-                            # the items that survive the lift. Codex sends a
-                            # single carrier; extra carriers merge into this
-                            # one rather than being split on a boundary that
-                            # compaction may have invalidated.
-                            carrier = (
-                                {k: v for k, v in item.items() if k != "tools"},
-                                len(kept),
-                            )
-                        lifted.extend(item["tools"])
-                    else:
-                        kept.append(item)
-                if not lifted:
-                    return 0
-                payload["tools"] = lifted
-                payload["input"] = kept
-                plan.append((carrier[0], carrier[1], list(lifted)))
-                if not _hd_at_announced:
-                    _hd_at_announced = True
-                    _hd_at_log.info(
-                        "event=codex_additional_tools_lifted tools=%d "
-                        "(codex >= 0.149.0 encoding; desktop guard active)",
-                        len(lifted),
-                    )
-                return len(lifted)
-
-            def _hd_at_restore(payload, plan):
-                # Put the definitions back into the carrier Codex sent them
-                # in, post-compaction, and drop the top-level array. The lift
-                # is an internal normalization for the tools consumers; the
-                # forwarded shape must match what the client sent. `tools` is
-                # a per-request parameter while additional_tools is an input
-                # item and therefore part of the transcript, so a stateful
-                # session (Codex TUI/app-server over WS) declares its tools
-                # once and relies on the transcript for every later turn --
-                # forwarding the lifted shape leaves that transcript
-                # tool-less: turn one works, then all shell/filesystem access
-                # vanishes for the rest of the session (upstream #3194).
-                if not isinstance(payload, dict) or not plan:
-                    return 0
-                items = payload.get("input")
-                if not isinstance(items, list):
-                    return 0
-                if any(
-                    isinstance(item, dict)
-                    and item.get("type") == "additional_tools"
-                    and item.get("tools")
-                    for item in items
-                ):
-                    # Already in carrier form; restoring again would
-                    # duplicate the definitions. Keeps the restore idempotent.
-                    return 0
-                template, position, original = plan[0]
-                tools = payload.get("tools")
-                if not isinstance(tools, list) or not tools:
-                    # A consumer emptied the array. Restoring what Codex sent
-                    # is strictly safer than forwarding a tool-less payload.
-                    tools = original
-                if not tools:
-                    return 0
-                carrier = dict(template)
-                carrier["type"] = "additional_tools"
-                carrier["tools"] = list(tools)
-                restored = list(items)
-                restored.insert(min(max(position, 0), len(restored)), carrier)
-                payload["input"] = restored
-                payload.pop("tools", None)
-                return len(carrier["tools"])
-
-            _hd_at_orig_compress = (
-                _hd_at_openai.OpenAIHandlerMixin._compress_openai_responses_payload_in_executor
-            )
-
-            async def _hd_at_compress(self, payload, **kwargs):
-                global _hd_at_warned
-                plan = []
-                result = None
-                try:
-                    _hd_at_lift(payload, plan)
-                except Exception:
-                    # The plan is deliberately kept: a lift that raised after
-                    # mutating the payload is undone by the restore below.
-                    pass
-                try:
-                    result = await _hd_at_orig_compress(self, payload, **kwargs)
-                finally:
-                    if plan:
-                        targets = [payload]
+                def _hd_sf_record(self, **kwargs):
+                    priced = kwargs.get("estimated_savings_usd")
+                    if priced is not None:
                         try:
-                            # result[0] is what the call sites forward; the caller
-                            # payload is restored too, for the paths that forward
-                            # the object they passed in when nothing was modified.
-                            out = result[0] if isinstance(result, tuple) and result else None
-                            if isinstance(out, dict) and out is not payload:
-                                targets.append(out)
-                            failed = [t for t in targets if not _hd_at_restore(t, plan)]
+                            unfolded = dict(priced)
+                            unfolded["tool_schema"] = 0.0
+                            kwargs["estimated_savings_usd"] = unfolded
                         except Exception:
-                            failed = targets
-                        if failed and not _hd_at_warned:
-                            # Logged once: the lifted shape is about to go out and
-                            # a stateful client will lose its tools after this
-                            # turn. Never silent.
-                            _hd_at_warned = True
-                            _hd_at_log.warning(
-                                "event=codex_additional_tools_restore_failed "
-                                "(forwarding lifted shape; set "
-                                "HEADROOM_ADDITIONAL_TOOLS_GUARD=0 to opt out)"
-                            )
-                return result
+                            pass
+                    return _hd_sf_orig_record(self, **kwargs)
 
-            _hd_at_openai.OpenAIHandlerMixin._compress_openai_responses_payload_in_executor = (
-                _hd_at_compress
-            )
+                _hd_sf_st.SavingsTracker.record_request = _hd_sf_record
     except Exception:
         pass
 
@@ -8662,24 +8533,24 @@ fn available_disk_bytes(path: &Path) -> Option<u64> {
 fn pinned_headroom_release() -> Result<HeadroomRelease> {
     let (url, sha256) = match (std::env::consts::OS, std::env::consts::ARCH) {
         ("macos", "aarch64") => (
-            "https://files.pythonhosted.org/packages/b0/27/a67c70358769ff1844326e1b9695bfa9ed2f298aeb7001bb32e74c92c7d5/headroom_ai-0.35.0-cp310-abi3-macosx_11_0_arm64.whl",
-            "54dc9be2b8f7b0397f35d15b73f48db3eefdd3b3c613630bcaee695a4fbf509e",
+            "https://files.pythonhosted.org/packages/47/21/8a87b66e83498da89404cdba4ced6397e84331047df9e11a9ea6f3510b29/headroom_ai-0.37.0-cp310-abi3-macosx_11_0_arm64.whl",
+            "b4392f68a8d02d74c62c1734cf5bf327511dcc72678f01669f44f0612944d59c",
         ),
         ("macos", "x86_64") => (
-            "https://files.pythonhosted.org/packages/af/7d/4f6199cf9ede6eec15df036ba06e52ce36025a82e23988397db6ff16d3a6/headroom_ai-0.35.0-cp310-abi3-macosx_10_12_x86_64.whl",
-            "ef8622df6230a6e63a44ca5d25a8aaca985d3573dbe83db9a74556286f4bee0f",
+            "https://files.pythonhosted.org/packages/56/cc/385712352911b7a482514902745cba802e03947850689a784b2d40764e06/headroom_ai-0.37.0-cp310-abi3-macosx_10_12_x86_64.whl",
+            "d89fd5858e701ada53d01849f73039d891fad84d9eb370f952d56581962d9cf8",
         ),
         ("linux", "aarch64") => (
-            "https://files.pythonhosted.org/packages/7d/4f/972f50843a9c419967b443ef41121de4687bbdab91682ac1e4b800366c68/headroom_ai-0.35.0-cp310-abi3-manylinux_2_28_aarch64.whl",
-            "ec261ca9c3a8599c4a1b8bc7b69301d39bd434448b64bd043b510fd5ee14d358",
+            "https://files.pythonhosted.org/packages/c6/2e/8d1c60683c74ae2871270789e0af1acc93727a51189799e74529679d795c/headroom_ai-0.37.0-cp310-abi3-manylinux_2_28_aarch64.whl",
+            "bc30d31a6b9336155d62bbdd99f3c2f6c5a1ed3882a8730ea0cd8ede4c40fa19",
         ),
         ("linux", "x86_64") => (
-            "https://files.pythonhosted.org/packages/56/ea/b5f112b90ea2033276c35a7bddd4bdfd4429a1c011b2f109fa5a809bac14/headroom_ai-0.35.0-cp310-abi3-manylinux_2_28_x86_64.whl",
-            "abdbbabc314b09e0f27b166f0be43dc386b8de338048a66fe804bc1d3cf2bff4",
+            "https://files.pythonhosted.org/packages/72/b8/16878cf4fe6fc390a0d22025b671468619db690ff14c1b103ace4b5e35f9/headroom_ai-0.37.0-cp310-abi3-manylinux_2_28_x86_64.whl",
+            "2efc5cdf681a10c5fc7a2a271a471179c409074537045f682b10e4d724976f46",
         ),
         ("windows", "x86_64") => (
-            "https://files.pythonhosted.org/packages/fc/8c/297b742144144c8411ca021436004a15318a6f5cce033093d9333f693089/headroom_ai-0.35.0-cp310-abi3-win_amd64.whl",
-            "c80533399c911761fb47f49ac02db35c33ef4eb628c6568c213d7d7f0b594bef",
+            "https://files.pythonhosted.org/packages/c9/84/6803f3cc069dc8a6843c7ed8b155d1cf0c603a7467f58ffa24c5c399b8c9/headroom_ai-0.37.0-cp310-abi3-win_amd64.whl",
+            "e961f892786f7577e75f2c26229f11e2609fc007083dae24d336e76fc4c72e58",
         ),
         (os, arch) => bail!("unsupported headroom-ai wheel target: {os}/{arch}"),
     };
@@ -10609,144 +10480,32 @@ mod tests {
     }
 
     #[test]
-    fn sitecustomize_lifts_codex_additional_tools() {
-        // Upstream issue #3185: Codex CLI 0.149.0 moved tool definitions off
-        // the top-level tools array into input items of type
-        // "additional_tools" (gpt-5.6-sol default), so every tools consumer
-        // classified those requests "notools" and savings recorded zero.
-        // Verified live against the ChatGPT Codex backend on 2026-08-21:
-        // lifted requests compact (608 tokens/turn) and tool calls execute.
+    fn sitecustomize_unfolds_tool_schema_dollars() {
+        // Upstream PR #3170 not yet in a wheel: 0.36.0's attribution
+        // unification folds priced tool-schema dollars into
+        // compression_savings_usd while every token field beside it stays
+        // message-only, inflating any $/token read on the persisted state by
+        // 1 + tool/message (5.59x measured; an implied $32.88/M next to
+        // models listing at $10/M). The guard zeroes the tool_schema bucket
+        // before the fold so the desktop's lifetime dollars keep their
+        // 0.35.0 meaning on the 0.37.0 wheel.
         let py = super::SITECUSTOMIZE_PY;
-        assert!(py.contains("HEADROOM_ADDITIONAL_TOOLS_GUARD"));
-        assert!(py.contains(r#"item.get("type") == "additional_tools""#));
-        // Self-neutralizes on classic-encoding requests: a present top-level
-        // tools array must short-circuit the lift.
-        assert!(py.contains(r#"or payload.get("tools"):"#));
-        // The wrapper must be installed on the executor seam (the single
-        // funnel for HTTP, WS, and passthrough responses compression)...
-        assert!(py.contains(
-            "_hd_at_openai.OpenAIHandlerMixin._compress_openai_responses_payload_in_executor = ("
-        ));
-        // ...and the lift must be symmetric. Upstream #3194: tools is a
-        // per-request parameter, additional_tools is an input item and so
-        // part of the transcript, so a stateful Codex session (TUI/app-server
-        // over WS) declares its tools once and relies on the transcript
-        // afterwards -- forwarding the lifted shape gives it tools on turn
-        // one and none for the rest of the session. The carrier goes back,
-        // carrying the compacted definitions, before the payload is
-        // forwarded, and the top-level array is dropped.
-        assert!(py.contains("def _hd_at_restore(payload, plan):"));
-        assert!(py.contains(r#"payload.pop("tools", None)"#));
-        assert!(py.contains("failed = [t for t in targets if not _hd_at_restore(t, plan)]"));
-        // Both what the call sites forward (result[0]) and the payload the
-        // caller passed in are restored.
-        assert!(py.contains("out = result[0] if isinstance(result, tuple) and result else None"));
-        assert!(py.contains("targets = [payload]"));
-        // Restoring an already-restored payload must not duplicate the
-        // definitions, and an emptied array falls back to what Codex sent
-        // rather than forwarding a tool-less payload.
-        assert!(py.contains("if not isinstance(tools, list) or not tools:"));
-        assert!(py.contains("tools = original"));
-        // A restore that cannot happen is logged, never silent.
-        assert!(py.contains("event=codex_additional_tools_restore_failed"));
-        let restore_pos = py.find("def _hd_at_restore").expect("restore present");
-        let call_pos = py
-            .find("failed = [t for t in targets")
-            .expect("restore call present");
-        let orig_pos = py
-            .find("result = await _hd_at_orig_compress")
-            .expect("inner compress call present");
-        assert!(restore_pos < orig_pos && orig_pos < call_pos);
-        // ...and AFTER the denominator guard's wrapper of the same method, so
-        // the lift is outermost and the widening sees the lifted tools.
-        let lift_pos = py
-            .find("_hd_at_openai.OpenAIHandlerMixin")
-            .expect("lift patch present");
-        let denom_pos = py
-            .find("_hd_rd_openai.OpenAIHandlerMixin")
-            .expect("denominator patch present");
-        assert!(denom_pos < lift_pos);
-    }
-
-    #[test]
-    fn sitecustomize_restores_codex_additional_tools_when_compression_raises() {
-        let py = super::SITECUSTOMIZE_PY;
-        let guard = &py[py
-            .find("    # Codex additional_tools guard")
-            .expect("additional_tools guard present")..];
-        let mut script = r#"
-import asyncio
-import copy
-import os as _hd_os
-import sys
-import types
-
-headroom = types.ModuleType("headroom")
-headroom.__path__ = []
-proxy = types.ModuleType("headroom.proxy")
-proxy.__path__ = []
-handlers = types.ModuleType("headroom.proxy.handlers")
-handlers.__path__ = []
-openai = types.ModuleType("headroom.proxy.handlers.openai")
-
-class OpenAIHandlerMixin:
-    async def _compress_openai_responses_payload_in_executor(self, payload, **kwargs):
-        assert payload.get("tools"), payload
-        raise TimeoutError("boom")
-
-openai.OpenAIHandlerMixin = OpenAIHandlerMixin
-headroom.proxy = proxy
-proxy.handlers = handlers
-handlers.openai = openai
-sys.modules.update({
-    "headroom": headroom,
-    "headroom.proxy": proxy,
-    "headroom.proxy.handlers": handlers,
-    "headroom.proxy.handlers.openai": openai,
-})
-"#
-        .to_string();
-        script.push_str("if True:\n");
-        script.push_str(guard);
-        script.push_str(
-            r#"
-payload = {
-    "input": [
-        {"type": "message", "content": "before"},
-        {
-            "type": "additional_tools",
-            "id": "carrier",
-            "tools": [{"type": "function", "name": "shell"}],
-        },
-        {"type": "message", "content": "after"},
-    ]
-}
-original = copy.deepcopy(payload)
-
-async def verify():
-    try:
-        await OpenAIHandlerMixin()._compress_openai_responses_payload_in_executor(payload)
-    except TimeoutError:
-        pass
-    else:
-        raise AssertionError("compressor did not raise")
-    assert payload == original, (payload, original)
-
-asyncio.run(verify())
-"#,
-        );
-
-        let python = if cfg!(windows) { "python" } else { "python3" };
-        let out = match crate::proc::command(python).args(["-c", &script]).output() {
-            Ok(out) => out,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return,
-            Err(e) => panic!("spawn failed: {e}"),
-        };
+        assert!(py.contains("HEADROOM_SAVINGS_FOLD_GUARD"));
+        assert!(py.contains("_hd_sf_st.SavingsTracker.record_request = _hd_sf_record"));
+        // The unfold works on a copy -- the caller's mapping is not mutated.
+        assert!(py.contains("unfolded = dict(priced)"));
+        assert!(py.contains(r#"unfolded["tool_schema"] = 0.0"#));
+        // Self-neutralizes on the first wheel shipping #3170's disjoint
+        // fields, so a proper upstream split is never zeroed.
         assert!(
-            out.status.success(),
-            "additional_tools exception round-trip failed: {}",
-            String::from_utf8_lossy(&out.stderr)
+            py.contains(r#""tool_schema_savings_usd" not in _hd_sf_st._empty_display_session()"#)
         );
+        // Only the dollar fold is undone; the token side must pass through.
+        assert!(!py.contains(r#"kwargs["tool_search_saved"]"#));
+        // The 0.37.0 wheel handles Codex additional_tools natively (#3186 +
+        // #3194), so the desktop lift is gone with the pin bump.
+        assert!(!py.contains("HEADROOM_ADDITIONAL_TOOLS_GUARD"));
+        assert!(!py.contains("additional_tools"));
     }
 
     #[test]

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -257,7 +257,7 @@ still compress -- so the flip stays. tool_result blocks compress
 regardless of this flag (the role gate only guards text blocks), so the
 coding token mass is unaffected.
 
-Also ports five fixes owed upstream (remove each once a wheel ships it),
+Also ports six fixes owed upstream (remove each once a wheel ships it),
 gated on HEADROOM_SDK=headroom-desktop-proxy so only the backend process
 pays the proxy import cost:
 Context-limit guard (upstream PR #2942): compression under-reports
@@ -301,6 +301,20 @@ persisted dollar field; tool-schema TOKENS are untouched and the
 desktop keeps pricing those itself at the cache-read rate.
 Self-neutralizes once a wheel ships #3170's disjoint fields. Kill
 switch: HEADROOM_SAVINGS_FOLD_GUARD=0.
+Chained-read protection (upstream PR #2668): _is_read_command
+inspects only the FIRST program and applies its write/redirect check
+to the whole string, so a read batched behind other work
+(`wc -l a.py && sed -n '1,60p' a.py`) classifies as a non-read and the
+file content is lossy-compressed despite read protection -- the agent
+then re-reads the file to recover exact bytes (turn inflation) or
+fails the edit outright (resolve loss). The guard splits on ;/&&/||
+(never on a single |: downstream pipeline stages consume output, not
+files), judges redirects and tee per segment so a sibling write does
+not unprotect the read beside it, keeps the heredoc whole-string
+bailout (a heredoc body may contain ; or &&), and delegates each
+segment's program parsing to the original function so wrapper peeling,
+bash -c recursion and the lockfile carve-out stay upstream's. Kill
+switch: HEADROOM_READ_CHAIN_GUARD=0.
 cc-switch Official-branch upstream reset (upstream PR #3166): the
 reconciler captures the third-party endpoint cc-switch selected (Kimi,
 DeepSeek, GLM) as this proxy's Anthropic upstream, but switching back to
@@ -811,6 +825,60 @@ if _hd_os.environ.get("HEADROOM_SDK") == "headroom-desktop-proxy":
                     return _hd_sf_orig_record(self, **kwargs)
 
                 _hd_sf_st.SavingsTracker.record_request = _hd_sf_record
+    except Exception:
+        pass
+
+    # Chained-read protection (upstream PR #2668; remove once a wheel ships it
+    # -- see the module docstring for the re-read/resolve-loss failure this
+    # prevents). Rebinding the module-level name covers both in-module call
+    # sites: Python resolves it via module globals at call time, which also
+    # routes the original's own bash -c recursion through the new version.
+    # Kill switch: HEADROOM_READ_CHAIN_GUARD=0.
+    try:
+        if _hd_os.environ.get(
+            "HEADROOM_READ_CHAIN_GUARD", "1"
+        ).strip().lower() not in ("0", "false", "no", "off"):
+            import re as _hd_rc_re
+
+            import headroom.transforms.content_router as _hd_rc_cr
+
+            _hd_rc_orig = _hd_rc_cr._is_read_command
+            # ; && and || start a NEW command; a single | deliberately does
+            # not: downstream pipeline stages consume the previous stage's
+            # output, not a file, so `grep -n x a.py | head -40` stays derived
+            # (compressible) while `cat a.py | head -40` reads via stage one.
+            _hd_rc_sep = _hd_rc_re.compile(r"\|\||&&|;")
+            _hd_rc_write = _hd_rc_re.compile(r"(^|\s)(>>?|tee\b)")
+            _hd_rc_heredoc = _hd_rc_re.compile(r"(^|\s)<<")
+
+            def _hd_rc_segment_is_read(seg):
+                # A redirect or tee in THIS segment means it writes a file;
+                # judged on the whole segment -- pipeline included, so
+                # `cat a.py | tee b.py` stays a write -- before reducing to
+                # the stage that touches the file. Sibling segments never
+                # see each other, so `cat a.py && echo done > marker` keeps
+                # its read protected.
+                if _hd_rc_write.search(seg):
+                    return False
+                first = seg.split("|", 1)[0].strip()
+                return bool(first) and _hd_rc_orig(first)
+
+            def _hd_rc_is_read(command):
+                if not command or not isinstance(command, str):
+                    return False
+                c = _hd_rc_cr._strip_cd_prefix(command)
+                # A heredoc is the one WHOLE-STRING bailout: its body can
+                # contain ; or &&, which would split into bogus segments that
+                # look like reads. The command as a whole writes a file.
+                if _hd_rc_heredoc.search(c):
+                    return False
+                return any(
+                    _hd_rc_segment_is_read(seg)
+                    for seg in (s.strip() for s in _hd_rc_sep.split(c))
+                    if seg
+                )
+
+            _hd_rc_cr._is_read_command = _hd_rc_is_read
     except Exception:
         pass
 
@@ -10506,6 +10574,32 @@ mod tests {
         // #3194), so the desktop lift is gone with the pin bump.
         assert!(!py.contains("HEADROOM_ADDITIONAL_TOOLS_GUARD"));
         assert!(!py.contains("additional_tools"));
+    }
+
+    #[test]
+    fn sitecustomize_ports_read_chain_guard() {
+        // Upstream PR #2668 not yet in a wheel: _is_read_command matches only
+        // the first program and applies its write check whole-string, so a
+        // read batched behind other work (`wc -l a.py && sed -n '1,60p'
+        // a.py`) is lossy-compressed despite read protection -- the exact
+        // re-read/resolve-loss failure the protection exists to prevent.
+        let py = super::SITECUSTOMIZE_PY;
+        assert!(py.contains("HEADROOM_READ_CHAIN_GUARD"));
+        assert!(py.contains("upstream PR #2668"));
+        // Split on ; && and || -- never on a single | (pipelines reduce to
+        // their first stage instead).
+        assert!(py.contains(r#"_hd_rc_re.compile(r"\|\||&&|;")"#));
+        assert!(py.contains(r#"seg.split("|", 1)[0].strip()"#));
+        // Redirect/tee are judged per SEGMENT so a sibling write cannot
+        // unprotect the read next to it; the heredoc bailout stays
+        // whole-string because its body may contain separators.
+        assert!(py.contains(r#"(^|\s)(>>?|tee\b)"#));
+        assert!(py.contains(r#"(^|\s)<<"#));
+        // Each segment delegates to the ORIGINAL parser (wrapper peeling,
+        // bash -c recursion, lockfile carve-out stay upstream's), and the
+        // rebind covers both in-module call sites via module globals.
+        assert!(py.contains("_hd_rc_orig(first)"));
+        assert!(py.contains("_hd_rc_cr._is_read_command = _hd_rc_is_read"));
     }
 
     #[test]

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -323,11 +323,16 @@ bytes change mid-conversation and the provider prompt cache busts from
 the first changed byte -- measured 2026-09-01 as a 160-210k-token cache
 re-write every 1-2 requests, dollar cache-hit rate 90% -> 52%, billable
 input $/M up 2.2x, across the 0.35.0 -> 0.37.0 wheel swap. The guard
-neuters only the size bound (every alignment guard stays) by stubbing
-_compact_json_bytes for the duration of each overlay call, restoring
-0.35.0's byte-identical replay. The desktop backend serves proxy-mode
-traffic only, whose snapshots refresh from every provider response, so
-byte-identical replay is always the cheaper request here. Gated on the
+ports #3380's reworked floor semantics: the provider-confirmed prefix
+is replayed unconditionally (declining there can only bust the cache),
+while beyond the floor a declined replay ships this turn's fresh bytes
+so background-compression improvements reach the wire, and a collapsed
+floor (cold cache) re-baselines the whole prefix. The confirmed count
+rides a side-channel -- the finalize path hands the overlay the exact
+list object get_last_forwarded_messages() returned, so the patched
+getter records id(list) -> (len, confirmed count) and the overlay
+wrapper pops it by identity; a missed lookup degrades to full replay,
+the cache-safe posture verified live on rc.2. Gated on the
 runtime NOT having the fix's parameter (enforce_non_inflation in the
 first PR shape, confirmed_frozen_count in the reworked #3380 shape), so
 the first wheel that ships either keeps its own replay policy and this
@@ -899,20 +904,24 @@ if _hd_os.environ.get("HEADROOM_SDK") == "headroom-desktop-proxy":
     except Exception:
         pass
 
-    # Prefix-replay inflation-skip guard (upstream issue #3379; remove once a
+    # Prefix-replay guard (upstream issue #3379 / PR #3380; remove once a
     # wheel ships the fix -- see the module docstring for the cache-bust loop
-    # this prevents). overlay_cached_prefix's size bound reads
-    # _compact_json_bytes via module globals at call time; stubbing it to
-    # return equal-length bytes for both candidates makes the
-    # len(replayed) > len(optimized) comparison always false, so the replay
-    # proceeds while every alignment/append-only guard still runs. Swap and
-    # restore around each call so any other caller of the helper stays
-    # honest; overlay is synchronous on the proxy's single event loop, so the
-    # swap cannot interleave with another request's overlay. Gated on the
-    # runtime NOT having the fix's parameter under either name shipped on
-    # #3380 (enforce_non_inflation / confirmed_frozen_count), so the first
-    # wheel that ships the fix keeps its own replay policy and this block
-    # goes inert. Kill switch: HEADROOM_PREFIX_REPLAY_GUARD=0.
+    # this prevents and the floor semantics this ports). The confirmed count
+    # travels by object identity: the wheel's finalize path passes the exact
+    # list get_last_forwarded_messages() returned, so the patched getter
+    # records it and the overlay wrapper pops it one-shot; a miss degrades to
+    # full replay (the cache-safe posture verified live on rc.2). The size
+    # bound is probed by calling the original twice on DECLINED turns only:
+    # once bound-on (a shrinking repair is accepted as-is), once with
+    # _compact_json_bytes stubbed to equal-length bytes (inflation compare
+    # goes false; every alignment guard still runs), then spliced at the
+    # floor so improvements beyond the confirmed prefix ship while confirmed
+    # bytes stay byte-identical. Overlay is synchronous on the proxy's single
+    # event loop, so the stub swap cannot interleave. Gated on the runtime
+    # NOT having the fix's parameter under either name shipped on #3380
+    # (enforce_non_inflation / confirmed_frozen_count), so the first wheel
+    # that ships the fix keeps its own replay policy and this block goes
+    # inert. Kill switch: HEADROOM_PREFIX_REPLAY_GUARD=0.
     try:
         if _hd_os.environ.get(
             "HEADROOM_PREFIX_REPLAY_GUARD", "1"
@@ -923,16 +932,73 @@ if _hd_os.environ.get("HEADROOM_SDK") == "headroom-desktop-proxy":
                 name in _hd_pr_pt.overlay_cached_prefix.__code__.co_varnames
                 for name in ("enforce_non_inflation", "confirmed_frozen_count")
             )
-            if hasattr(_hd_pr_pt, "_compact_json_bytes") and not _hd_pr_fixed:
+            if (
+                hasattr(_hd_pr_pt, "_compact_json_bytes")
+                and not _hd_pr_fixed
+                and hasattr(_hd_pr_pt, "PrefixCacheTracker")
+                and hasattr(_hd_pr_pt.PrefixCacheTracker, "get_last_forwarded_messages")
+                and hasattr(_hd_pr_pt.PrefixCacheTracker, "get_frozen_message_count")
+            ):
+                # id(list) -> (len, provider-confirmed count); one-shot pop.
+                _hd_pr_floors = {}
+                _hd_pr_orig_getter = (
+                    _hd_pr_pt.PrefixCacheTracker.get_last_forwarded_messages
+                )
+
+                def _hd_pr_getter(self):
+                    result = _hd_pr_orig_getter(self)
+                    try:
+                        if len(_hd_pr_floors) > 128:
+                            _hd_pr_floors.clear()
+                        _hd_pr_floors[id(result)] = (
+                            len(result),
+                            max(int(self.get_frozen_message_count() or 0), 0),
+                        )
+                    except Exception:
+                        pass
+                    return result
+
+                _hd_pr_pt.PrefixCacheTracker.get_last_forwarded_messages = _hd_pr_getter
                 _hd_pr_orig_overlay = _hd_pr_pt.overlay_cached_prefix
 
                 def _hd_pr_overlay(*args, **kwargs):
+                    optimized = args[0] if args else kwargs.get("optimized_messages")
+                    prev_fwd = (
+                        args[3]
+                        if len(args) > 3
+                        else kwargs.get("previous_forwarded_messages")
+                    )
+                    ent = (
+                        _hd_pr_floors.pop(id(prev_fwd), None)
+                        if prev_fwd is not None
+                        else None
+                    )
+                    # Pass 1, bound enforced -- identical to stock. A repair
+                    # that shrinks (freeze drift, #1850) is accepted as-is.
+                    r1 = _hd_pr_orig_overlay(*args, **kwargs)
+                    if r1 is not optimized:
+                        return r1
+                    # Pass 2, bound neutered; alignment guards still run.
+                    # Only reached on declined turns (post-kompress, a few
+                    # per minute at most).
                     _hd_pr_saved = _hd_pr_pt._compact_json_bytes
                     _hd_pr_pt._compact_json_bytes = lambda value: b""
                     try:
-                        return _hd_pr_orig_overlay(*args, **kwargs)
+                        r2 = _hd_pr_orig_overlay(*args, **kwargs)
                     finally:
                         _hd_pr_pt._compact_json_bytes = _hd_pr_saved
+                    if r2 is optimized:
+                        return optimized
+                    if ent is None or ent[0] != len(prev_fwd) or len(r2) != len(optimized):
+                        # No trustworthy floor: full replay, the verified
+                        # cache-safe fallback.
+                        return r2
+                    floor = min(ent[1], len(r2))
+                    # Confirmed region keeps last turn's forwarded bytes;
+                    # beyond it this turn's fresh output ships, so the
+                    # improvement that triggered the decline lands (and a
+                    # collapsed floor on a cold cache re-baselines fully).
+                    return list(r2[:floor]) + list(optimized[floor:])
 
                 _hd_pr_pt.overlay_cached_prefix = _hd_pr_overlay
     except Exception:
@@ -10983,9 +11049,19 @@ mod tests {
         // keeps its own replay policy.
         assert!(py.contains("in _hd_pr_pt.overlay_cached_prefix.__code__.co_varnames"));
         assert!(py.contains(r#""enforce_non_inflation", "confirmed_frozen_count""#));
-        // Swap-and-restore of the sizing helper, never a permanent stub.
+        // Floor side-channel: the getter records the exact returned list by
+        // identity, the overlay pops it ONE-SHOT (no stale reuse), and a
+        // miss degrades to full replay.
+        assert!(
+            py.contains("_hd_pr_pt.PrefixCacheTracker.get_last_forwarded_messages = _hd_pr_getter")
+        );
+        assert!(py.contains("_hd_pr_floors.pop(id(prev_fwd), None)"));
+        // Two-pass probe: bound-on first (shrinking repair accepted), then
+        // stubbed sizing, then the floor splice that lets improvements ship.
+        assert!(py.contains("if r1 is not optimized:"));
         assert!(py.contains(r#"_hd_pr_pt._compact_json_bytes = lambda value: b"""#));
         assert!(py.contains("_hd_pr_pt._compact_json_bytes = _hd_pr_saved"));
+        assert!(py.contains("return list(r2[:floor]) + list(optimized[floor:])"));
         assert!(py.contains("_hd_pr_pt.overlay_cached_prefix = _hd_pr_overlay"));
     }
 

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -9549,6 +9549,41 @@ fn strip_unsupported_proxy_env(command: &mut Command) {
     }
 }
 
+/// True when a proxy env value names a socks-scheme proxy (any variant -
+/// socks4/socks4a/socks5/socks5h), which pip's vendored requests cannot use
+/// without the optional pysocks package.
+fn is_socks_proxy_value(value: &str) -> bool {
+    value.trim().to_ascii_lowercase().starts_with("socks")
+}
+
+/// Remove socks-scheme proxy env vars from tool children. The managed venv
+/// does not ship pysocks, so every pip run under `all_proxy=socks5://...`
+/// dies with "Missing dependencies for SOCKS support" (RUST-6S) - going
+/// direct is strictly better than that guaranteed failure. http/https
+/// proxies pass through untouched, and the backend spawn is unaffected: it
+/// keeps socks5 via its own narrower `strip_unsupported_proxy_env`, because
+/// httpx vendors socksio and can actually use it.
+fn strip_socks_proxy_env(command: &mut Command) {
+    for (name, value) in std::env::vars_os() {
+        let Some(name) = name.to_str() else { continue };
+        let is_proxy_var = ["http_proxy", "https_proxy", "all_proxy"]
+            .iter()
+            .any(|p| name.eq_ignore_ascii_case(p));
+        if !is_proxy_var {
+            continue;
+        }
+        if !is_socks_proxy_value(&value.to_string_lossy()) {
+            continue;
+        }
+        // info, not warn: warn is bridged to Sentry and would re-report on
+        // every launch of an affected machine, forever.
+        log::info!(
+            "[tool_manager] dropping {name} from child env: socks proxies need pysocks, which the managed venv does not ship (pip would fail on it)"
+        );
+        command.env_remove(name);
+    }
+}
+
 /// True when the SSLKEYLOGFILE path can actually be opened for append, which
 /// is exactly what CPython's `SSLContext.keylog_filename` setter does the
 /// moment a TLS context is created. Probing with create matches those
@@ -9625,6 +9660,7 @@ fn build_command(binary: &Path, args: &[&str], cwd: &Path) -> Command {
             if cfg!(windows) { "NUL" } else { "/dev/null" },
         );
     strip_unusable_sslkeylogfile(&mut command);
+    strip_socks_proxy_env(&mut command);
     command
 }
 
@@ -13230,6 +13266,30 @@ after
             assert!(
                 !super::httpx_supports_proxy_url(bad),
                 "{bad:?} should be stripped"
+            );
+        }
+    }
+
+    /// RUST-6S: pip cannot use socks proxies without pysocks, so any socks
+    /// scheme must read as strippable for pip-class children; http/https and
+    /// the empty "proxy disabled" value pass through.
+    #[test]
+    fn socks_proxy_detection_covers_every_socks_scheme() {
+        for socks in [
+            "socks5://127.0.0.1:10808",
+            "SOCKS4://127.0.0.1:1080",
+            "socks5h://proxy.local:1080",
+            "  socks4a://127.0.0.1:9 ",
+        ] {
+            assert!(
+                super::is_socks_proxy_value(socks),
+                "{socks:?} should be stripped for pip children"
+            );
+        }
+        for other in ["", "http://127.0.0.1:8080", "https://proxy.corp:3128"] {
+            assert!(
+                !super::is_socks_proxy_value(other),
+                "{other:?} should pass through"
             );
         }
     }

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -2642,6 +2642,7 @@ impl ToolManager {
                     command.process_group(0);
                 }
                 strip_unsupported_proxy_env(&mut command);
+                override_unsupported_registry_proxy(&mut command);
                 strip_unusable_sslkeylogfile(&mut command);
                 command
                     .env("PYTHONNOUSERSITE", "1")
@@ -9549,6 +9550,163 @@ fn strip_unsupported_proxy_env(command: &mut Command) {
     }
 }
 
+/// Windows keeps a second proxy source the env strip above cannot reach:
+/// the WinINET registry proxy (`ProxyEnable`/`ProxyServer` under HKCU).
+/// Python's `urllib.getproxies()` falls back to it whenever the process env
+/// carries not a single non-empty `*_proxy` var, and httpx wraps every
+/// http/https entry in `Proxy(url=...)` at AsyncClient() construction -- so a
+/// v2rayN-style `socks4://127.0.0.1:10808` system proxy kills backend boot
+/// with the exact ValueError of RUST-AS/RUST-AT even on builds that ship
+/// `strip_unsupported_proxy_env` (RUST-AY, stable 0.9.3). Mirror urllib's
+/// expansion; if the entries httpx would mount include a scheme it cannot
+/// parse, override the child env: usable entries become explicit
+/// http_proxy/https_proxy vars (any env proxy var makes urllib skip the
+/// registry), and when nothing is usable NO_PROXY="*" sends the backend
+/// direct -- strictly better than a guaranteed boot crash.
+fn override_unsupported_registry_proxy(command: &mut Command) {
+    if !cfg!(windows) {
+        return;
+    }
+    // urllib consults the registry only when the child sees zero non-empty
+    // *_proxy env vars. Vars the strip above removes are gone from the child,
+    // so they do not count; anything else (ftp_proxy, no_proxy, a supported
+    // http_proxy) suppresses the registry on its own.
+    let child_keeps_a_proxy_var = std::env::vars_os().any(|(name, value)| {
+        let Some(name) = name.to_str() else {
+            return false;
+        };
+        let lower = name.to_ascii_lowercase();
+        let value = value.to_string_lossy();
+        if value.is_empty() || !lower.ends_with("_proxy") {
+            return false;
+        }
+        let stripped_above = ["http_proxy", "https_proxy", "all_proxy"].contains(&lower.as_str())
+            && !httpx_supports_proxy_url(&value);
+        !stripped_above
+    });
+    if child_keeps_a_proxy_var {
+        return;
+    }
+    let Some(output) = crate::proc::command("reg")
+        .args([
+            "query",
+            r"HKCU\Software\Microsoft\Windows\CurrentVersion\Internet Settings",
+        ])
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+    else {
+        return;
+    };
+    let text = String::from_utf8_lossy(&output.stdout).to_string();
+    let enabled = parse_reg_value(&text, "ProxyEnable")
+        .map(|v| reg_dword_is_set(&v))
+        .unwrap_or(false);
+    if !enabled {
+        return;
+    }
+    let Some(server) = parse_reg_value(&text, "ProxyServer") else {
+        return;
+    };
+    let Some(overrides) = registry_proxy_env_overrides(&server) else {
+        return;
+    };
+    // info, not warn: warn is bridged to Sentry and would re-report on every
+    // launch of an affected machine, forever. Values stay out of the log --
+    // proxy URLs can embed credentials.
+    log::info!(
+        "[tool_manager] WinINET registry proxy carries a scheme httpx cannot parse; overriding {} child proxy env var(s) so backend boot survives",
+        overrides.len()
+    );
+    for (name, value) in overrides {
+        command.env(name, value);
+    }
+}
+
+/// The data row for `value_name` in `reg query` output:
+/// `    ProxyServer    REG_SZ    socks4://127.0.0.1:10808`.
+/// Localized Windows translates headers and INFO lines but never the value
+/// rows' REG_* type token, so matching name + type token is locale-safe.
+fn parse_reg_value(reg_output: &str, value_name: &str) -> Option<String> {
+    for line in reg_output.lines() {
+        let mut parts = line.split_whitespace();
+        if parts.next() != Some(value_name) {
+            continue;
+        }
+        let Some(ty) = parts.next() else { continue };
+        if !ty.starts_with("REG_") {
+            continue;
+        }
+        let rest = parts.collect::<Vec<_>>().join(" ");
+        if !rest.is_empty() {
+            return Some(rest);
+        }
+    }
+    None
+}
+
+/// `reg query` prints REG_DWORD as hex (`0x1`).
+fn reg_dword_is_set(value: &str) -> bool {
+    let v = value.trim().trim_start_matches("0x");
+    u64::from_str_radix(v, 16).map(|n| n != 0).unwrap_or(false)
+}
+
+/// urllib's `getproxies_registry` expansion of the `ProxyServer` string,
+/// restricted to the keys httpx mounts (http/https -- keyed socks entries
+/// never reach httpx and are harmless). A value without `=` applies to every
+/// protocol; `proto=addr` pairs are per-protocol; an address without a scheme
+/// inherits its protocol name as the scheme. Returns None when no override is
+/// needed (nothing mounted, or every mounted entry parses), otherwise the env
+/// vars to set on the child.
+fn registry_proxy_env_overrides(proxy_server: &str) -> Option<Vec<(String, String)>> {
+    let server = proxy_server.trim();
+    if server.is_empty() {
+        return None;
+    }
+    let expanded = if server.contains('=') {
+        server.to_string()
+    } else {
+        format!("http={server};https={server}")
+    };
+    let mut mounted: Vec<(String, String)> = Vec::new();
+    for pair in expanded.split(';') {
+        let Some((proto, addr)) = pair.split_once('=') else {
+            continue;
+        };
+        let proto = proto.trim().to_ascii_lowercase();
+        if proto != "http" && proto != "https" {
+            continue;
+        }
+        let addr = addr.trim();
+        if addr.is_empty() {
+            continue;
+        }
+        // urllib keeps an existing scheme (`^([^/:]+)://`) and otherwise
+        // prefixes the protocol name.
+        let has_scheme = addr
+            .split_once("://")
+            .is_some_and(|(scheme, _)| !scheme.contains('/') && !scheme.contains(':'));
+        let url = if has_scheme {
+            addr.to_string()
+        } else {
+            format!("{proto}://{addr}")
+        };
+        mounted.push((proto, url));
+    }
+    if mounted.iter().all(|(_, url)| httpx_supports_proxy_url(url)) {
+        return None;
+    }
+    let usable: Vec<(String, String)> = mounted
+        .into_iter()
+        .filter(|(_, url)| httpx_supports_proxy_url(url))
+        .map(|(proto, url)| (format!("{proto}_proxy"), url))
+        .collect();
+    if usable.is_empty() {
+        return Some(vec![("NO_PROXY".to_string(), "*".to_string())]);
+    }
+    Some(usable)
+}
+
 /// True when a proxy env value names a socks-scheme proxy (any variant -
 /// socks4/socks4a/socks5/socks5h), which pip's vendored requests cannot use
 /// without the optional pysocks package.
@@ -13268,6 +13426,64 @@ after
                 "{bad:?} should be stripped"
             );
         }
+    }
+
+    #[test]
+    fn parse_reg_value_reads_typed_rows() {
+        let out = "\r\nHKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\r\n    ProxyEnable    REG_DWORD    0x1\r\n    ProxyServer    REG_SZ    socks4://127.0.0.1:10808\r\n";
+        assert_eq!(
+            super::parse_reg_value(out, "ProxyEnable").as_deref(),
+            Some("0x1")
+        );
+        assert_eq!(
+            super::parse_reg_value(out, "ProxyServer").as_deref(),
+            Some("socks4://127.0.0.1:10808")
+        );
+        assert!(super::parse_reg_value(out, "ProxyOverride").is_none());
+        assert!(super::reg_dword_is_set("0x1"));
+        assert!(!super::reg_dword_is_set("0x0"));
+    }
+
+    /// RUST-AY: v2rayN "set system proxy" writes a single socks4 URL into
+    /// `ProxyServer`; urllib mounts it under http AND https, httpx's
+    /// AsyncClient() raises, and the backend dies before opening the port.
+    /// Nothing is usable -> the child goes direct.
+    #[test]
+    fn registry_socks4_single_value_goes_direct() {
+        assert_eq!(
+            super::registry_proxy_env_overrides("socks4://127.0.0.1:10808"),
+            Some(vec![("NO_PROXY".to_string(), "*".to_string())])
+        );
+    }
+
+    #[test]
+    fn registry_clean_proxies_need_no_override() {
+        assert_eq!(super::registry_proxy_env_overrides("1.2.3.4:8080"), None);
+        assert_eq!(
+            super::registry_proxy_env_overrides("http=1.2.3.4:8080;https=1.2.3.4:8080"),
+            None
+        );
+        // Keyed socks entries never reach httpx's mounts.
+        assert_eq!(
+            super::registry_proxy_env_overrides("http=1.2.3.4:8080;socks=127.0.0.1:10808"),
+            None
+        );
+        assert_eq!(super::registry_proxy_env_overrides(""), None);
+        assert_eq!(super::registry_proxy_env_overrides("   "), None);
+    }
+
+    /// A corporate box with a usable http proxy next to a broken socks4
+    /// https entry keeps the working half as an explicit env var (which also
+    /// makes urllib skip the registry entirely).
+    #[test]
+    fn registry_mixed_keeps_the_usable_entry() {
+        assert_eq!(
+            super::registry_proxy_env_overrides("http=socks4://127.0.0.1:10808;https=1.2.3.4:8080"),
+            Some(vec![(
+                "https_proxy".to_string(),
+                "https://1.2.3.4:8080".to_string()
+            )])
+        );
     }
 
     /// RUST-6S: pip cannot use socks proxies without pysocks, so any socks

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.4-rc.5",
+  "version": "0.9.4",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.4-rc.1",
+  "version": "0.9.4-rc.2",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.4-rc.4",
+  "version": "0.9.4-rc.5",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.4-rc.2",
+  "version": "0.9.4-rc.3",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.4-rc.3",
+  "version": "0.9.4-rc.4",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.3-rc.8",
+  "version": "0.9.4-rc.1",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3937,12 +3937,17 @@ export default function App() {
       let latestConnectors = await fetchConnectors();
       applyConnectorsIfChanged(latestConnectors);
 
-      const step = nextAutoConfigureStep(
-        getLauncherAutoConfigureDecision(latestConnectors),
-        latestConnectors
-      );
+      const decision = getLauncherAutoConfigureDecision(latestConnectors);
+      const step = nextAutoConfigureStep(decision, latestConnectors);
 
       if (step.kind === "show_client_setup") {
+        // Landing here at launch means the probe found no installed client
+        // (decision "show_client_setup" is exactly installed.length === 0) --
+        // the biggest unexplained drop in the Windows funnel. Name it so the
+        // per-OS funnel can separate "no editor found" from "found but unused".
+        if (decision === "show_client_setup") {
+          reportFunnelStep("client_setup_no_clients_detected");
+        }
         setLauncherStage("client_setup");
         return;
       }
@@ -3956,7 +3961,6 @@ export default function App() {
         }
         latestConnectors = await fetchConnectors();
         applyConnectorsIfChanged(latestConnectors);
-        reportFunnelStep("client_setup_applied");
 
         const postApplyStep = nextAutoConfigureStepAfterApply(
           getLauncherAutoConfigureDecision(latestConnectors)

--- a/src/lib/launcherHelpers.test.ts
+++ b/src/lib/launcherHelpers.test.ts
@@ -27,6 +27,7 @@ describe("install-wizard funnel steps", () => {
       "email_code_requested",
       "email_code_verified",
       "client_setup_shown",
+      "client_setup_no_clients_detected",
       "client_setup_applied",
       "proxy_verify_started",
       "proxy_verified",

--- a/src/lib/launcherHelpers.ts
+++ b/src/lib/launcherHelpers.ts
@@ -31,6 +31,7 @@ export const INSTALL_WIZARD_STEPS = [
   "email_code_requested",
   "email_code_verified",
   "client_setup_shown",
+  "client_setup_no_clients_detected",
   "client_setup_applied",
   "proxy_verify_started",
   "proxy_verified",

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -21,6 +21,8 @@ export function claudePlanLabel(plan: ClaudePlanTier) {
       return "Claude Max x5";
     case "max20x":
       return "Claude Max x20";
+    case "api":
+      return "Claude API";
     default:
       return "Unknown Claude plan";
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -517,7 +517,7 @@ export interface ActivityFeedResponse {
 
 export type ClaudeAuthMethod = "claude_ai_oauth" | "api_key" | "unknown";
 
-export type ClaudePlanTier = "free" | "pro" | "max5x" | "max20x" | "unknown";
+export type ClaudePlanTier = "free" | "pro" | "max5x" | "max20x" | "api" | "unknown";
 
 export type HeadroomSubscriptionTier = "pro" | "max5x" | "max20x";
 


### PR DESCRIPTION
Stable promotion of 0.9.4 from the rc.5 staging tip.

Highlights since 0.9.3:
- API plan tier for API-console orgs + server-driven usage-band pitch (RUST-B2)
- socks4 registry-proxy backfill fix (RUST-B3)
- Desktop guard for the headroom-ai 0.37.0 prompt-cache-bust regression (prefix-replay, floor semantics ported from upstream PR #3380 — self-neutralizes once the wheel ships the fix)
- Self-diagnosing savings-rate-implausible warning (wheel version + raw sums, RUST-89)

Verification: full `./scripts/verify-release.sh` (1081 Rust tests + frontend coverage) green locally before cutting this branch. Prefix-replay guard v2 verified end-to-end against the real finalize_turn code path and against live production traffic (0 cache busts across the rc.4 sample window, vs 6 on 0.37.0 unguarded).

No release notes for this version (per request) — the in-app update dialog will show an empty notes block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)