### PR TITLE
Point the app at the docs it never linked to

### DIFF
--- a/scripts/check-colors.sh
+++ b/scripts/check-colors.sh
@@ -13,7 +13,7 @@ file="${1:-src/styles.css}"
 # the count is only allowed to shrink. Lower this number as you migrate rules.
 # ponytail: a stale baseline lets offenders regrow up to it after a migration;
 # tighten by failing on count < BASELINE if that ever actually happens.
-BASELINE="${CHECK_COLORS_BASELINE:-480}"
+BASELINE="${CHECK_COLORS_BASELINE:-478}"
 
 # Use awk to track whether we are inside a :root block or a @media (prefers-color-scheme) block.
 # Raw colors inside those blocks are the token definitions themselves — allowed.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -603,6 +603,8 @@ const CODEX_CLI_LOGIN_CMD = "codex login";
 const CODEX_INSTALL_DOCS_URL = "https://developers.openai.com/codex/cli";
 const CODEX_INSTALL_NPM_CMD = "npm i -g @openai/codex";
 
+const DOCS_URL = "https://extraheadroom.com/docs";
+
 const APPSUMO_ACCOUNT_URL = "https://appsumo.com/account/products/";
 
 const SALES_CONTACT_URL = (
@@ -6714,6 +6716,16 @@ export default function App() {
               </div>
             )}
 
+            <p className="tray-footnote">
+              <button
+                className="link-button"
+                onClick={() => void openExternalLink(DOCS_URL)}
+                type="button"
+              >
+                Docs and guides
+              </button>
+            </p>
+
           </div>
 
         <div className="tray-content" hidden={activeView !== "optimization"}>
@@ -6735,7 +6747,16 @@ export default function App() {
                       <span className="optimize-card__auto-learn-meta">
                         {autoLearnEnabled === false
                           ? "Off — only manual scans add learnings."
-                          : autoLearnMeta}
+                          : autoLearnMeta}{" "}
+                        <button
+                          className="link-button"
+                          onClick={() =>
+                            void openExternalLink(`${DOCS_URL}/how-learning-works`)
+                          }
+                          type="button"
+                        >
+                          How learning works
+                        </button>
                       </span>
                     </div>
                     <button
@@ -7193,8 +7214,17 @@ export default function App() {
                 <h1>Addons</h1>
               </div>
               <p className="addons-card__blurb">
-                Additional tools that reduce token usage. Missing an addon you
-                want?{" "}
+                Additional tools that reduce token usage. The core proxy is
+                always on; these change how your agent behaves, so they ship off
+                and you switch on the ones you want.{" "}
+                <button
+                  type="button"
+                  className="addon-card__link"
+                  onClick={() => void openExternalLink(`${DOCS_URL}/add-ons`)}
+                >
+                  What each addon does
+                </button>
+                {". Missing an addon you want? "}
                 <button
                   type="button"
                   className="addon-card__link"
@@ -8122,6 +8152,15 @@ export default function App() {
                   </div>
                 ) : null}
                 <div className="modal-actions">
+                  <button
+                    className="link-button"
+                    onClick={() =>
+                      void openExternalLink(`${DOCS_URL}/how-savings-are-measured`)
+                    }
+                    type="button"
+                  >
+                    Full method
+                  </button>
                   <button
                     className="button button--primary"
                     onClick={() => setShowSavingsInfo(false)}

--- a/src/styles.css
+++ b/src/styles.css
@@ -4101,7 +4101,7 @@ details[open] .optimize-minimal__details summary::after {
 .link-button {
   border: 0;
   background: transparent;
-  color: #59514a;
+  color: var(--text-secondary);
   font-size: var(--text-sm);
   text-decoration: underline;
   cursor: pointer;
@@ -4110,7 +4110,7 @@ details[open] .optimize-minimal__details summary::after {
 }
 
 .link-button:hover {
-  color: #2e2824;
+  color: var(--text-primary);
 }
 
 .connector-switch {
@@ -6296,6 +6296,17 @@ html.window-hiding {
   font-size: var(--text-xs);
   margin: 0;
   text-align: center;
+}
+
+.tray-footnote {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  margin: 0;
+  text-align: center;
+}
+
+.tray-footnote .link-button {
+  margin-left: 0;
 }
 
 .paywall__sale-banner {


### PR DESCRIPTION
## Why

All four rows of the AppSumo beta-ling feedback (Steve Finegan, 2026-08-17) were about education. We answered three of them by building `/docs`: a hub plus nine pages, live and linked from the site nav and footer.

The app never linked to any of it. Before this PR the desktop app's only outbound links were `/features`, `/terms`, `/privacy` and `mailto:` - so a user who installed Headroom had no path to the docs written for them. The education shipped to the marketing site; the person who needed it was in the app.

## What

Four contextual links, each placed where the question actually gets asked:

- Addons blurb -> `/docs/add-ons`. The blurb also now states why add-ons ship off ("the core proxy is always on; these change how your agent behaves"), which was the tester's second row and previously had no in-app answer at all.
- Auto-learning meta line -> `/docs/how-learning-works`, next to the copy that explains the evidence gate. This is where "I ran six hours of Claude Code and got zero learnings" lands.
- Savings modal -> `/docs/how-savings-are-measured`, alongside the existing breakdown.
- Home -> `/docs`, as a general entry point on the default view.

## Dark mode fix

`.link-button` hardcoded `#59514a` / `#2e2824`. Three of the four new links use it on main-window surfaces, where those greys are near-illegible against a dark background. Tokenized to `--text-secondary` / `--text-primary` at the class rather than patching each call site, so the existing paywall and auth-card uses get fixed too. Colour baseline drops 480 -> 478.

## Not in this PR

- Row 4 (learnings visible in real time) is still blocked upstream. The desktop half shipped a while back, but headroomlabs-ai/headroom#3104 - which adds the `traffic_learner` block to `/stats` - is still open, so `parse_learner_progress` returns `None` on the pinned 0.37.0 wheel and every user sees the static fallback copy. Nudged on the PR; needs the merge plus a wheel bump.
- No explainer video anywhere, which the tester asked for twice.

## Checks

`tsc --noEmit` clean, vitest 23 files / 418 tests pass, `check-colors` 478/478, `check-no-console` pass. Not visually verified in a running app - the new CSS uses only tokens that already have dark-mode overrides, but that is inference rather than an eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
