### PR TITLE
Report output reduction as inactive when the wheel blocks the shaper

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5524,6 +5524,26 @@ fn lifetime_token_milestone_kind(milestone_tokens_saved: u64) -> &'static str {
 /// How many recent days of savings travel with the milestone/heartbeat post.
 const SAVINGS_REPORT_DAYS: usize = 30;
 
+/// The output-reduction fields the savings report should carry. The desktop
+/// requests the shaper, but the wheel's rollout gate can block it by channel
+/// (all stable installs on the 0.37.0 wheel). A blocked shaper produces no
+/// live reduction, so the ledger-recomputed figure would report an "estimated"
+/// percentage for a feature that never ran; label it inactive and withhold the
+/// percent instead. Unknown state (older wheels without the rollout block)
+/// reports as before.
+fn reported_output_reduction(
+    reduction: Option<&crate::models::OutputReduction>,
+    shaper_active: Option<bool>,
+) -> (Option<f64>, Option<String>) {
+    if shaper_active == Some(false) {
+        return (None, Some("inactive".to_string()));
+    }
+    (
+        reduction.map(|o| o.reduction_percent),
+        reduction.map(|o| o.method.clone()),
+    )
+}
+
 /// Projects the dashboard's real savings figures into the payload
 /// headroom-web stores for the admin profile. Must be called on the dashboard
 /// BEFORE `maybe_inject_fake_daily_savings`, or demo data reaches the server.
@@ -5536,14 +5556,16 @@ fn savings_report(dashboard: &DashboardState) -> pricing::SavingsReport {
         cache_read_tokens: breakdown.map(|b| b.cache_read_tokens).unwrap_or(0),
         total_input_cost_usd: breakdown.map(|b| b.total_input_cost_usd).unwrap_or(0.0),
         cache_savings_usd: breakdown.map(|b| b.cache_savings_usd).unwrap_or(0.0),
-        output_reduction_percent: dashboard
-            .output_reduction
-            .as_ref()
-            .map(|o| o.reduction_percent),
-        output_reduction_method: dashboard
-            .output_reduction
-            .as_ref()
-            .map(|o| o.method.clone()),
+        output_reduction_percent: reported_output_reduction(
+            dashboard.output_reduction.as_ref(),
+            dashboard.output_shaper_active,
+        )
+        .0,
+        output_reduction_method: reported_output_reduction(
+            dashboard.output_reduction.as_ref(),
+            dashboard.output_shaper_active,
+        )
+        .1,
         reread_tokens: dashboard.reread_tokens,
         reread_compressed_tokens: dashboard.reread_compressed_tokens,
         ccr_retrievals: dashboard.ccr_retrievals,
@@ -11240,5 +11262,45 @@ Some unrelated content.
             None,
             "a reload must not replay a spent code"
         );
+    }
+}
+
+#[cfg(test)]
+mod output_reduction_report_tests {
+    use super::reported_output_reduction;
+    use crate::models::OutputReduction;
+
+    fn reduction() -> OutputReduction {
+        OutputReduction {
+            method: "estimated".to_string(),
+            reduction_percent: 28.0,
+            ci_low_percent: 20.0,
+            ci_high_percent: 36.0,
+            requests: 19_644,
+        }
+    }
+
+    #[test]
+    fn blocked_shaper_reports_inactive_without_a_percent() {
+        let (pct, method) = reported_output_reduction(Some(&reduction()), Some(false));
+        assert_eq!(pct, None);
+        assert_eq!(method.as_deref(), Some("inactive"));
+    }
+
+    #[test]
+    fn active_shaper_reports_the_reduction_unchanged() {
+        let (pct, method) = reported_output_reduction(Some(&reduction()), Some(true));
+        assert_eq!(pct, Some(28.0));
+        assert_eq!(method.as_deref(), Some("estimated"));
+    }
+
+    #[test]
+    fn unknown_rollout_state_keeps_the_old_behavior() {
+        let (pct, method) = reported_output_reduction(Some(&reduction()), None);
+        assert_eq!(pct, Some(28.0));
+        assert_eq!(method.as_deref(), Some("estimated"));
+        let (none_pct, none_method) = reported_output_reduction(None, None);
+        assert_eq!(none_pct, None);
+        assert_eq!(none_method, None);
     }
 }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -306,6 +306,13 @@ pub struct DashboardState {
     /// `None` until a verbosity baseline is seeded (the dashboard hides the stat
     /// until then). Always honestly labelled (`method` + confidence band).
     pub output_reduction: Option<OutputReduction>,
+    /// Whether the running wheel's rollout gate actually enabled the output
+    /// shaper. `Some(false)` means blocked (e.g. blocked_by_channel on stable
+    /// with the 0.37.0 wheel): the reduction above then describes an inactive
+    /// feature and must not be reported to the server as a live one. `None`
+    /// on wheels that predate the rollout block.
+    #[serde(default)]
+    pub output_shaper_active: Option<bool>,
     /// Auto-learning progress; `None` when the backend doesn't report it.
     #[serde(default)]
     pub learner_progress: Option<LearnerProgress>,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -2683,6 +2683,7 @@ impl AppState {
                 session_estimated_tokens_saved: snapshot.session_estimated_tokens_saved,
                 session_savings_pct: snapshot.session_savings_pct,
                 output_reduction,
+                output_shaper_active: stats.as_ref().and_then(|s| s.output_shaper_active),
                 learner_progress,
                 reread_tokens: stats.as_ref().and_then(|s| s.reread_tokens),
                 reread_compressed_tokens: stats.as_ref().and_then(|s| s.reread_compressed_tokens),
@@ -5708,6 +5709,12 @@ struct HeadroomDashboardStats {
     session_total_tokens_sent: Option<u64>,
     savings_history: Vec<HeadroomSavingsHistoryPoint>,
     output_reduction: Option<OutputReduction>,
+    /// Whether the wheel's rollout gate actually enabled the output shaper
+    /// (`rollout.features[name=="proxy_output_shaper"].enabled`). The desktop
+    /// requests the shaper via HEADROOM_OUTPUT_SHAPER=1, but a wheel's rollout
+    /// registry can block it by channel (the 0.37.0 wheel gates it to beta,
+    /// silently disabling it on stable). None on wheels without the block.
+    output_shaper_active: Option<bool>,
     /// Tool-definition tokens the proxy kept out of the model's context by
     /// deferring heavy tool schemas. Process-cumulative (it resets when the
     /// backend restarts), and the backend never writes it to its rollups, so
@@ -6350,6 +6357,17 @@ fn parse_headroom_stats_from_json(body: &str) -> Option<HeadroomDashboardStats> 
         .unwrap_or_default();
 
     let output_reduction = parse_output_reduction(&root);
+    // Rollout truth for the shaper: a ledger-recomputed reduction is only a
+    // live claim while the wheel actually runs the shaper. Absent block => None
+    // (older wheels), and the report gate stays open.
+    let output_shaper_active = value_at_path(&root, &["rollout", "features"])
+        .and_then(Value::as_array)
+        .and_then(|features| {
+            features
+                .iter()
+                .find(|f| f.get("name").and_then(Value::as_str) == Some("proxy_output_shaper"))
+        })
+        .and_then(|f| f.get("enabled").and_then(Value::as_bool));
     // `summary.compression` carries the process-cumulative counter. The
     // `savings.by_layer` block reports the same layer but only over the recent
     // request window, so it is a fallback for shape, not a preferred source.
@@ -6398,6 +6416,7 @@ fn parse_headroom_stats_from_json(body: &str) -> Option<HeadroomDashboardStats> 
             session_total_tokens_sent,
             savings_history,
             output_reduction,
+            output_shaper_active,
             tool_schema_tokens_saved,
         })
     }
@@ -10337,6 +10356,7 @@ mod tests {
         // savings_history backfills the daily buckets the lifetime total (and
         // hence milestones) is derived from; a cumulative 1.5M crosses 100k+1M.
         let stats = HeadroomDashboardStats {
+            output_shaper_active: None,
             reread_tokens: None,
             reread_compressed_tokens: None,
             ccr_retrievals: None,
@@ -10385,6 +10405,7 @@ mod tests {
 
         let first = tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -10408,6 +10429,7 @@ mod tests {
 
         let second = tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -10435,6 +10457,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -10453,6 +10476,7 @@ mod tests {
 
         let reset = tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -10479,6 +10503,7 @@ mod tests {
         let mut tracker = make_tracker();
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -10550,6 +10575,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -10711,7 +10737,16 @@ mod tests {
                     "history_size": 12
                 },
                 "waste_signals": { "reread": 91000, "reread_compressed": 4500 },
-                "compression": { "ccr_retrievals": 6 }
+                "compression": { "ccr_retrievals": 6 },
+                "rollout": {
+                    "features": [
+                        {
+                            "name": "proxy_output_shaper",
+                            "enabled": false,
+                            "decision": "blocked_by_channel"
+                        }
+                    ]
+                }
             }"#,
         )
         .expect("contract fixture must parse");
@@ -10743,6 +10778,10 @@ mod tests {
         let learner = parsed.learner_progress.expect("learner parsed");
         assert_eq!(learner.pending_patterns, 3);
 
+        // The rollout block decides whether the shaper's reduction is a live
+        // claim; blocked_by_channel must parse as an explicit false.
+        assert_eq!(parsed.output_shaper_active, Some(false));
+
         // Retrieval-churn gauges ride the savings report to the server.
         assert_eq!(parsed.reread_tokens, Some(91000));
         assert_eq!(parsed.reread_compressed_tokens, Some(4500));
@@ -10758,6 +10797,9 @@ mod tests {
         )
         .expect("fallback fixture must parse");
         assert_eq!(fallback.tool_schema_tokens_saved, Some(555));
+        // No rollout block (older wheel) => unknown, and the report gate must
+        // stay open rather than mislabel the layer inactive.
+        assert_eq!(fallback.output_shaper_active, None);
     }
 
     #[test]
@@ -11059,6 +11101,7 @@ mod tests {
         // that was already starved.
         let state = AppState::new().expect("state");
         let good = HeadroomDashboardStats {
+            output_shaper_active: None,
             tool_schema_tokens_saved: Some(4_242),
             ..HeadroomDashboardStats::default()
         };
@@ -11676,6 +11719,7 @@ mod tests {
         let mut tracker = make_tracker();
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -11702,6 +11746,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -11724,6 +11769,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -11756,6 +11802,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -11777,6 +11824,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -11871,6 +11919,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -11902,6 +11951,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -11924,6 +11974,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -11955,6 +12006,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -11981,6 +12033,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -12047,6 +12100,7 @@ mod tests {
         ] {
             tracker
                 .observe(&HeadroomDashboardStats {
+                    output_shaper_active: None,
                     reread_tokens: None,
                     reread_compressed_tokens: None,
                     ccr_retrievals: None,
@@ -12078,6 +12132,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -12100,6 +12155,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -12132,6 +12188,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -12150,6 +12207,7 @@ mod tests {
 
         let second = tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -12202,6 +12260,7 @@ mod tests {
 
         let snapshot = tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -12735,6 +12794,7 @@ mod tests {
 
         // First observation: 1_000 tokens saved, history shows 0→1_000 across hours 9→10.
         tracker.observe(&HeadroomDashboardStats {
+            output_shaper_active: None,
             reread_tokens: None,
             reread_compressed_tokens: None,
             ccr_retrievals: None,
@@ -12757,6 +12817,7 @@ mod tests {
 
         // Second observation: 3_000 tokens saved, history adds hour 11.
         tracker.observe(&HeadroomDashboardStats {
+            output_shaper_active: None,
             reread_tokens: None,
             reread_compressed_tokens: None,
             ccr_retrievals: None,


### PR DESCRIPTION
## What

When the running wheel's rollout gate blocks the output shaper, the savings report sent to headroom-web now carries `output_reduction_method: "inactive"` and no percentage, instead of a ledger-recomputed "estimated" figure for a feature that is not running.

## Why

The desktop has always requested the shaper via `HEADROOM_OUTPUT_SHAPER=1`, but the 0.37.0 wheel introduced a rollout registry that gates `proxy_output_shaper` to the beta channel - `/stats` `.rollout.features[]` shows `enabled: false, decision: "blocked_by_channel"` on stable installs (verified on a live stable box). That means the wheel bump silently disabled output shaping for every stable user, while the desktop kept reporting the ledger recompute to the web (user 462's admin profile shows 28.04% "estimated"; his own audit quoted the blocked_by_channel state back at us). This PR makes the web report honest regardless of how the channel question is later resolved.

## How

- `parse_headroom_stats_from_json` reads `rollout.features[name=="proxy_output_shaper"].enabled` into `HeadroomDashboardStats.output_shaper_active` (None on wheels without the rollout block, so old wheels behave exactly as before). Path pinned in `stats_contract_pins_every_consumed_path`.
- `DashboardState.output_shaper_active` (`#[serde(default)]`) carries it to the reporter.
- `savings_report` routes through a new pure `reported_output_reduction(reduction, shaper_active)`: `Some(false)` -> `(None, Some("inactive"))`; anything else unchanged.
- Local dashboard display is deliberately untouched (chip behavior is a separate decision).

## Verification

- `cargo test --lib`: 1102 passed (includes new `output_reduction_report_tests` and the extended stats contract test with a `blocked_by_channel` fixture).
- `cargo fmt --check`, `npx tsc --noEmit`, `npx vitest run` (416 passed) all clean.
- Not tested: end-to-end against headroom-web (whether the upsert overwrites a previously-reported percent with null is web-side behavior; if it keeps the stale 28.04, the "inactive" method still labels it).

## Open question for the channel decision (not in this PR)

Restoring shaping on stable needs either the wheel's channel set so the rollout gate passes, an unsafe override, or an upstream registry change. Until then, stable installs genuinely have no output shaping - this PR only makes the reporting match that reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
