### PR TITLE
Fix four production Sentry issues: learn auth, /stats timeout, wheel fallback, bootstrap ETA

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5848,6 +5848,78 @@ fn normalize_learn_failure_signature(signature: &str) -> String {
     )
 }
 
+/// True when a `headroom learn` failure was the coding agent's CLI refusing to
+/// run because nobody is signed in to it on this machine.
+///
+/// This is a user-environment condition, not an app bug: the analyzer shells
+/// out to `claude`/`codex`/`opencode`, and if that CLI has no session it exits
+/// non-zero with its own login prompt. RUST-B6 is the whole class -- four
+/// events whose only content was `Not logged in - Please run /login`, which no
+/// change on our side can resolve. It stays out of Sentry and becomes an
+/// actionable message in the UI instead (see `learn_agent_auth_hint`).
+fn learn_failure_is_agent_auth(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    // Each needle is a full CLI phrase, not a bare word: "login" alone would
+    // also match a project's own source lines echoed back in the output.
+    const NEEDLES: &[&str] = &[
+        "not logged in",
+        "please run /login",
+        "run /login",
+        "please log in",
+        "not authenticated",
+        "authentication_error",
+        "invalid api key",
+        "oauth token has expired",
+        "credentials have expired",
+        "session has expired",
+        "please run `codex login`",
+        "run `codex login`",
+        "no credentials found",
+    ];
+    NEEDLES.iter().any(|needle| lower.contains(needle))
+}
+
+/// The user-facing remedy for [`learn_failure_is_agent_auth`], naming the CLI
+/// the run actually shelled out to.
+fn learn_agent_auth_hint(agent: LearnAgent) -> String {
+    let (cli, command) = match agent {
+        LearnAgent::Claude => ("Claude Code", "claude"),
+        LearnAgent::Codex => ("Codex", "codex"),
+        LearnAgent::Opencode => ("opencode", "opencode"),
+        LearnAgent::Grok => ("Grok", "grok"),
+    };
+    format!(
+        "{cli} is not signed in on this machine, so headroom learn could not run its analysis. \
+         Open a terminal, run `{command}`, sign in, then start the scan again."
+    )
+}
+
+/// The text a learn failure is fingerprinted on.
+///
+/// Upstream's first stderr line is a marker whose reason is EMPTY -- ``LLM
+/// analysis failed: `claude -p ...` failed (exit 1):`` -- because the child
+/// CLI writes its diagnosis to its own stream, which upstream appends on the
+/// FOLLOWING line. Fingerprinting the marker alone collapsed every distinct
+/// cause onto one issue with nothing in it to tell them apart (RUST-74, then
+/// RUST-B6). When the first line ends at that dangling colon, the next
+/// non-empty line is the actual reason, so join it in.
+///
+/// stderr only at the call site: stdout echoes written memory files back
+/// verbatim and must never reach a Sentry title.
+fn learn_failure_signature_source(text: &str) -> String {
+    let mut lines = text.lines().map(str::trim).filter(|l| !l.is_empty());
+    let Some(first) = lines.next() else {
+        return "no output".to_string();
+    };
+    if !first.ends_with(':') {
+        return first.to_string();
+    }
+    match lines.next() {
+        Some(reason) => format!("{first} {reason}"),
+        None => first.to_string(),
+    }
+}
+
 /// Turn a `headroom learn` stdout line into the step shown under the scan timer,
 /// or None to leave the current step alone.
 ///
@@ -6131,50 +6203,69 @@ fn execute_headroom_learn_run(
                     // failure class per user (RUST-A2/RUST-9Z). The unmodified
                     // text stays in `reason` and `stderr_tail` below.
                     let signature = normalize_learn_failure_signature(&raw_signature);
-                    sentry::with_scope(
-                        |scope| {
-                            scope.set_tag("flow", "headroom_learn");
-                            scope.set_tag("learn_outcome", "llm_analysis_failed");
-                            scope.set_tag("learn_agent", agent.as_tag());
-                            scope.set_extra("reason", warnings.clone().into());
-                            scope.set_extra("raw_signature", raw_signature.clone().into());
-                            scope.set_extra("project_name", project_name.to_string().into());
-                            // The marker line ends at its colon: upstream
-                            // appends the child's stderr, and `claude -p
-                            // --output-format stream-json` writes its diagnosis
-                            // to stdout, so `reason` arrives empty and every
-                            // distinct cause -- usage limit, dead local route,
-                            // our own 400 -- collapses onto one fingerprint
-                            // (RUST-74: 14 events over six users' machines with
-                            // nothing in them to tell apart). The analyzer's
-                            // surrounding log lines are the only context left
-                            // on this side of the process boundary.
-                            //
-                            // stderr ONLY. stdout echoes written memory files
-                            // back verbatim (see `learn_step_label`), and that
-                            // is the user's project content -- it must never
-                            // reach Sentry.
-                            scope.set_extra(
-                                "stderr_tail",
-                                crate::state::tail_lines(&stderr, 32).join("\n").into(),
-                            );
-                            scope.set_fingerprint(Some(
-                                ["headroom_learn_llm_failure", signature.as_str()].as_slice(),
-                            ));
-                        },
-                        || {
-                            sentry::capture_message(
-                                &format!("headroom learn produced no recommendations: {signature}"),
-                                sentry::Level::Warning,
-                            );
-                        },
-                    );
+                    // Same user-environment carve-out as the non-zero-exit
+                    // branch below (RUST-B6): when the agent CLI has no signed-in
+                    // session, nothing on our side can change the outcome.
+                    let agent_not_signed_in = learn_failure_is_agent_auth(&stderr);
+                    if !agent_not_signed_in {
+                        sentry::with_scope(
+                            |scope| {
+                                scope.set_tag("flow", "headroom_learn");
+                                scope.set_tag("learn_outcome", "llm_analysis_failed");
+                                scope.set_tag("learn_agent", agent.as_tag());
+                                scope.set_extra("reason", warnings.clone().into());
+                                scope.set_extra("raw_signature", raw_signature.clone().into());
+                                scope.set_extra("project_name", project_name.to_string().into());
+                                // The marker line ends at its colon: upstream
+                                // appends the child's stderr, and `claude -p
+                                // --output-format stream-json` writes its diagnosis
+                                // to stdout, so `reason` arrives empty and every
+                                // distinct cause -- usage limit, dead local route,
+                                // our own 400 -- collapses onto one fingerprint
+                                // (RUST-74: 14 events over six users' machines with
+                                // nothing in them to tell apart). The analyzer's
+                                // surrounding log lines are the only context left
+                                // on this side of the process boundary.
+                                //
+                                // stderr ONLY. stdout echoes written memory files
+                                // back verbatim (see `learn_step_label`), and that
+                                // is the user's project content -- it must never
+                                // reach Sentry.
+                                scope.set_extra(
+                                    "stderr_tail",
+                                    crate::state::tail_lines(&stderr, 32).join("\n").into(),
+                                );
+                                scope.set_fingerprint(Some(
+                                    ["headroom_learn_llm_failure", signature.as_str()].as_slice(),
+                                ));
+                            },
+                            || {
+                                sentry::capture_message(
+                                    &format!(
+                                        "headroom learn produced no recommendations: {signature}"
+                                    ),
+                                    sentry::Level::Warning,
+                                );
+                            },
+                        );
+                    }
+                    let (summary, detail) = if agent_not_signed_in {
+                        (
+                            format!("headroom learn needs a signed-in agent for {project_name}."),
+                            learn_agent_auth_hint(agent),
+                        )
+                    } else {
+                        (
+                            format!(
+                                "headroom learn could not produce recommendations for {project_name}."
+                            ),
+                            warnings,
+                        )
+                    };
                     (
-                        format!(
-                            "headroom learn could not produce recommendations for {project_name}."
-                        ),
+                        summary,
                         false,
-                        Some(warnings),
+                        Some(detail),
                         output_tail,
                         stdout,
                         stderr,
@@ -6226,12 +6317,24 @@ fn execute_headroom_learn_run(
                 // command-shaped reason, the resolved CLI path in it would
                 // split one failure class per machine. A no-op on any line that
                 // is not command-shaped.
-                let signature: String = normalize_learn_failure_signature(
+                // The marker line's reason sits on the NEXT line, so join it in
+                // when the first line ends at its dangling colon -- but only
+                // for stderr. `signature_source` falls back to stdout when
+                // stderr is empty, and stdout echoes written memory files back
+                // verbatim (see `learn_step_label`): that is the user's project
+                // content and must never reach a Sentry title.
+                let signature_head = if stderr.trim().is_empty() {
                     signature_source
                         .lines()
                         .map(str::trim)
                         .find(|l| !l.is_empty())
                         .unwrap_or("no output")
+                        .to_string()
+                } else {
+                    learn_failure_signature_source(signature_source)
+                };
+                let signature: String = normalize_learn_failure_signature(
+                    signature_head
                         .chars()
                         .take(160)
                         .collect::<String>()
@@ -6251,7 +6354,14 @@ fn execute_headroom_learn_run(
                 // unreadable between the pre-flight read_dir check and the CLI
                 // run. Click reports that as exit 2 with "is not readable" — a
                 // user-environment condition, not an app bug, so don't report it.
-                let user_env_condition = signature.contains("is not readable");
+                //
+                // The agent CLI having no signed-in session is the same class
+                // (RUST-B6). Matched against the whole stderr rather than the
+                // signature: upstream's marker line ends before the child's
+                // login prompt, which can land several lines further down.
+                let agent_not_signed_in = learn_failure_is_agent_auth(&stderr);
+                let user_env_condition =
+                    signature.contains("is not readable") || agent_not_signed_in;
                 if !user_env_condition {
                     sentry::with_scope(
                         |scope| {
@@ -6277,13 +6387,25 @@ fn execute_headroom_learn_run(
                         },
                     );
                 }
-                (
-                    format!("headroom learn failed for {project_name}."),
-                    false,
-                    Some(format!(
+                // A missing agent session has a remedy the user can act on;
+                // the raw exit status and output tail do not name it.
+                let user_error = if agent_not_signed_in {
+                    learn_agent_auth_hint(agent)
+                } else {
+                    format!(
                         "headroom learn exited with {}.\n{}",
                         output.status, fail_tail
-                    )),
+                    )
+                };
+                let user_summary = if agent_not_signed_in {
+                    format!("headroom learn needs a signed-in agent for {project_name}.")
+                } else {
+                    format!("headroom learn failed for {project_name}.")
+                };
+                (
+                    user_summary,
+                    false,
+                    Some(user_error),
                     output_tail,
                     stdout,
                     stderr,
@@ -7785,6 +7907,7 @@ mod tests {
         fake_override, fetch_transformations_feed_from, first_savings_body, format_token_count,
         install_pending_update, is_disk_full_signal, is_endpoint_protection_signal,
         is_network_download_signal, is_port_conflict_failure, is_prerelease_version,
+        learn_agent_auth_hint, learn_failure_is_agent_auth, learn_failure_signature_source,
         learn_step_label, lifetime_token_milestone_kind, noop_app_update_progress_emitter,
         normalize_learn_failure_signature, onboarding_recovery_copy, parse_live_learnings,
         parse_magic_link_auth, parse_request_count_from_stats_body, parse_request_counts_by_agent,
@@ -10340,6 +10463,67 @@ Some unrelated content.
             !block.contains("&stdout") && !block.contains("&merged"),
             "stdout carries memory-file contents and must never reach Sentry: {block}"
         );
+    }
+
+    #[test]
+    fn learn_failure_is_agent_auth_matches_the_cli_login_prompts() {
+        // RUST-B6 verbatim: four events whose only content was the child CLI
+        // saying nobody is signed in.
+        let stderr = "LLM analysis failed: `claude -p --output-format stream-json --verbose` failed (exit 1):\nNot logged in \u{b7} Please run /login\n";
+        assert!(learn_failure_is_agent_auth(stderr));
+        assert!(learn_failure_is_agent_auth(
+            "Error: not authenticated. Please run `codex login`."
+        ));
+        assert!(learn_failure_is_agent_auth(
+            "AuthenticationError: invalid API key"
+        ));
+        assert!(learn_failure_is_agent_auth("Your OAuth token has expired."));
+    }
+
+    #[test]
+    fn learn_failure_is_agent_auth_does_not_swallow_real_failures() {
+        // These must keep reporting: they are ours to fix.
+        for stderr in [
+            "LLM analysis failed: `claude -p` did not respond within 120s.",
+            "ModuleNotFoundError: No module named 'headroom.learn'",
+            "Error: rate limit exceeded, try again later",
+            "usage limit reached for this session",
+            "",
+        ] {
+            assert!(!learn_failure_is_agent_auth(stderr), "for: {stderr}");
+        }
+    }
+
+    #[test]
+    fn learn_failure_signature_source_joins_the_dangling_marker_line() {
+        // Upstream's marker ends at a colon and appends the child's real
+        // diagnosis on the next line. Fingerprinting the marker alone put every
+        // distinct cause on one issue (RUST-74, then RUST-B6).
+        let stderr = "LLM analysis failed: `claude -p --output-format stream-json --verbose` failed (exit 1):\nNot logged in \u{b7} Please run /login\n";
+        let signature = learn_failure_signature_source(stderr);
+        assert!(signature.contains("Not logged in"), "got: {signature}");
+
+        // Two different causes behind the same marker must not collapse.
+        let other = "LLM analysis failed: `claude -p --output-format stream-json --verbose` failed (exit 1):\nCredit balance is too low\n";
+        assert_ne!(signature, learn_failure_signature_source(other));
+    }
+
+    #[test]
+    fn learn_failure_signature_source_leaves_a_self_contained_line_alone() {
+        let stderr = "ModuleNotFoundError: No module named 'headroom'\nTraceback follows\n";
+        assert_eq!(
+            learn_failure_signature_source(stderr),
+            "ModuleNotFoundError: No module named 'headroom'"
+        );
+        assert_eq!(learn_failure_signature_source("   \n\n"), "no output");
+    }
+
+    #[test]
+    fn learn_agent_auth_hint_names_the_cli_the_run_shelled_out_to() {
+        let hint = learn_agent_auth_hint(LearnAgent::Claude);
+        assert!(hint.contains("Claude Code"), "got: {hint}");
+        assert!(hint.contains("`claude`"), "got: {hint}");
+        assert!(learn_agent_auth_hint(LearnAgent::Codex).contains("`codex`"));
     }
 
     #[test]

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -232,6 +232,15 @@ fn skip_sentry(target: &str, msg: &str) -> bool {
     {
         return true;
     }
+    // The direct-wheel fallback warn embeds the full PyPI URL, so message
+    // grouping opened a fresh issue per wheel version and per platform tag for
+    // one condition (RUST-22). `report_wheel_download_fallback` captures it
+    // fingerprinted on the cause class instead; this line stays local.
+    if target.starts_with("headroom_desktop_lib::tool_manager")
+        && msg.starts_with("headroom wheel download failed")
+    {
+        return true;
+    }
     // Boot-validation failure reaches Sentry via the fully-tagged Level::Error
     // capture at the same emit site (capture_runtime_upgrade_failure, RUST-4A:
     // versions, boot diagnostics, pip tail); this bridged warn double-reports
@@ -1034,6 +1043,22 @@ mod tests {
         assert!(!skip_sentry(
             "headroom_desktop_lib::state",
             "some other state warning"
+        ));
+    }
+
+    #[test]
+    fn skips_wheel_download_fallback_warn() {
+        // RUST-22: the full PyPI URL was the message, so every wheel bump and
+        // every platform tag opened a new issue for one condition.
+        assert!(skip_sentry(
+            "headroom_desktop_lib::tool_manager",
+            "headroom wheel download failed (will fall back to pip index): downloading https://files.pythonhosted.org/packages/47/21/headroom_ai-0.37.0-cp310-abi3-macosx_11_0_arm64.whl"
+        ));
+        // The checksum-mismatch path is a hard failure, not this warn, and
+        // must keep its own reporting.
+        assert!(!skip_sentry(
+            "headroom_desktop_lib::tool_manager",
+            "Headroom wheel failed checksum verification; refusing unverified fallback"
         ));
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -559,6 +559,12 @@ pub struct AppState {
     activity_facts: Mutex<ActivityFacts>,
     cached_clients: Mutex<Option<(Vec<ClientStatus>, Instant)>>,
     cached_headroom_stats: Mutex<Option<(Option<HeadroomDashboardStats>, Instant)>>,
+    /// Last `/stats` payload that actually arrived, with the time it did.
+    /// Kept apart from `cached_headroom_stats` so the miss backoff and the
+    /// retention window measure different things: that cache stamps the last
+    /// FETCH (and must expire fast on success, slowly on failure), this one
+    /// stamps the last real ANSWER.
+    last_good_headroom_stats: Mutex<Option<(HeadroomDashboardStats, Instant)>>,
     /// `(history, fetched_at, fresh)` — `fresh` is false when `history` is a
     /// retained last-good value served because the latest fetch failed (proxy
     /// paused/unreachable), so it re-probes on the short miss TTL.
@@ -718,6 +724,7 @@ impl AppState {
             activity_facts: Mutex::new(activity_facts),
             cached_clients: Mutex::new(None),
             cached_headroom_stats: Mutex::new(None),
+            last_good_headroom_stats: Mutex::new(None),
             cached_headroom_history: Mutex::new(None),
             cached_rtk_gain_summary: Mutex::new(None),
             cached_rtk_today_stats: Mutex::new(None),
@@ -2134,15 +2141,59 @@ impl AppState {
         persist_last_known_good_plan(&self.last_known_good_plan_path, &entry);
     }
 
+    /// How long a last-good `/stats` payload may stand in for a failed fetch.
+    ///
+    /// The layers only `/stats` reports (output shaping, tool schema) describe
+    /// configuration, which does not move between polls, so serving the
+    /// previous answer through a transient timeout is honest -- and blanking
+    /// them is the entire harm the warning names ("dashboard loses the
+    /// layers"). Bounded so a backend that is starved for good eventually
+    /// shows absent layers rather than an ever-staler snapshot presented as
+    /// live.
+    const HEADROOM_STATS_RETAIN_LAST_GOOD: Duration = Duration::from_secs(10 * 60);
+
     fn cached_headroom_stats(&self) -> Option<HeadroomDashboardStats> {
+        match self.polled_headroom_stats() {
+            Some(stats) => {
+                *self.last_good_headroom_stats.lock() = Some((stats.clone(), Instant::now()));
+                Some(stats)
+            }
+            // Retain the previous good payload rather than blanking the
+            // dashboard on one timeout. The stamp is the age of the DATA, not
+            // of the failed fetch, so the window counts from the last real
+            // answer and repeated failures cannot extend it.
+            None => self
+                .last_good_headroom_stats
+                .lock()
+                .as_ref()
+                .filter(|(_, at)| at.elapsed() < Self::HEADROOM_STATS_RETAIN_LAST_GOOD)
+                .map(|(stats, _)| stats.clone()),
+        }
+    }
+
+    /// The raw poll behind [`Self::cached_headroom_stats`]: cache lookup, then
+    /// a live fetch on miss. Returns `None` for "this poll had no answer",
+    /// which the caller may still cover with a retained payload.
+    fn polled_headroom_stats(&self) -> Option<HeadroomDashboardStats> {
         // Dashboard polls at 5s; a 4s TTL caused every poll to miss and
         // re-fetch from the proxy. 12s gives at least one cache hit between
         // dashboard refreshes while keeping session savings visibly fresh.
         const TTL: Duration = Duration::from_secs(12);
+        // A failure is held far longer than a success, which is the opposite of
+        // `cached_headroom_history` and deliberate: the dominant failure here
+        // is a `/stats` rebuild that outruns its 15s timeout on a backend busy
+        // serving a session. Re-probing that every 12s keeps a 15s blocking
+        // request in flight essentially all the time, so the poll itself
+        // becomes part of the starvation it is reporting -- RUST-86 shipped
+        // 1601 events that way. At 60s the probe still recovers within a few
+        // seconds of the backend freeing up, at a fifth of the load, and the
+        // retained payload above covers the gap.
+        const MISS_TTL: Duration = Duration::from_secs(60);
         {
             let cache = self.cached_headroom_stats.lock();
             if let Some((stats, at)) = cache.as_ref() {
-                if at.elapsed() < TTL {
+                let ttl = if stats.is_some() { TTL } else { MISS_TTL };
+                if at.elapsed() < ttl {
                     return stats.clone();
                 }
             }
@@ -10975,6 +11026,50 @@ mod tests {
 
         *STATS_FETCH_WARNED_AT.lock() = None;
         *STATS_FETCH_RECOVERED_AT.lock() = None;
+    }
+
+    #[test]
+    fn stats_miss_serves_the_last_good_payload_and_stops_hammering_the_backend() {
+        // RUST-86: a /stats rebuild that outruns its 15s timeout used to blank
+        // the dashboard layers AND get re-probed every 12s, so a 15s blocking
+        // request was in flight nearly all the time against the very backend
+        // that was already starved.
+        let state = AppState::new().expect("state");
+        let good = HeadroomDashboardStats {
+            tool_schema_tokens_saved: Some(4_242),
+            ..HeadroomDashboardStats::default()
+        };
+        *state.last_good_headroom_stats.lock() = Some((good.clone(), Instant::now()));
+        // A failed poll, cached as a miss.
+        *state.cached_headroom_stats.lock() = Some((None, Instant::now()));
+
+        let served = state
+            .cached_headroom_stats()
+            .expect("the retained payload covers a transient failure");
+        assert_eq!(served.tool_schema_tokens_saved, Some(4_242));
+
+        // The miss is still cached: no fetch was attempted, so the 15s probe
+        // is not re-armed on the next dashboard poll.
+        let (cached, _) = (*state.cached_headroom_stats.lock())
+            .clone()
+            .expect("miss stays cached");
+        assert!(
+            cached.is_none(),
+            "serving a retained payload must not \
+             overwrite the miss and reset the backoff"
+        );
+
+        // Past the retention window the layers go absent rather than being
+        // presented as live forever.
+        let stale = Instant::now()
+            .checked_sub(AppState::HEADROOM_STATS_RETAIN_LAST_GOOD + Duration::from_secs(1));
+        if let Some(stale) = stale {
+            *state.last_good_headroom_stats.lock() = Some((good, stale));
+            assert!(
+                state.cached_headroom_stats().is_none(),
+                "a retained payload must expire"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -3727,6 +3727,7 @@ impl ToolManager {
     {
         let requirements_lock = bootstrap_requirements_lock();
         let lock_path = self.write_headroom_requirements_lock(requirements_lock)?;
+        let dep_total = requirements_lock_package_count(requirements_lock);
 
         progress(BootstrapStepUpdate {
             step: "Repairing dependencies",
@@ -3759,9 +3760,14 @@ impl ToolManager {
             ],
             &self.runtime.root_dir,
             |line| {
-                if let Some(update) =
-                    pip_line_to_progress(line, deps_start.elapsed(), &mut dep_counter, 40, 82)
-                {
+                if let Some(update) = pip_line_to_progress(
+                    line,
+                    deps_start.elapsed(),
+                    &mut dep_counter,
+                    40,
+                    82,
+                    dep_total,
+                ) {
                     if let Ok(mut cb) = progress_ref.try_borrow_mut() {
                         (cb)(BootstrapStepUpdate {
                             step: "Repairing dependencies",
@@ -4271,6 +4277,7 @@ impl ToolManager {
     {
         let requirements_lock = bootstrap_requirements_lock();
         let lock_path = self.write_headroom_requirements_lock(requirements_lock)?;
+        let dep_total = requirements_lock_package_count(requirements_lock);
         let wheel_path = self.wheel_download_path(&release.wheel_url);
 
         progress(BootstrapStepUpdate {
@@ -4293,9 +4300,7 @@ impl ToolManager {
                     ));
                 }
                 Err(download_err) => {
-                    log::warn!(
-                    "headroom wheel download failed (will fall back to pip index): {download_err}"
-                );
+                    report_wheel_download_fallback(&release.wheel_url, &download_err);
                     false
                 }
             };
@@ -4340,9 +4345,14 @@ impl ToolManager {
                 if let Some(cap) = pip_capture {
                     cap.borrow_mut().push(line);
                 }
-                if let Some(update) =
-                    pip_line_to_progress(line, deps_start.elapsed(), &mut dep_counter, 55, 80)
-                {
+                if let Some(update) = pip_line_to_progress(
+                    line,
+                    deps_start.elapsed(),
+                    &mut dep_counter,
+                    55,
+                    80,
+                    dep_total,
+                ) {
                     if let Ok(mut cb) = deps_progress_ref.try_borrow_mut() {
                         (cb)(update);
                     }
@@ -5239,6 +5249,7 @@ impl ToolManager {
             });
 
             let requirements_lock = bootstrap_requirements_lock();
+            let dep_total = requirements_lock_package_count(requirements_lock);
             let lock_path = match self.write_headroom_requirements_lock(requirements_lock) {
                 Ok(p) => p,
                 Err(err) => {
@@ -5275,9 +5286,14 @@ impl ToolManager {
                 &self.runtime.root_dir,
                 |line| {
                     pip_capture.borrow_mut().push(line);
-                    if let Some(update) =
-                        pip_line_to_progress(line, deps_start.elapsed(), &mut dep_counter, 15, 55)
-                    {
+                    if let Some(update) = pip_line_to_progress(
+                        line,
+                        deps_start.elapsed(),
+                        &mut dep_counter,
+                        15,
+                        55,
+                        dep_total,
+                    ) {
                         if let Ok(mut cb) = deps_progress_ref.try_borrow_mut() {
                             (cb)(update);
                         }
@@ -5318,9 +5334,7 @@ impl ToolManager {
                 };
                 }
                 Err(download_err) => {
-                    log::warn!(
-                    "headroom wheel download failed (will fall back to pip index): {download_err}"
-                );
+                    report_wheel_download_fallback(&release.wheel_url, &download_err);
                     false
                 }
             };
@@ -9917,49 +9931,119 @@ fn run_pip_install_with_retries(python: &Path, args: &[&str], cwd: &Path) -> Res
     run_pip_install_with_retries_streaming(python, args, cwd, |_| {})
 }
 
+/// Number of requirement lines in a lock, i.e. how many packages pip will
+/// resolve. `requirements_lock_sha` already defines what counts as a
+/// requirement line (non-blank, non-comment); this is the same rule, so the
+/// two can never disagree about the file's contents.
+fn requirements_lock_package_count(lock: &str) -> u32 {
+    lock.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .count()
+        .try_into()
+        .unwrap_or(u32::MAX)
+}
+
 /// Translate a pip stdout/stderr line into a progress update, or None for
-/// noise. Counter-based monotonic advance inside `[base_percent, max_percent-1]`:
-/// we don't know the final dep count up-front, so each interesting line nudges
-/// the bar forward and it saturates just below the parent step's ceiling.
+/// noise. Monotonic advance inside `[base_percent, max_percent-1]`.
+///
+/// `total_packages` is the requirement count from the lock we handed pip, so
+/// the bar and the ETA track real progress. Pass 0 when it isn't known and the
+/// old counter heuristic applies: each interesting line nudges the bar forward
+/// and it saturates just below the parent step's ceiling.
+///
+/// Both numbers used to be fictional, and on a slow link that read as a hang.
+/// `remaining` was `90 - elapsed`, floored at 5, so past 90 seconds the UI said
+/// "5 seconds left" forever; the percent saturated at `max_percent - 1` after
+/// `span` lines, which ~170 packages cross in the first minute. The Windows
+/// host in RUST-9Y was pulling torch and opencv at ~60 kB/s -- hours of install
+/// behind a bar frozen at 79% claiming it was finishing up -- and quit. The
+/// funnel calls that `bootstrap_abandoned`; the user was told the wrong thing.
 fn pip_line_to_progress(
     line: &str,
     elapsed: Duration,
     counter: &mut u32,
     base_percent: u8,
     max_percent: u8,
+    total_packages: u32,
 ) -> Option<BootstrapStepUpdate> {
     let trimmed = line.trim();
     if trimmed.is_empty() {
         return None;
     }
 
-    let message = if let Some(rest) = trimmed.strip_prefix("Collecting ") {
+    // `resolved` marks the lines that mean every package has been fetched, so
+    // the fraction can jump to 1.0 instead of extrapolating a download rate
+    // through a phase that no longer downloads anything.
+    let (message, collected, resolved) = if let Some(rest) = trimmed.strip_prefix("Collecting ") {
         let spec = rest.split_whitespace().next().unwrap_or(rest);
         let pkg = spec
             .split(|c: char| matches!(c, '=' | '<' | '>' | '!' | '~' | ';' | '['))
             .next()
             .unwrap_or(spec);
-        format!("Fetching {}...", pkg)
+        (format!("Fetching {}...", pkg), true, false)
     } else if let Some(rest) = trimmed.strip_prefix("Downloading ") {
         let file = rest.split_whitespace().next().unwrap_or(rest);
         let name = file.rsplit('/').next().unwrap_or(file);
         let pkg = name.split('-').next().unwrap_or(name);
-        format!("Downloading {}...", pkg)
+        (format!("Downloading {}...", pkg), false, false)
     } else if trimmed.starts_with("Installing collected packages") {
-        "Installing packages...".to_string()
+        ("Installing packages...".to_string(), false, true)
     } else if let Some(rest) = trimmed.strip_prefix("Successfully installed ") {
         let count = rest.split_whitespace().count();
-        format!("Installed {} packages.", count)
+        (format!("Installed {} packages.", count), false, true)
     } else {
         return None;
     };
 
-    *counter = counter.saturating_add(1);
+    // Counts packages, not lines: pip prints a `Collecting` and a `Downloading`
+    // for each one, and counting both made the bar move at twice the true rate.
+    if collected {
+        *counter = counter.saturating_add(1);
+    }
     let span = max_percent.saturating_sub(base_percent).max(1) as u32;
-    let advance = (*counter).min(span.saturating_sub(1));
+
+    // Fraction of the dependency set pip has reached. Transitive deps that are
+    // not in our lock (pip resolves those too) can push the count past the
+    // total, hence the clamp.
+    let fraction = if resolved {
+        1.0
+    } else if total_packages > 0 {
+        (f64::from(*counter) / f64::from(total_packages)).clamp(0.0, 1.0)
+    } else {
+        // Unknown total: the old counter heuristic, which saturates just below
+        // the ceiling once enough packages have gone by.
+        f64::from((*counter).min(span.saturating_sub(1))) / f64::from(span.max(1))
+    };
+
+    let advance = (f64::from(span) * fraction) as u32;
     let percent = (base_percent as u32 + advance).min(max_percent as u32 - 1) as u8;
 
-    let remaining = 90_u64.saturating_sub(elapsed.as_secs()).max(5);
+    // Extrapolate from the rate this machine is actually achieving. A host on a
+    // 60 kB/s link gets an ETA in the hours, which is the truth and reads as
+    // "slow", where the old fixed 90-second budget read as "hung". Needs a real
+    // sample first: the first few packages land before any large wheel and
+    // would project absurdly low.
+    const INITIAL_ETA_SECS: u64 = 90;
+    const MIN_SAMPLE_SECS: u64 = 10;
+    const MIN_SAMPLE_FRACTION: f64 = 0.02;
+    // A whole day, so a genuinely stalled transfer still produces a finite
+    // number rather than saturating into nonsense.
+    const MAX_ETA_SECS: u64 = 24 * 3600;
+    let elapsed_secs = elapsed.as_secs();
+    let remaining = if resolved {
+        // Unpack and install of what is already on disk. Short and roughly
+        // machine-independent next to the download it follows.
+        15
+    } else if elapsed_secs >= MIN_SAMPLE_SECS && fraction >= MIN_SAMPLE_FRACTION {
+        let projected_total = elapsed.as_secs_f64() / fraction;
+        (projected_total - elapsed.as_secs_f64()).clamp(5.0, MAX_ETA_SECS as f64) as u64
+    } else {
+        // Too early to measure. Never floor at a near-zero value the way the
+        // old `.max(5)` did once the budget ran out -- that is what turned a
+        // slow install into an apparently finished one.
+        INITIAL_ETA_SECS.saturating_sub(elapsed_secs).max(30)
+    };
     Some(BootstrapStepUpdate {
         step: "Updating dependencies",
         message,
@@ -10160,6 +10244,102 @@ pub(crate) fn pip_failure_category_with_evidence(compact: &str, evidence: &str) 
     } else {
         "other"
     }
+}
+
+/// Cause class for a direct-wheel download that fell back to the pip index.
+///
+/// The failure's top context is `downloading <url>`, and that URL carries the
+/// wheel version, the platform tag and PyPI's content hash -- so a
+/// message-grouped report opens a NEW issue on every wheel bump and a separate
+/// one per platform for one underlying condition (RUST-22, reopened at 0.37.0
+/// after the same fallback was already triaged at earlier pins). The cause
+/// class is what triage acts on: a proxy blocking files.pythonhosted.org is a
+/// different problem from a 30-minute transfer timeout on a slow link, and
+/// neither changes when the pin does.
+fn wheel_download_failure_category(detail: &str) -> &'static str {
+    let lower = detail.to_ascii_lowercase();
+    if lower.contains("operation timed out") || lower.contains("timed out") {
+        "timeout"
+    } else if let Some(code) = http_status_code_in(&lower) {
+        // A status the CDN actually answered with: 403 is a corporate proxy
+        // or a geo block, 404 a pin whose wheel PyPI never published. Keep
+        // them apart -- only one of the two is ours to fix.
+        match code {
+            403 => "http-403",
+            404 => "http-404",
+            _ => "http-other",
+        }
+    } else if lower.contains("dns error")
+        || lower.contains("failed to lookup address")
+        || lower.contains("nodename nor servname")
+    {
+        "dns"
+    } else if lower.contains("certificate")
+        || lower.contains("tls")
+        || lower.contains("ssl")
+        || lower.contains("self-signed")
+    {
+        // A TLS-terminating corporate proxy without its CA in our trust store.
+        "tls"
+    } else if lower.contains("connection refused")
+        || lower.contains("connection reset")
+        || lower.contains("connection closed")
+        || lower.contains("error sending request")
+        || lower.contains("channel closed")
+    {
+        "connection"
+    } else if crate::is_disk_full_signal(&lower) {
+        "disk-full"
+    } else if lower.contains("permission denied") || lower.contains("access is denied") {
+        "permission"
+    } else {
+        "other"
+    }
+}
+
+/// First HTTP status code in a reqwest `error_for_status` message, which
+/// renders as `HTTP status client error (403 Forbidden) for url (...)`.
+fn http_status_code_in(lower: &str) -> Option<u16> {
+    let idx = lower.find("http status")?;
+    lower[idx..]
+        .split(|c: char| !c.is_ascii_digit())
+        .find(|tok| tok.len() == 3)
+        .and_then(|tok| tok.parse::<u16>().ok())
+}
+
+/// Report a direct-wheel download that fell back to the pip index.
+///
+/// Warning, not Error: the fallback install that follows normally succeeds, so
+/// this is a degraded path rather than a broken one. It still reports, because
+/// a category that shows up fleet-wide (a blocked CDN, an expired cert) is the
+/// early signal that the *next* release's bootstrap will fail outright.
+fn report_wheel_download_fallback(url: &str, err: &anyhow::Error) {
+    let detail = format!("{err:#}");
+    let category = wheel_download_failure_category(&detail);
+    sentry::with_scope(
+        |scope| {
+            scope.set_tag("wheel_download_failure", category);
+            scope.set_extra("wheel_url", url.to_string().into());
+            scope.set_extra(
+                "detail",
+                detail.chars().take(2000).collect::<String>().into(),
+            );
+            scope.set_fingerprint(Some(["wheel-download-fallback", category].as_slice()));
+        },
+        || {
+            sentry::capture_message(
+                &format!(
+                    "headroom wheel download failed ({category}); falling back to the pip index"
+                ),
+                sentry::Level::Warning,
+            );
+        },
+    );
+    // Local only: the fingerprinted capture above is the Sentry path, and the
+    // bridged warn would re-open the URL-grouped issue this replaced. The full
+    // URL and error chain stay in the file log, where triage can still read
+    // them per-machine.
+    log::warn!("headroom wheel download failed (will fall back to pip index): {detail}");
 }
 
 /// Cause class for a partial plugin install, so each shape gets its own Sentry
@@ -10675,18 +10855,18 @@ mod tests {
         looks_like_corrupt_venv_error, parse_lsof_listener, parse_major_minor_patch,
         parse_netstat_listener, parse_pid_from_lsof_detail, parse_ss_listener,
         parse_tasklist_image, path_with_binary_dir, pending_addon_update, pinned_headroom_release,
-        pip_failure_category, plugin_install_failure_category, pre_upstream_concurrency,
-        probe_backend_readyz_ok, proxy_argv_contains_expected_flags,
+        pip_failure_category, pip_line_to_progress, plugin_install_failure_category,
+        pre_upstream_concurrency, probe_backend_readyz_ok, proxy_argv_contains_expected_flags,
         purge_legacy_output_savings_control_arm_once, read_headroom_learn_metadata_from_path,
         receipt_requires_atomic_rebuild, reclaim_orphan_proxy, redact_sensitive,
-        requirements_lock_sha, rtk_distribution_artifact, run_command, sanitize_log_variant,
-        savings_profile_for_runtime, settle_unowned_port, sha256_bytes,
-        summarize_kompress_prefetch_failure, upstream_spawn_env, verify_sha256_file,
-        wait_for_port_free, CommandFailure, HeadroomRelease, ManagedRuntime, PipOutputCapture,
-        PortState, ToolManager, UpgradeOutcome, ATOMIC_REBUILD_FLOOR_VERSION,
-        HEADROOM_LINUX_REQUIREMENTS_LOCK, HEADROOM_PINNED_VERSION, HEADROOM_REQUIREMENTS_LOCK,
-        HEADROOM_WINDOWS_REQUIREMENTS_LOCK, MARKITDOWN_PINNED_VERSION, PLUGIN_ADDONS,
-        PLUGIN_DISPLAY_VERSION, RTK_VERSION, UNKNOWN_OCCUPANT,
+        requirements_lock_package_count, requirements_lock_sha, rtk_distribution_artifact,
+        run_command, sanitize_log_variant, savings_profile_for_runtime, settle_unowned_port,
+        sha256_bytes, summarize_kompress_prefetch_failure, upstream_spawn_env, verify_sha256_file,
+        wait_for_port_free, wheel_download_failure_category, CommandFailure, HeadroomRelease,
+        ManagedRuntime, PipOutputCapture, PortState, ToolManager, UpgradeOutcome,
+        ATOMIC_REBUILD_FLOOR_VERSION, HEADROOM_LINUX_REQUIREMENTS_LOCK, HEADROOM_PINNED_VERSION,
+        HEADROOM_REQUIREMENTS_LOCK, HEADROOM_WINDOWS_REQUIREMENTS_LOCK, MARKITDOWN_PINNED_VERSION,
+        PLUGIN_ADDONS, PLUGIN_DISPLAY_VERSION, RTK_VERSION, UNKNOWN_OCCUPANT,
     };
     use super::{is_python_interpreter, log_tail, path_without_dirs};
     use crate::backend_port;
@@ -11484,6 +11664,158 @@ mod tests {
             .context("configuring Headroom MCP integration")
             .unwrap_err();
         assert!(looks_like_corrupt_venv_error(&wrapped));
+    }
+
+    #[test]
+    fn requirements_lock_package_count_counts_only_requirement_lines() {
+        let lock =
+            "# header\n\nabsl-py==2.4.0\n# inline note\naiohttp==3.13.5\n  \ntorch==2.12.1\n";
+        assert_eq!(requirements_lock_package_count(lock), 3);
+        // Same rule as requirements_lock_sha, so the two never disagree about
+        // what a requirement line is.
+        assert_eq!(requirements_lock_package_count(""), 0);
+        assert_eq!(requirements_lock_package_count("# only comments\n\n"), 0);
+        // The shipped locks must produce a usable total; a zero here silently
+        // reverts pip progress to the old counter heuristic.
+        for lock in [
+            HEADROOM_REQUIREMENTS_LOCK,
+            HEADROOM_LINUX_REQUIREMENTS_LOCK,
+            HEADROOM_WINDOWS_REQUIREMENTS_LOCK,
+        ] {
+            assert!(requirements_lock_package_count(lock) > 10);
+        }
+    }
+
+    #[test]
+    fn pip_progress_eta_tracks_a_slow_link_instead_of_claiming_five_seconds() {
+        // RUST-9Y: 168 packages over a ~60 kB/s link. Ten minutes in, a tenth
+        // of the way through, the old code said "5 seconds" and pinned the bar
+        // just under the ceiling. Both numbers now follow the real rate.
+        let mut counter = 0u32;
+        let total = 168;
+        let mut last = None;
+        for _ in 0..17 {
+            last = pip_line_to_progress(
+                "Collecting torch==2.12.1",
+                Duration::from_secs(600),
+                &mut counter,
+                55,
+                80,
+                total,
+            );
+        }
+        let update = last.expect("Collecting is a progress line");
+        // ~10% done in 600s projects ~90 minutes remaining, not 5 seconds.
+        assert!(
+            update.eta_seconds > 3000 && update.eta_seconds < 7200,
+            "eta was {}",
+            update.eta_seconds
+        );
+        // And the bar reflects the tenth actually done, not the ceiling.
+        assert!(
+            (56..=60).contains(&update.percent),
+            "percent was {}",
+            update.percent
+        );
+    }
+
+    #[test]
+    fn pip_progress_never_reports_a_near_zero_eta_before_it_can_measure() {
+        // The old floor was `.max(5)`, which is what made an install that had
+        // outrun its 90s budget look finished.
+        let mut counter = 0u32;
+        let update = pip_line_to_progress(
+            "Collecting absl-py==2.4.0",
+            Duration::from_secs(300),
+            &mut counter,
+            55,
+            80,
+            0,
+        )
+        .expect("Collecting is a progress line");
+        assert!(update.eta_seconds >= 30, "eta was {}", update.eta_seconds);
+    }
+
+    #[test]
+    fn pip_progress_counts_packages_not_lines() {
+        // pip prints Collecting AND Downloading per package; counting both
+        // advanced the bar at twice the true rate.
+        let mut counter = 0u32;
+        let elapsed = Duration::from_secs(60);
+        pip_line_to_progress(
+            "Collecting torch==2.12.1",
+            elapsed,
+            &mut counter,
+            55,
+            80,
+            100,
+        );
+        pip_line_to_progress(
+            "Downloading torch-2.12.1-cp312-cp312-win_amd64.whl (31 kB)",
+            elapsed,
+            &mut counter,
+            55,
+            80,
+            100,
+        );
+        assert_eq!(counter, 1);
+    }
+
+    #[test]
+    fn pip_progress_resolves_to_the_ceiling_once_downloads_are_done() {
+        let mut counter = 0u32;
+        let update = pip_line_to_progress(
+            "Installing collected packages: absl-py, aiohttp",
+            Duration::from_secs(4000),
+            &mut counter,
+            55,
+            80,
+            168,
+        )
+        .expect("Installing is a progress line");
+        assert_eq!(update.percent, 79);
+        // No more downloading, so the download rate must not be extrapolated
+        // into a multi-hour estimate for an unpack.
+        assert!(update.eta_seconds <= 60, "eta was {}", update.eta_seconds);
+    }
+
+    #[test]
+    fn wheel_download_failure_category_splits_causes_not_urls() {
+        // RUST-22: one condition, a new Sentry issue per wheel version and
+        // platform, because the URL was the message.
+        let cases = [
+            ("downloading https://files.pythonhosted.org/a.whl: operation timed out", "timeout"),
+            (
+                "downloading https://files.pythonhosted.org/a.whl: HTTP status client error (403 Forbidden) for url (https://files.pythonhosted.org/a.whl)",
+                "http-403",
+            ),
+            (
+                "downloading https://files.pythonhosted.org/a.whl: HTTP status client error (404 Not Found) for url (https://files.pythonhosted.org/a.whl)",
+                "http-404",
+            ),
+            ("downloading https://x/a.whl: dns error: failed to lookup address information", "dns"),
+            ("downloading https://x/a.whl: invalid peer certificate: UnknownIssuer", "tls"),
+            ("downloading https://x/a.whl: error sending request", "connection"),
+            ("writing /tmp/a.partial: Permission denied (os error 13)", "permission"),
+            ("downloading https://x/a.whl: something new", "other"),
+        ];
+        for (detail, expected) in cases {
+            assert_eq!(
+                wheel_download_failure_category(detail),
+                expected,
+                "for: {detail}"
+            );
+        }
+        // Two different pins of the same platform wheel must land on one
+        // category -- that is the whole point.
+        assert_eq!(
+            wheel_download_failure_category(
+                "downloading https://files.pythonhosted.org/47/21/headroom_ai-0.37.0-cp310-abi3-macosx_11_0_arm64.whl: operation timed out"
+            ),
+            wheel_download_failure_category(
+                "downloading https://files.pythonhosted.org/99/aa/headroom_ai-0.38.0-cp310-abi3-win_amd64.whl: operation timed out"
+            )
+        );
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1789,6 +1789,12 @@ export default function App() {
   const [stepSignature, setStepSignature] = useState("");
   const [stepStartedAtMs, setStepStartedAtMs] = useState<number | null>(null);
   const [stepEtaSeedSeconds, setStepEtaSeedSeconds] = useState(0);
+  // When the current ETA seed arrived. The backend re-estimates the dependency
+  // install continuously, so its ETA is time-remaining-from-that-update, not a
+  // budget measured from the start of the step -- counting it from
+  // stepStartedAtMs double-charged the elapsed time and pinned a long install
+  // at "finishing up" (RUST-9Y).
+  const [stepEtaSeedAtMs, setStepEtaSeedAtMs] = useState<number | null>(null);
   const [stepBasePercent, setStepBasePercent] = useState(0);
   const [chartResetSignal, setChartResetSignal] = useState(0);
   const [chartMode, setChartMode] = useState<SavingsChartMode>("usd");
@@ -2572,14 +2578,17 @@ export default function App() {
     }
 
     const signature = `${bootstrapProgress.currentStep}|${bootstrapProgress.running}|${bootstrapProgress.complete}|${bootstrapProgress.failed}`;
-    if (signature === stepSignature) {
-      return;
+    if (signature !== stepSignature) {
+      setStepSignature(signature);
+      setStepStartedAtMs(Date.now());
+      setStepBasePercent(bootstrapProgress.overallPercent);
     }
-
-    setStepSignature(signature);
-    setStepStartedAtMs(Date.now());
+    // Re-anchor on every new estimate, step change or not. "Updating
+    // dependencies" is one step for the whole install, so without this the
+    // seed froze at the first frame's 90s and every later, truthful estimate
+    // was discarded -- which is what a slow link saw as a hang.
     setStepEtaSeedSeconds(bootstrapProgress.currentStepEtaSeconds);
-    setStepBasePercent(bootstrapProgress.overallPercent);
+    setStepEtaSeedAtMs(Date.now());
   }, [bootstrapProgress, showInstallProgress, stepSignature]);
 
   // Reaching the final screen IS the end of onboarding, so satisfy the tray's
@@ -3546,7 +3555,12 @@ export default function App() {
       return 0;
     }
 
-    const elapsedSeconds = Math.max(0, (Date.now() - stepStartedAtMs) / 1000);
+    // Measured from the latest estimate, not from the start of the step: the
+    // backend's number is time remaining as of that update (see
+    // stepEtaSeedAtMs). Falling back to the step start keeps the old behaviour
+    // for steps that only ever report one, static ETA.
+    const anchorMs = stepEtaSeedAtMs ?? stepStartedAtMs;
+    const elapsedSeconds = Math.max(0, (Date.now() - anchorMs) / 1000);
     const eta = Math.max(8, stepEtaSeedSeconds || progress.currentStepEtaSeconds || 20);
     const linear = Math.min(0.96, elapsedSeconds / eta);
 
@@ -3580,8 +3594,9 @@ export default function App() {
       return "ETA: unavailable";
     }
 
-    const elapsedSeconds = stepStartedAtMs
-      ? Math.max(0, Math.round((Date.now() - stepStartedAtMs) / 1000))
+    const anchorMs = stepEtaSeedAtMs ?? stepStartedAtMs;
+    const elapsedSeconds = anchorMs
+      ? Math.max(0, Math.round((Date.now() - anchorMs) / 1000))
       : 0;
     const baselineEta = Math.max(stepEtaSeedSeconds, seconds);
     const remainingSeconds = Math.max(0, baselineEta - elapsedSeconds);
@@ -3597,6 +3612,12 @@ export default function App() {
     }
     const mins = Math.floor(remainingSeconds / 60);
     const secs = remainingSeconds % 60;
+    // Past an hour the seconds are noise and the minutes read as a wall of
+    // digits. A slow link legitimately lands here, and "1h 20m" is the number
+    // that stops someone concluding the install is wedged and quitting.
+    if (mins >= 60) {
+      return `ETA: ${Math.floor(mins / 60)}h ${mins % 60}m`;
+    }
     return `ETA: ${mins}m ${secs}s`;
   }
 


### PR DESCRIPTION
Fixes the four unresolved Sentry issues in `extra-headroom/rust`. Each is a distinct root cause, not a noise-suppression pass; three are user-visible bugs.

## RUST-B6 - `headroom learn` reports the agent CLI's login prompt as an app error

4 events. The analyzer shells out to `claude -p`; with no signed-in session that CLI exits 1 with `Not logged in - Please run /login`. Nothing on our side can resolve it, and the user was shown a raw exit status that never named the remedy.

- Treat "the agent CLI has no session" as a user-environment condition, the same carve-out that already exists for `is not readable`. Applied on both the exit-1 branch and the exit-0 `LLM analysis failed` branch.
- Surface an actionable message instead: which CLI to sign in to, and how.
- Join the child's diagnosis line into the fingerprint. Upstream's marker line ends at a dangling colon (`` `claude -p ...` failed (exit 1): ``) with the real reason on the next line, so fingerprinting the marker alone collapsed every distinct cause onto one issue - the problem the RUST-74 comment in this file describes. stderr only; stdout echoes written memory files back verbatim and must never reach a Sentry title.

## RUST-86 - `/stats` fetch timeout (1601 events, the volume leader)

Two compounding faults, both in `cached_headroom_stats`:

- A failed fetch blanked the dashboard layers only `/stats` reports (output shaping, tool schema) - the exact harm the warning text names. Unlike the sibling history cache, there was no last-good retention.
- A miss was cached for the same 12s as a hit, so a backend whose `/stats` rebuild outran its 15s timeout got a fresh 15s blocking request roughly every 12s. The poll became part of the starvation it was reporting.

Now: retain the last good payload for up to 10 minutes (that data is configuration and does not move between polls), and hold a miss for 60s. Recovery still lands within a dashboard refresh cycle, at a fifth of the load. The retention stamp tracks the age of the *data*, so repeated failures cannot extend the window.

## RUST-22 - wheel download fallback opens a new issue per pin

57 events, 4 users. The warn embedded the full PyPI URL - wheel version, platform tag, content hash - and Sentry groups bridged log lines by message text, so one condition opened a fresh issue on every wheel bump and a separate one per platform.

Captured fingerprinted on the cause class instead (`timeout` / `http-403` / `http-404` / `dns` / `tls` / `connection` / `disk-full` / `permission` / `other`), with the URL and error chain in extras. The bridged warn is suppressed and stays in the local file log. Same split pattern already used for the kompress prefetch, `/stats`, and pip-install failures. The checksum-mismatch path is untouched - it still fails hard rather than falling back.

## RUST-9Y - bootstrap abandoned at "Updating dependencies", 79%

Both progress numbers shown during the dependency install were fictional:

- ETA was `90 - elapsed` floored at 5, so past ninety seconds the UI said "5 seconds left" for the rest of the install.
- Percent saturated at `max_percent - 1` after `span` pip lines, which ~170 packages cross inside the first minute.
- The frontend seeded its ETA baseline once per *step*, and the whole dependency install is one step - so every later estimate was discarded, and it counted the backend's remaining-time as a budget measured from step start, double-charging elapsed.

The reporting host (Windows, ~60 kB/s) was pulling torch and opencv - hours of install behind a bar frozen at 79% claiming it was finishing up. It quit. The funnel calls that `bootstrap_abandoned`; the user was told the wrong thing.

- Derive percent from packages actually collected against the lock's requirement count (`Collecting` only - pip prints two lines per package, and counting both moved the bar at twice the true rate).
- Extrapolate the ETA from the rate the machine is achieving, once there is a sample worth measuring. A slow link now gets an honest number in the hours, which reads as "slow" rather than "hung"; ETAs past an hour render as `1h 20m`.
- Jump to the ceiling on `Installing collected packages` rather than extrapolating a download rate through a phase that no longer downloads.
- Re-anchor the frontend ETA baseline on every estimate, and measure elapsed from that anchor.

## Testing

- `cargo test --lib`: 1088 pass. Two `client_adapters` failures are pre-existing on `staging` and environmental - they assert that read-only permissions block deletion, which root in this container bypasses.
- `cargo fmt --check` clean (baseline was clean).
- `npx tsc --noEmit`: no new errors (the one `tsconfig` deprecation warning is pre-existing).
- `npm test`: 416 pass across 23 files.
- `npm run check:colors`: 480, at baseline. No CSS touched, so no light/dark verification was needed.

New tests cover: the login-prompt classifier and its negative cases (rate limits, timeouts and module errors must keep reporting), the signature join, the wheel-download cause split including two pins landing on one category, the logging suppression, the stats retention and miss backoff, and the pip ETA/percent against the RUST-9Y scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEZxvTKVdNfhHrh5he8RX5

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEZxvTKVdNfhHrh5he8RX5)_