### PR TITLE
0.9.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ it unprompted and the harness enforces the rest. Do not re-add it.
 ## Wheel Bump Rules
 - Before changing `HEADROOM_PINNED_VERSION`: diff upstream `savings_tracker.py`, `prometheus_metrics.py`, and `server.py` between the old and new pins, and check every consumed field against `stats_contract_pins_every_consumed_path` in state.rs. Upstream has silently redefined persisted savings fields before (0.36.0 widened `compression_savings_usd`); the savings-rate canary in state.rs is the runtime tripwire, this diff is the compile-time one.
 - Re-pick every platform's wheel URL/sha256 when bumping (see the pin comment in tool_manager.rs).
+- Diff `rollout.py`'s FEATURES registry between the old and new pins. The app declares `HEADROOM_ROLLOUT_CHANNEL=beta` (tool_manager.rs), so any new feature with `default_enabled_in` at or below beta auto-enables for every user on the bump; any feature the app requests whose `available_in` moved above beta silently turns off (this is how 0.37.0 disabled the output shaper on stable).
 
 ## Persistence Rules
 Most stability bugs in this codebase's history were violations of one of these five. Follow them for any new code; treat violations found in existing code as bugs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.5-rc.1",
+  "version": "0.9.5-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.5-rc.1",
+      "version": "0.9.5-rc.2",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.5-rc.2",
+  "version": "0.9.5-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.5-rc.2",
+      "version": "0.9.5-rc.3",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.5-rc.5",
+  "version": "0.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.5-rc.5",
+      "version": "0.9.5",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.5-rc.4",
+  "version": "0.9.5-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.5-rc.4",
+      "version": "0.9.5-rc.5",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.5-rc.3",
+  "version": "0.9.5-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.5-rc.3",
+      "version": "0.9.5-rc.4",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.4",
+  "version": "0.9.5-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.4",
+      "version": "0.9.5-rc.1",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.5-rc.4",
+  "version": "0.9.5-rc.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.5-rc.3",
+  "version": "0.9.5-rc.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.5-rc.1",
+  "version": "0.9.5-rc.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.4",
+  "version": "0.9.5-rc.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.5-rc.2",
+  "version": "0.9.5-rc.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.5-rc.5",
+  "version": "0.9.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.5-rc.2"
+version = "0.9.5-rc.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.5-rc.3"
+version = "0.9.5-rc.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.5-rc.1"
+version = "0.9.5-rc.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.5-rc.5"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.4"
+version = "0.9.5-rc.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.5-rc.4"
+version = "0.9.5-rc.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.5-rc.1"
+version = "0.9.5-rc.2"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.5-rc.2"
+version = "0.9.5-rc.3"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.5-rc.4"
+version = "0.9.5-rc.5"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.5-rc.3"
+version = "0.9.5-rc.4"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.5-rc.5"
+version = "0.9.5"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.4"
+version = "0.9.5-rc.1"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5848,6 +5848,78 @@ fn normalize_learn_failure_signature(signature: &str) -> String {
     )
 }
 
+/// True when a `headroom learn` failure was the coding agent's CLI refusing to
+/// run because nobody is signed in to it on this machine.
+///
+/// This is a user-environment condition, not an app bug: the analyzer shells
+/// out to `claude`/`codex`/`opencode`, and if that CLI has no session it exits
+/// non-zero with its own login prompt. RUST-B6 is the whole class -- four
+/// events whose only content was `Not logged in - Please run /login`, which no
+/// change on our side can resolve. It stays out of Sentry and becomes an
+/// actionable message in the UI instead (see `learn_agent_auth_hint`).
+fn learn_failure_is_agent_auth(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    // Each needle is a full CLI phrase, not a bare word: "login" alone would
+    // also match a project's own source lines echoed back in the output.
+    const NEEDLES: &[&str] = &[
+        "not logged in",
+        "please run /login",
+        "run /login",
+        "please log in",
+        "not authenticated",
+        "authentication_error",
+        "invalid api key",
+        "oauth token has expired",
+        "credentials have expired",
+        "session has expired",
+        "please run `codex login`",
+        "run `codex login`",
+        "no credentials found",
+    ];
+    NEEDLES.iter().any(|needle| lower.contains(needle))
+}
+
+/// The user-facing remedy for [`learn_failure_is_agent_auth`], naming the CLI
+/// the run actually shelled out to.
+fn learn_agent_auth_hint(agent: LearnAgent) -> String {
+    let (cli, command) = match agent {
+        LearnAgent::Claude => ("Claude Code", "claude"),
+        LearnAgent::Codex => ("Codex", "codex"),
+        LearnAgent::Opencode => ("opencode", "opencode"),
+        LearnAgent::Grok => ("Grok", "grok"),
+    };
+    format!(
+        "{cli} is not signed in on this machine, so headroom learn could not run its analysis. \
+         Open a terminal, run `{command}`, sign in, then start the scan again."
+    )
+}
+
+/// The text a learn failure is fingerprinted on.
+///
+/// Upstream's first stderr line is a marker whose reason is EMPTY -- ``LLM
+/// analysis failed: `claude -p ...` failed (exit 1):`` -- because the child
+/// CLI writes its diagnosis to its own stream, which upstream appends on the
+/// FOLLOWING line. Fingerprinting the marker alone collapsed every distinct
+/// cause onto one issue with nothing in it to tell them apart (RUST-74, then
+/// RUST-B6). When the first line ends at that dangling colon, the next
+/// non-empty line is the actual reason, so join it in.
+///
+/// stderr only at the call site: stdout echoes written memory files back
+/// verbatim and must never reach a Sentry title.
+fn learn_failure_signature_source(text: &str) -> String {
+    let mut lines = text.lines().map(str::trim).filter(|l| !l.is_empty());
+    let Some(first) = lines.next() else {
+        return "no output".to_string();
+    };
+    if !first.ends_with(':') {
+        return first.to_string();
+    }
+    match lines.next() {
+        Some(reason) => format!("{first} {reason}"),
+        None => first.to_string(),
+    }
+}
+
 /// Turn a `headroom learn` stdout line into the step shown under the scan timer,
 /// or None to leave the current step alone.
 ///
@@ -6131,50 +6203,69 @@ fn execute_headroom_learn_run(
                     // failure class per user (RUST-A2/RUST-9Z). The unmodified
                     // text stays in `reason` and `stderr_tail` below.
                     let signature = normalize_learn_failure_signature(&raw_signature);
-                    sentry::with_scope(
-                        |scope| {
-                            scope.set_tag("flow", "headroom_learn");
-                            scope.set_tag("learn_outcome", "llm_analysis_failed");
-                            scope.set_tag("learn_agent", agent.as_tag());
-                            scope.set_extra("reason", warnings.clone().into());
-                            scope.set_extra("raw_signature", raw_signature.clone().into());
-                            scope.set_extra("project_name", project_name.to_string().into());
-                            // The marker line ends at its colon: upstream
-                            // appends the child's stderr, and `claude -p
-                            // --output-format stream-json` writes its diagnosis
-                            // to stdout, so `reason` arrives empty and every
-                            // distinct cause -- usage limit, dead local route,
-                            // our own 400 -- collapses onto one fingerprint
-                            // (RUST-74: 14 events over six users' machines with
-                            // nothing in them to tell apart). The analyzer's
-                            // surrounding log lines are the only context left
-                            // on this side of the process boundary.
-                            //
-                            // stderr ONLY. stdout echoes written memory files
-                            // back verbatim (see `learn_step_label`), and that
-                            // is the user's project content -- it must never
-                            // reach Sentry.
-                            scope.set_extra(
-                                "stderr_tail",
-                                crate::state::tail_lines(&stderr, 32).join("\n").into(),
-                            );
-                            scope.set_fingerprint(Some(
-                                ["headroom_learn_llm_failure", signature.as_str()].as_slice(),
-                            ));
-                        },
-                        || {
-                            sentry::capture_message(
-                                &format!("headroom learn produced no recommendations: {signature}"),
-                                sentry::Level::Warning,
-                            );
-                        },
-                    );
+                    // Same user-environment carve-out as the non-zero-exit
+                    // branch below (RUST-B6): when the agent CLI has no signed-in
+                    // session, nothing on our side can change the outcome.
+                    let agent_not_signed_in = learn_failure_is_agent_auth(&stderr);
+                    if !agent_not_signed_in {
+                        sentry::with_scope(
+                            |scope| {
+                                scope.set_tag("flow", "headroom_learn");
+                                scope.set_tag("learn_outcome", "llm_analysis_failed");
+                                scope.set_tag("learn_agent", agent.as_tag());
+                                scope.set_extra("reason", warnings.clone().into());
+                                scope.set_extra("raw_signature", raw_signature.clone().into());
+                                scope.set_extra("project_name", project_name.to_string().into());
+                                // The marker line ends at its colon: upstream
+                                // appends the child's stderr, and `claude -p
+                                // --output-format stream-json` writes its diagnosis
+                                // to stdout, so `reason` arrives empty and every
+                                // distinct cause -- usage limit, dead local route,
+                                // our own 400 -- collapses onto one fingerprint
+                                // (RUST-74: 14 events over six users' machines with
+                                // nothing in them to tell apart). The analyzer's
+                                // surrounding log lines are the only context left
+                                // on this side of the process boundary.
+                                //
+                                // stderr ONLY. stdout echoes written memory files
+                                // back verbatim (see `learn_step_label`), and that
+                                // is the user's project content -- it must never
+                                // reach Sentry.
+                                scope.set_extra(
+                                    "stderr_tail",
+                                    crate::state::tail_lines(&stderr, 32).join("\n").into(),
+                                );
+                                scope.set_fingerprint(Some(
+                                    ["headroom_learn_llm_failure", signature.as_str()].as_slice(),
+                                ));
+                            },
+                            || {
+                                sentry::capture_message(
+                                    &format!(
+                                        "headroom learn produced no recommendations: {signature}"
+                                    ),
+                                    sentry::Level::Warning,
+                                );
+                            },
+                        );
+                    }
+                    let (summary, detail) = if agent_not_signed_in {
+                        (
+                            format!("headroom learn needs a signed-in agent for {project_name}."),
+                            learn_agent_auth_hint(agent),
+                        )
+                    } else {
+                        (
+                            format!(
+                                "headroom learn could not produce recommendations for {project_name}."
+                            ),
+                            warnings,
+                        )
+                    };
                     (
-                        format!(
-                            "headroom learn could not produce recommendations for {project_name}."
-                        ),
+                        summary,
                         false,
-                        Some(warnings),
+                        Some(detail),
                         output_tail,
                         stdout,
                         stderr,
@@ -6226,12 +6317,24 @@ fn execute_headroom_learn_run(
                 // command-shaped reason, the resolved CLI path in it would
                 // split one failure class per machine. A no-op on any line that
                 // is not command-shaped.
-                let signature: String = normalize_learn_failure_signature(
+                // The marker line's reason sits on the NEXT line, so join it in
+                // when the first line ends at its dangling colon -- but only
+                // for stderr. `signature_source` falls back to stdout when
+                // stderr is empty, and stdout echoes written memory files back
+                // verbatim (see `learn_step_label`): that is the user's project
+                // content and must never reach a Sentry title.
+                let signature_head = if stderr.trim().is_empty() {
                     signature_source
                         .lines()
                         .map(str::trim)
                         .find(|l| !l.is_empty())
                         .unwrap_or("no output")
+                        .to_string()
+                } else {
+                    learn_failure_signature_source(signature_source)
+                };
+                let signature: String = normalize_learn_failure_signature(
+                    signature_head
                         .chars()
                         .take(160)
                         .collect::<String>()
@@ -6251,7 +6354,14 @@ fn execute_headroom_learn_run(
                 // unreadable between the pre-flight read_dir check and the CLI
                 // run. Click reports that as exit 2 with "is not readable" — a
                 // user-environment condition, not an app bug, so don't report it.
-                let user_env_condition = signature.contains("is not readable");
+                //
+                // The agent CLI having no signed-in session is the same class
+                // (RUST-B6). Matched against the whole stderr rather than the
+                // signature: upstream's marker line ends before the child's
+                // login prompt, which can land several lines further down.
+                let agent_not_signed_in = learn_failure_is_agent_auth(&stderr);
+                let user_env_condition =
+                    signature.contains("is not readable") || agent_not_signed_in;
                 if !user_env_condition {
                     sentry::with_scope(
                         |scope| {
@@ -6277,13 +6387,25 @@ fn execute_headroom_learn_run(
                         },
                     );
                 }
-                (
-                    format!("headroom learn failed for {project_name}."),
-                    false,
-                    Some(format!(
+                // A missing agent session has a remedy the user can act on;
+                // the raw exit status and output tail do not name it.
+                let user_error = if agent_not_signed_in {
+                    learn_agent_auth_hint(agent)
+                } else {
+                    format!(
                         "headroom learn exited with {}.\n{}",
                         output.status, fail_tail
-                    )),
+                    )
+                };
+                let user_summary = if agent_not_signed_in {
+                    format!("headroom learn needs a signed-in agent for {project_name}.")
+                } else {
+                    format!("headroom learn failed for {project_name}.")
+                };
+                (
+                    user_summary,
+                    false,
+                    Some(user_error),
                     output_tail,
                     stdout,
                     stderr,
@@ -7785,6 +7907,7 @@ mod tests {
         fake_override, fetch_transformations_feed_from, first_savings_body, format_token_count,
         install_pending_update, is_disk_full_signal, is_endpoint_protection_signal,
         is_network_download_signal, is_port_conflict_failure, is_prerelease_version,
+        learn_agent_auth_hint, learn_failure_is_agent_auth, learn_failure_signature_source,
         learn_step_label, lifetime_token_milestone_kind, noop_app_update_progress_emitter,
         normalize_learn_failure_signature, onboarding_recovery_copy, parse_live_learnings,
         parse_magic_link_auth, parse_request_count_from_stats_body, parse_request_counts_by_agent,
@@ -10340,6 +10463,67 @@ Some unrelated content.
             !block.contains("&stdout") && !block.contains("&merged"),
             "stdout carries memory-file contents and must never reach Sentry: {block}"
         );
+    }
+
+    #[test]
+    fn learn_failure_is_agent_auth_matches_the_cli_login_prompts() {
+        // RUST-B6 verbatim: four events whose only content was the child CLI
+        // saying nobody is signed in.
+        let stderr = "LLM analysis failed: `claude -p --output-format stream-json --verbose` failed (exit 1):\nNot logged in \u{b7} Please run /login\n";
+        assert!(learn_failure_is_agent_auth(stderr));
+        assert!(learn_failure_is_agent_auth(
+            "Error: not authenticated. Please run `codex login`."
+        ));
+        assert!(learn_failure_is_agent_auth(
+            "AuthenticationError: invalid API key"
+        ));
+        assert!(learn_failure_is_agent_auth("Your OAuth token has expired."));
+    }
+
+    #[test]
+    fn learn_failure_is_agent_auth_does_not_swallow_real_failures() {
+        // These must keep reporting: they are ours to fix.
+        for stderr in [
+            "LLM analysis failed: `claude -p` did not respond within 120s.",
+            "ModuleNotFoundError: No module named 'headroom.learn'",
+            "Error: rate limit exceeded, try again later",
+            "usage limit reached for this session",
+            "",
+        ] {
+            assert!(!learn_failure_is_agent_auth(stderr), "for: {stderr}");
+        }
+    }
+
+    #[test]
+    fn learn_failure_signature_source_joins_the_dangling_marker_line() {
+        // Upstream's marker ends at a colon and appends the child's real
+        // diagnosis on the next line. Fingerprinting the marker alone put every
+        // distinct cause on one issue (RUST-74, then RUST-B6).
+        let stderr = "LLM analysis failed: `claude -p --output-format stream-json --verbose` failed (exit 1):\nNot logged in \u{b7} Please run /login\n";
+        let signature = learn_failure_signature_source(stderr);
+        assert!(signature.contains("Not logged in"), "got: {signature}");
+
+        // Two different causes behind the same marker must not collapse.
+        let other = "LLM analysis failed: `claude -p --output-format stream-json --verbose` failed (exit 1):\nCredit balance is too low\n";
+        assert_ne!(signature, learn_failure_signature_source(other));
+    }
+
+    #[test]
+    fn learn_failure_signature_source_leaves_a_self_contained_line_alone() {
+        let stderr = "ModuleNotFoundError: No module named 'headroom'\nTraceback follows\n";
+        assert_eq!(
+            learn_failure_signature_source(stderr),
+            "ModuleNotFoundError: No module named 'headroom'"
+        );
+        assert_eq!(learn_failure_signature_source("   \n\n"), "no output");
+    }
+
+    #[test]
+    fn learn_agent_auth_hint_names_the_cli_the_run_shelled_out_to() {
+        let hint = learn_agent_auth_hint(LearnAgent::Claude);
+        assert!(hint.contains("Claude Code"), "got: {hint}");
+        assert!(hint.contains("`claude`"), "got: {hint}");
+        assert!(learn_agent_auth_hint(LearnAgent::Codex).contains("`codex`"));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1723,7 +1723,69 @@ fn is_ssl_library_conflict_signal(text: &str) -> bool {
 /// `pip_failure_category`'s `app-control` bucket so the two layers agree.
 fn is_app_control_signal(text: &str) -> bool {
     let lower = text.to_ascii_lowercase();
-    lower.contains("application control policy has blocked") || lower.contains("(os error 4551)")
+    lower.contains("application control policy has blocked")
+        || lower.contains("(os error 4551)")
+        // Windows localizes the verdict and only `CreateProcess` failures
+        // carry the numeric code. When the policy blocks a DLL that Python is
+        // importing, CPython reports it as an ImportError with the OS prose
+        // and no code at all (RUST-BB/BA: `_sqlite3`, Spanish Windows). The
+        // Spanish text is verbatim from those events; the structural check in
+        // `is_blocked_runtime_dll_signal` covers every other locale.
+        || lower.contains("control de aplicaciones bloque")
+}
+
+/// True when Windows refused to load one of the bundled interpreter's own
+/// extension DLLs.
+///
+/// CPython reports that as `ImportError: DLL load failed while importing
+/// <module>: <reason>`. The prefix is CPython's and English on every locale;
+/// the reason is Windows' `FormatMessage` prose, localized, and for an
+/// Application Control verdict it carries no numeric code -- so it slips past
+/// `is_app_control_signal` on any non-English machine (RUST-BB/BA/5C: one host,
+/// Spanish Windows, `_sqlite3` blocked, filed as three Error-level issues).
+///
+/// Scoped to the standard-library extensions that python-build-standalone
+/// ships: those are self-contained (their dependent DLLs sit in the same
+/// folder), so a load failure is a policy or antivirus verdict on our freshly
+/// installed files, or a quarantined one -- not a dependency the user could
+/// install. Third-party extensions (onnxruntime, torch) are deliberately NOT
+/// here: their load failures are usually a missing Visual C++ runtime, which
+/// `classify_startup_error` handles from onnxruntime's own English warning.
+pub(crate) fn is_blocked_runtime_dll_signal(text: &str) -> bool {
+    const STDLIB_EXTENSIONS: &[&str] = &[
+        "_sqlite3",
+        "_ssl",
+        "_ctypes",
+        "_socket",
+        "_hashlib",
+        "_bz2",
+        "_lzma",
+        "_decimal",
+        "_multiprocessing",
+        "_asyncio",
+        "_overlapped",
+        "_queue",
+        "_uuid",
+        "_elementtree",
+        "_zoneinfo",
+        "pyexpat",
+        "select",
+        "unicodedata",
+    ];
+    let lower = text.to_ascii_lowercase();
+    let mut rest = lower.as_str();
+    while let Some(idx) = rest.find("dll load failed while importing ") {
+        let after = &rest[idx + "dll load failed while importing ".len()..];
+        let module = after
+            .split(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+            .next()
+            .unwrap_or("");
+        if STDLIB_EXTENSIONS.contains(&module) {
+            return true;
+        }
+        rest = after;
+    }
+    false
 }
 
 /// PATH directories holding an OpenSSL that could be loaded into our
@@ -2279,6 +2341,23 @@ pub(crate) fn child_state_fingerprint_key(
     }
 }
 
+/// Extra fingerprint bucket for a give-up whose `last_startup_error` names a
+/// cause with its own remedy. `None` for the ordinary case (no startup error,
+/// or one we cannot classify), so the fingerprint those events already carry
+/// is untouched.
+pub(crate) fn startup_error_fingerprint_key(
+    last_startup_error: Option<&str>,
+) -> Option<&'static str> {
+    let err = last_startup_error?;
+    if is_endpoint_protection_signal(err) {
+        Some("startup_endpoint_protection")
+    } else if is_port_conflict_failure(err) {
+        Some("startup_port_conflict")
+    } else {
+        None
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn build_watchdog_give_up_report(
     consecutive_failures: u32,
@@ -2546,11 +2625,21 @@ fn capture_watchdog_give_up(
     // network/restart blips stay at Warning so they don't pollute the Error
     // inbox.
     let cpu_deadlock_signal = cpu_actively_burning && report.log_silent_secs.unwrap_or(0) >= 30;
-    let level = if report.last_startup_error.is_some() || cpu_deadlock_signal {
-        sentry::Level::Error
-    } else {
-        sentry::Level::Warning
-    };
+    // A spawn that keeps failing is an Error -- unless the machine's own
+    // security policy is what keeps failing it. That verdict is already
+    // reported once per session by `capture_headroom_start_failure`, has a
+    // user-facing remedy, and cannot be changed by anything we ship; filing
+    // the give-up that follows it as an Error just re-reports the same block
+    // (RUST-5C's latest events were one Spanish Windows host whose `_sqlite3`
+    // was blocked, escalated to Error three times over).
+    let startup_key = startup_error_fingerprint_key(report.last_startup_error.as_deref());
+    let startup_is_policy = startup_key == Some("startup_endpoint_protection");
+    let level =
+        if (report.last_startup_error.is_some() && !startup_is_policy) || cpu_deadlock_signal {
+            sentry::Level::Error
+        } else {
+            sentry::Level::Warning
+        };
 
     sentry::with_scope(
         |scope| {
@@ -2563,8 +2652,16 @@ fn capture_watchdog_give_up(
             let readyz_key = readyz_outcome_fingerprint_key(&report.backend_readyz_outcome);
             let child_key =
                 child_state_fingerprint_key(&report.tracked_child_exit_status, report.tracked_pid);
-            let fp: &[&str] = &["proxy_unreachable_post_boot", readyz_key, child_key];
-            scope.set_fingerprint(Some(fp));
+            // A recognised startup cause gets its own issue: an endpoint
+            // protection block and a port conflict are not the wedge the
+            // readyz/child keys describe, and each has its own lifecycle.
+            // Absent (the common case) the fingerprint is unchanged, so the
+            // existing issues keep their history.
+            let mut fp: Vec<&str> = vec!["proxy_unreachable_post_boot", readyz_key, child_key];
+            if let Some(key) = startup_key {
+                fp.push(key);
+            }
+            scope.set_fingerprint(Some(fp.as_slice()));
             scope.set_extra(
                 "tracked_child_exit_status",
                 report.tracked_child_exit_status.clone().into(),
@@ -2883,6 +2980,11 @@ pub(crate) fn is_endpoint_protection_signal(text: &str) -> bool {
     if is_app_control_signal(&lower) {
         return true;
     }
+    // The same verdict seen from inside Python, where the OS prose is
+    // localized and carries no code (RUST-BB/BA/5C).
+    if is_blocked_runtime_dll_signal(&lower) {
+        return true;
+    }
     false
 }
 
@@ -2911,12 +3013,27 @@ const ENDPOINT_PROTECTION_HINT_RUNTIME: &str =
      interfering with freshly-installed code. Allow `~/Library/Application Support/Headroom` \
      in your security software, then click Retry.";
 
+/// The Windows wording: the block there is almost always Application Control
+/// (Smart App Control on a personal PC, WDAC or AppLocker on a managed one),
+/// which has a specific place to look and a specific folder to allow. The
+/// macOS text above named a `~/Library` path to Windows users (RUST-BB).
+const ENDPOINT_PROTECTION_HINT_RUNTIME_WINDOWS: &str =
+    "Windows blocked part of Headroom's runtime from loading — usually Application Control \
+     (Smart App Control, AppLocker, or a company WDAC policy) or antivirus / endpoint protection \
+     acting on freshly-installed files. On a personal PC, check Windows Security > App & browser control; \
+     on a work PC, ask IT to allow %LOCALAPPDATA%\\Headroom. Then click Retry. If nothing is \
+     blocking it, reinstall the runtime from Settings > Advanced.";
+
 pub(crate) fn endpoint_protection_hint_install() -> String {
     ENDPOINT_PROTECTION_HINT_INSTALL.to_string()
 }
 
 pub(crate) fn endpoint_protection_hint_runtime() -> String {
-    ENDPOINT_PROTECTION_HINT_RUNTIME.to_string()
+    if cfg!(windows) {
+        ENDPOINT_PROTECTION_HINT_RUNTIME_WINDOWS.to_string()
+    } else {
+        ENDPOINT_PROTECTION_HINT_RUNTIME.to_string()
+    }
 }
 
 /// Map common runtime-upgrade failure modes to a short user-facing hint.
@@ -5911,13 +6028,24 @@ fn learn_failure_signature_source(text: &str) -> String {
     let Some(first) = lines.next() else {
         return "no output".to_string();
     };
-    if !first.ends_with(':') {
+    // Only the `failed (exit N):` marker is followed by a one-line diagnosis
+    // worth grouping on. Other markers also end at a colon but introduce a
+    // DUMP -- `returned unparseable output. First 2000 chars:` (RUST-B7) is
+    // followed by the model's raw output, which is derived from the user's
+    // sessions and must not become a Sentry title.
+    if !learn_marker_expects_reason_line(first) {
         return first.to_string();
     }
     match lines.next() {
         Some(reason) => format!("{first} {reason}"),
         None => first.to_string(),
     }
+}
+
+/// True for upstream's ``... `<cli> ...` failed (exit N):`` marker, whose
+/// reason -- the child CLI's own stderr -- lands on the next line.
+fn learn_marker_expects_reason_line(line: &str) -> bool {
+    line.ends_with("):") && line.contains(" failed (exit ")
 }
 
 /// Turn a `headroom learn` stdout line into the step shown under the scan timer,
@@ -6087,9 +6215,17 @@ fn execute_headroom_learn_run(
     // every release from 0.8.2 to 0.8.6). Same failure the /stats probe had at
     // 500ms -- a cap tight enough to turn "slow" into "broken".
     //
-    // Only the IDLE cap moves. Upstream's 300s hard cap still bounds a genuine
-    // hang, so this trades a slower failure for runs that now finish.
+    // The idle cap is what catches a genuine hang: a wedged CLI stops
+    // streaming, and 180s of silence kills it whatever the wall clock says.
     command.env("HEADROOM_LEARN_CLI_IDLE_TIMEOUT_SECS", "180");
+    // The hard cap bounds a run that IS still streaming. Upstream's 300s
+    // default was sized for a small digest; a user with 1600 sessions and
+    // 69k calls (RUST-B8) needs the model to read and write for longer than
+    // that while producing events the whole time, and the cap killed a
+    // healthy run at five minutes with a hint to raise this very variable.
+    // Fifteen minutes: this is a background job with its own step timer in
+    // the UI, and the idle cap above still ends a stall within three.
+    command.env("HEADROOM_LEARN_CLI_TIMEOUT_SECS", "900");
     match agent {
         LearnAgent::Claude => {
             // Per-project Claude scan; writes CLAUDE.md / MEMORY.md for the
@@ -7905,23 +8041,24 @@ mod tests {
         cpu_rate_indicates_burn, debounced_tray_runtime_visual, delete_applied_pattern,
         empty_live_learnings_for_projects, exe_path_resolvable, extract_llm_failure_warnings,
         fake_override, fetch_transformations_feed_from, first_savings_body, format_token_count,
-        install_pending_update, is_disk_full_signal, is_endpoint_protection_signal,
-        is_network_download_signal, is_port_conflict_failure, is_prerelease_version,
-        learn_agent_auth_hint, learn_failure_is_agent_auth, learn_failure_signature_source,
-        learn_step_label, lifetime_token_milestone_kind, noop_app_update_progress_emitter,
-        normalize_learn_failure_signature, onboarding_recovery_copy, parse_live_learnings,
-        parse_magic_link_auth, parse_request_count_from_stats_body, parse_request_counts_by_agent,
+        install_pending_update, is_blocked_runtime_dll_signal, is_disk_full_signal,
+        is_endpoint_protection_signal, is_network_download_signal, is_port_conflict_failure,
+        is_prerelease_version, learn_agent_auth_hint, learn_failure_is_agent_auth,
+        learn_failure_signature_source, learn_step_label, lifetime_token_milestone_kind,
+        noop_app_update_progress_emitter, normalize_learn_failure_signature,
+        onboarding_recovery_copy, parse_live_learnings, parse_magic_link_auth,
+        parse_request_count_from_stats_body, parse_request_counts_by_agent,
         parse_updater_endpoint_list, pattern_matches_project, persistent_zero_spend,
         physical_rect_from_rect, read_applied_patterns_for_project, readyz_failed_checks_csv,
         readyz_failure_has_core_unhealthy, readyz_failure_is_upstream_only,
         readyz_outcome_fingerprint_key, recent_savings_days, resolve_release_updater_config,
-        select_updater_endpoints, store_checked_update, strip_connection_noise,
-        tail_bytes_for_sentry, take_pending_magic_link, user_message_for, watchdog_should_be_up,
-        zero_spend_affected_days, AppUpdateProgress, AppUpdateProgressEmitter, AvailableAppUpdate,
-        BootstrapFailureKind, DailySavingsPoint, HeadroomLearnPrereqStatus,
-        InstallPendingUpdateFuture, InstallableAppUpdate, LearnAgent, MonitorBounds, PhysicalRect,
-        QuitSource, TrayRuntimeVisual, DEFAULT_UPDATER_ENDPOINT, DEFAULT_UPDATER_PUBLIC_KEY,
-        PENDING_MAGIC_LINK,
+        select_updater_endpoints, startup_error_fingerprint_key, store_checked_update,
+        strip_connection_noise, tail_bytes_for_sentry, take_pending_magic_link, user_message_for,
+        watchdog_should_be_up, zero_spend_affected_days, AppUpdateProgress,
+        AppUpdateProgressEmitter, AvailableAppUpdate, BootstrapFailureKind, DailySavingsPoint,
+        HeadroomLearnPrereqStatus, InstallPendingUpdateFuture, InstallableAppUpdate, LearnAgent,
+        MonitorBounds, PhysicalRect, QuitSource, TrayRuntimeVisual, DEFAULT_UPDATER_ENDPOINT,
+        DEFAULT_UPDATER_PUBLIC_KEY, PENDING_MAGIC_LINK,
     };
     use parking_lot::Mutex;
     use serde_json::json;
@@ -10509,6 +10646,19 @@ Some unrelated content.
     }
 
     #[test]
+    fn learn_failure_signature_source_never_joins_a_dump_marker() {
+        // RUST-B7: "First 2000 chars:" introduces the model's raw output,
+        // derived from the user's own sessions. It ends at a colon like the
+        // exit marker does, but must never be pulled into a Sentry title.
+        let stderr = "LLM analysis failed: `claude -p --output-format stream-json --verbose` \
+                      returned unparseable output. First 2000 chars:\n\
+                      {\"type\":\"assistant\",\"text\":\"The auth module in src/login.ts ...\"}\n";
+        let signature = learn_failure_signature_source(stderr);
+        assert!(signature.ends_with("First 2000 chars:"), "got: {signature}");
+        assert!(!signature.contains("login.ts"), "got: {signature}");
+    }
+
+    #[test]
     fn learn_failure_signature_source_leaves_a_self_contained_line_alone() {
         let stderr = "ModuleNotFoundError: No module named 'headroom'\nTraceback follows\n";
         assert_eq!(
@@ -10746,6 +10896,68 @@ Some unrelated content.
             "starting headroom background process: port 6768 is occupied by a \
              non-headroom process"
         ));
+    }
+
+    /// RUST-BB/BA/5C verbatim: the App Control verdict seen from inside
+    /// Python. No `os error 4551` -- CPython's ImportError carries Windows'
+    /// localized prose and nothing else -- so the code-based match above
+    /// missed it and one host was filed as three Error-level issues.
+    #[test]
+    fn an_app_control_block_on_a_stdlib_dll_is_recognised_from_the_import_error() {
+        let chain = "unable to keep headroom running in background (prior attempts: \
+                     ~\\AppData\\Local\\Headroom\\headroom\\runtime\\venv\\Scripts\\headroom.exe \
+                     proxy --port 6768 exited with status exit code: 0xffffffff before opening \
+                     port 6768) (onnx probe: onnxruntime imports cleanly): python.exe -m \
+                     headroom.proxy.server exited with status exit code: 1 before opening port 6768\n\
+                     --- log tail ---\n  File \"...\\Lib\\sqlite3\\dbapi2.py\", line 27, in <module>\n    \
+                     from _sqlite3 import *\nImportError: DLL load failed while importing _sqlite3: \
+                     Una directiva de Control de aplicaciones bloqueó este archivo.\n--- end log ---";
+        assert!(is_blocked_runtime_dll_signal(chain));
+        assert!(is_endpoint_protection_signal(chain));
+        assert_eq!(
+            startup_error_fingerprint_key(Some(chain)),
+            Some("startup_endpoint_protection")
+        );
+
+        // Any locale: the structural half needs no prose at all.
+        assert!(is_blocked_runtime_dll_signal(
+            "ImportError: DLL load failed while importing _ssl: 지정된 모듈을 찾을 수 없습니다."
+        ));
+    }
+
+    #[test]
+    fn a_third_party_dll_load_failure_is_not_endpoint_protection() {
+        // onnxruntime/torch failing to load is usually a missing Visual C++
+        // runtime, which has its own hint; it must not be sold as antivirus.
+        for raw in [
+            "ImportError: DLL load failed while importing onnxruntime_pybind11_state: \
+             The specified module could not be found.",
+            "ImportError: DLL load failed while importing _C: The specified module could not be found.",
+            "ModuleNotFoundError: No module named '_sqlite3'",
+        ] {
+            assert!(!is_blocked_runtime_dll_signal(raw), "for: {raw}");
+            assert!(!is_endpoint_protection_signal(raw), "for: {raw}");
+        }
+    }
+
+    #[test]
+    fn startup_error_fingerprint_key_only_names_causes_with_a_remedy() {
+        assert_eq!(startup_error_fingerprint_key(None), None);
+        assert_eq!(
+            startup_error_fingerprint_key(Some(
+                "python.exe -m headroom.proxy.server exited with status exit code: 1 \
+                 before opening port 6768"
+            )),
+            None,
+            "an unclassified crash keeps the fingerprint the existing issues carry"
+        );
+        assert_eq!(
+            startup_error_fingerprint_key(Some(
+                "starting headroom background process: port 6768 is occupied by a \
+                 non-headroom process"
+            )),
+            Some("startup_port_conflict")
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6050,27 +6050,42 @@ fn learn_agent_auth_hint(agent: LearnAgent) -> String {
 /// CLI writes its diagnosis to its own stream, which upstream appends on the
 /// FOLLOWING line. Fingerprinting the marker alone collapsed every distinct
 /// cause onto one issue with nothing in it to tell them apart (RUST-74, then
-/// RUST-B6). When the first line ends at that dangling colon, the next
-/// non-empty line is the actual reason, so join it in.
+/// RUST-B6). The marker's next non-empty line is the actual reason, so join
+/// it in.
+///
+/// The marker is not always the FIRST line: upstream's own logging can precede
+/// it -- RUST-BC's stderr opens with an onnxruntime C-API warning from
+/// `_ort.py`, which is unrelated to the failure and titled the issue anyway.
+/// Preamble like that is per-machine, so fingerprinting it merges every
+/// distinct failure on the hosts that emit it. Scan for the marker instead of
+/// only checking line one.
 ///
 /// stderr only at the call site: stdout echoes written memory files back
 /// verbatim and must never reach a Sentry title.
 fn learn_failure_signature_source(text: &str) -> String {
-    let mut lines = text.lines().map(str::trim).filter(|l| !l.is_empty());
-    let Some(first) = lines.next() else {
+    let lines: Vec<&str> = text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .collect();
+    let Some(first) = lines.first() else {
         return "no output".to_string();
     };
     // Only the `failed (exit N):` marker is followed by a one-line diagnosis
     // worth grouping on. Other markers also end at a colon but introduce a
     // DUMP -- `returned unparseable output. First 2000 chars:` (RUST-B7) is
     // followed by the model's raw output, which is derived from the user's
-    // sessions and must not become a Sentry title.
-    if !learn_marker_expects_reason_line(first) {
+    // sessions and must not become a Sentry title. With no marker at all the
+    // first line is still the best guess.
+    let Some(marker) = lines
+        .iter()
+        .position(|line| learn_marker_expects_reason_line(line))
+    else {
         return first.to_string();
-    }
-    match lines.next() {
-        Some(reason) => format!("{first} {reason}"),
-        None => first.to_string(),
+    };
+    match lines.get(marker + 1) {
+        Some(reason) => format!("{} {reason}", lines[marker]),
+        None => lines[marker].to_string(),
     }
 }
 
@@ -10712,6 +10727,36 @@ Some unrelated content.
         let signature = learn_failure_signature_source(stderr);
         assert!(signature.ends_with("First 2000 chars:"), "got: {signature}");
         assert!(!signature.contains("login.ts"), "got: {signature}");
+    }
+
+    #[test]
+    fn learn_failure_signature_source_skips_unrelated_stderr_preamble() {
+        // RUST-BC: an onnxruntime C-API warning from upstream's own logger is
+        // the first stderr line on any host with onnxruntime < 1.24. It has
+        // nothing to do with the failure, and fingerprinting it merged every
+        // distinct learn failure on those machines onto one issue.
+        let preamble = "onnxruntime 1.20 exposes an older C API than Rust detection requires (1.24+); leaving ORT_DYLIB_PATH unset and using Python detection\n";
+        let stderr = format!(
+            "{preamble}LLM analysis failed: `claude -p --output-format stream-json --verbose` failed (exit 1):\nCredit balance is too low\n"
+        );
+        let signature = learn_failure_signature_source(&stderr);
+        assert!(
+            signature.contains("Credit balance is too low"),
+            "got: {signature}"
+        );
+        assert!(!signature.contains("onnxruntime"), "got: {signature}");
+
+        // Two causes behind the same preamble must still not collapse.
+        let other = format!(
+            "{preamble}LLM analysis failed: `claude -p --output-format stream-json --verbose` failed (exit 1):\nNot logged in \u{b7} Please run /login\n"
+        );
+        assert_ne!(signature, learn_failure_signature_source(&other));
+
+        // No marker anywhere: the first line is still all there is.
+        assert!(
+            learn_failure_signature_source(preamble).starts_with("onnxruntime 1.20"),
+            "preamble-only stderr should fall back to line one"
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1772,11 +1772,21 @@ pub(crate) fn is_blocked_runtime_dll_signal(text: &str) -> bool {
         "select",
         "unicodedata",
     ];
+    // Anchor on `dll load failed` and step over an optional `while `: CPython
+    // 3.8+ writes "while importing", but the copy of this chain that reaches us
+    // is not always CPython's own -- upstream re-wraps the traceback into
+    // `last_startup_error`, and RUST-5C's event carries both spellings across
+    // its two fields. The module name after it is what makes the match
+    // specific, so tolerating the shorter phrasing costs no precision.
+    const MARKER: &str = "dll load failed ";
     let lower = text.to_ascii_lowercase();
     let mut rest = lower.as_str();
-    while let Some(idx) = rest.find("dll load failed while importing ") {
-        let after = &rest[idx + "dll load failed while importing ".len()..];
+    while let Some(idx) = rest.find(MARKER) {
+        let after = &rest[idx + MARKER.len()..];
+        let after = after.strip_prefix("while ").unwrap_or(after);
         let module = after
+            .strip_prefix("importing ")
+            .unwrap_or("")
             .split(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
             .next()
             .unwrap_or("");
@@ -6367,9 +6377,21 @@ fn execute_headroom_learn_run(
                                 // back verbatim (see `learn_step_label`), and that
                                 // is the user's project content -- it must never
                                 // reach Sentry.
+                                // Pre-redacted, and under a `_redacted` key so
+                                // it can be allowlisted in the project's
+                                // Sentry `safeFields` without also un-scrubbing
+                                // the raw `stderr_tail` that already-shipped
+                                // builds keep sending. Same reasoning as
+                                // `proxy_log_tail`: one `sk-ant-…` anywhere in
+                                // the value and the scrubber replaces the whole
+                                // field with `[Filtered]`, which is how RUST-BC
+                                // arrived undiagnosable.
                                 scope.set_extra(
-                                    "stderr_tail",
-                                    crate::state::tail_lines(&stderr, 32).join("\n").into(),
+                                    "stderr_tail_redacted",
+                                    crate::tool_manager::redact_sensitive(
+                                        &crate::state::tail_lines(&stderr, 32).join("\n"),
+                                    )
+                                    .into(),
                                 );
                                 scope.set_fingerprint(Some(
                                     ["headroom_learn_llm_failure", signature.as_str()].as_slice(),
@@ -6476,7 +6498,16 @@ fn execute_headroom_learn_run(
                         .collect::<String>()
                         .as_str(),
                 );
-                let stderr_head: String = stderr.chars().take(2000).collect();
+                // Redacted before Sentry sees them: the agent CLI's stderr on an
+                // auth failure is exactly where a key can appear, and one
+                // `sk-ant-…` costs the WHOLE field to the scrubber (RUST-BC's
+                // stderr arrived `[Filtered]`, so the failure could not be
+                // diagnosed at all). `stdout_head` stays raw and stays scrubbed:
+                // it echoes the user's memory files, which we do not want
+                // readable in Sentry even when it survives.
+                let stderr_head = crate::tool_manager::redact_sensitive(
+                    &stderr.chars().take(2000).collect::<String>(),
+                );
                 let stdout_head: String = stdout.chars().take(2000).collect();
                 let cli_path_str = cli_path
                     .as_ref()
@@ -6511,8 +6542,11 @@ fn execute_headroom_learn_run(
                                     .map(|s| s.to_string().into())
                                     .unwrap_or(serde_json::Value::Null),
                             );
-                            scope.set_extra("output_tail", fail_tail.clone().into());
-                            scope.set_extra("stderr_head", stderr_head.into());
+                            scope.set_extra(
+                                "output_tail_redacted",
+                                crate::tool_manager::redact_sensitive(&fail_tail).into(),
+                            );
+                            scope.set_extra("stderr_head_redacted", stderr_head.into());
                             scope.set_extra("stdout_head", stdout_head.into());
                             scope.set_extra("cli_path", cli_path_str.into());
                             scope.set_extra("project_name", project_name.to_string().into());
@@ -10922,6 +10956,26 @@ Some unrelated content.
         // Any locale: the structural half needs no prose at all.
         assert!(is_blocked_runtime_dll_signal(
             "ImportError: DLL load failed while importing _ssl: 지정된 모듈을 찾을 수 없습니다."
+        ));
+
+        // RUST-5C's `last_startup_error` carries the same verdict without the
+        // `while`, in the copy upstream re-wraps into the error chain. Both
+        // spellings must reach the same verdict or the give-up escalates to
+        // Error for a block we already reported once.
+        let no_while = "ImportError: DLL load failed importing _sqlite3: \
+                        Una directiva de Control de aplicaciones bloqueó este archivo.";
+        assert!(is_blocked_runtime_dll_signal(no_while));
+        assert_eq!(
+            startup_error_fingerprint_key(Some(no_while)),
+            Some("startup_endpoint_protection")
+        );
+        // Still module-scoped, so the looser anchor cannot pull in a
+        // third-party load failure or a bare "DLL load failed:".
+        assert!(!is_blocked_runtime_dll_signal(
+            "ImportError: DLL load failed importing onnxruntime_pybind11_state: not found."
+        ));
+        assert!(!is_blocked_runtime_dll_signal(
+            "ImportError: DLL load failed: The specified module could not be found."
         ));
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5524,6 +5524,26 @@ fn lifetime_token_milestone_kind(milestone_tokens_saved: u64) -> &'static str {
 /// How many recent days of savings travel with the milestone/heartbeat post.
 const SAVINGS_REPORT_DAYS: usize = 30;
 
+/// The output-reduction fields the savings report should carry. The desktop
+/// requests the shaper, but the wheel's rollout gate can block it by channel
+/// (all stable installs on the 0.37.0 wheel). A blocked shaper produces no
+/// live reduction, so the ledger-recomputed figure would report an "estimated"
+/// percentage for a feature that never ran; label it inactive and withhold the
+/// percent instead. Unknown state (older wheels without the rollout block)
+/// reports as before.
+fn reported_output_reduction(
+    reduction: Option<&crate::models::OutputReduction>,
+    shaper_active: Option<bool>,
+) -> (Option<f64>, Option<String>) {
+    if shaper_active == Some(false) {
+        return (None, Some("inactive".to_string()));
+    }
+    (
+        reduction.map(|o| o.reduction_percent),
+        reduction.map(|o| o.method.clone()),
+    )
+}
+
 /// Projects the dashboard's real savings figures into the payload
 /// headroom-web stores for the admin profile. Must be called on the dashboard
 /// BEFORE `maybe_inject_fake_daily_savings`, or demo data reaches the server.
@@ -5536,14 +5556,16 @@ fn savings_report(dashboard: &DashboardState) -> pricing::SavingsReport {
         cache_read_tokens: breakdown.map(|b| b.cache_read_tokens).unwrap_or(0),
         total_input_cost_usd: breakdown.map(|b| b.total_input_cost_usd).unwrap_or(0.0),
         cache_savings_usd: breakdown.map(|b| b.cache_savings_usd).unwrap_or(0.0),
-        output_reduction_percent: dashboard
-            .output_reduction
-            .as_ref()
-            .map(|o| o.reduction_percent),
-        output_reduction_method: dashboard
-            .output_reduction
-            .as_ref()
-            .map(|o| o.method.clone()),
+        output_reduction_percent: reported_output_reduction(
+            dashboard.output_reduction.as_ref(),
+            dashboard.output_shaper_active,
+        )
+        .0,
+        output_reduction_method: reported_output_reduction(
+            dashboard.output_reduction.as_ref(),
+            dashboard.output_shaper_active,
+        )
+        .1,
         reread_tokens: dashboard.reread_tokens,
         reread_compressed_tokens: dashboard.reread_compressed_tokens,
         ccr_retrievals: dashboard.ccr_retrievals,
@@ -11240,5 +11262,45 @@ Some unrelated content.
             None,
             "a reload must not replay a spent code"
         );
+    }
+}
+
+#[cfg(test)]
+mod output_reduction_report_tests {
+    use super::reported_output_reduction;
+    use crate::models::OutputReduction;
+
+    fn reduction() -> OutputReduction {
+        OutputReduction {
+            method: "estimated".to_string(),
+            reduction_percent: 28.0,
+            ci_low_percent: 20.0,
+            ci_high_percent: 36.0,
+            requests: 19_644,
+        }
+    }
+
+    #[test]
+    fn blocked_shaper_reports_inactive_without_a_percent() {
+        let (pct, method) = reported_output_reduction(Some(&reduction()), Some(false));
+        assert_eq!(pct, None);
+        assert_eq!(method.as_deref(), Some("inactive"));
+    }
+
+    #[test]
+    fn active_shaper_reports_the_reduction_unchanged() {
+        let (pct, method) = reported_output_reduction(Some(&reduction()), Some(true));
+        assert_eq!(pct, Some(28.0));
+        assert_eq!(method.as_deref(), Some("estimated"));
+    }
+
+    #[test]
+    fn unknown_rollout_state_keeps_the_old_behavior() {
+        let (pct, method) = reported_output_reduction(Some(&reduction()), None);
+        assert_eq!(pct, Some(28.0));
+        assert_eq!(method.as_deref(), Some("estimated"));
+        let (none_pct, none_method) = reported_output_reduction(None, None);
+        assert_eq!(none_pct, None);
+        assert_eq!(none_method, None);
     }
 }

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -232,6 +232,15 @@ fn skip_sentry(target: &str, msg: &str) -> bool {
     {
         return true;
     }
+    // The direct-wheel fallback warn embeds the full PyPI URL, so message
+    // grouping opened a fresh issue per wheel version and per platform tag for
+    // one condition (RUST-22). `report_wheel_download_fallback` captures it
+    // fingerprinted on the cause class instead; this line stays local.
+    if target.starts_with("headroom_desktop_lib::tool_manager")
+        && msg.starts_with("headroom wheel download failed")
+    {
+        return true;
+    }
     // Boot-validation failure reaches Sentry via the fully-tagged Level::Error
     // capture at the same emit site (capture_runtime_upgrade_failure, RUST-4A:
     // versions, boot diagnostics, pip tail); this bridged warn double-reports
@@ -1034,6 +1043,22 @@ mod tests {
         assert!(!skip_sentry(
             "headroom_desktop_lib::state",
             "some other state warning"
+        ));
+    }
+
+    #[test]
+    fn skips_wheel_download_fallback_warn() {
+        // RUST-22: the full PyPI URL was the message, so every wheel bump and
+        // every platform tag opened a new issue for one condition.
+        assert!(skip_sentry(
+            "headroom_desktop_lib::tool_manager",
+            "headroom wheel download failed (will fall back to pip index): downloading https://files.pythonhosted.org/packages/47/21/headroom_ai-0.37.0-cp310-abi3-macosx_11_0_arm64.whl"
+        ));
+        // The checksum-mismatch path is a hard failure, not this warn, and
+        // must keep its own reporting.
+        assert!(!skip_sentry(
+            "headroom_desktop_lib::tool_manager",
+            "Headroom wheel failed checksum verification; refusing unverified fallback"
         ));
     }
 

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -306,6 +306,13 @@ pub struct DashboardState {
     /// `None` until a verbosity baseline is seeded (the dashboard hides the stat
     /// until then). Always honestly labelled (`method` + confidence band).
     pub output_reduction: Option<OutputReduction>,
+    /// Whether the running wheel's rollout gate actually enabled the output
+    /// shaper. `Some(false)` means blocked (e.g. blocked_by_channel on stable
+    /// with the 0.37.0 wheel): the reduction above then describes an inactive
+    /// feature and must not be reported to the server as a live one. `None`
+    /// on wheels that predate the rollout block.
+    #[serde(default)]
+    pub output_shaper_active: Option<bool>,
     /// Auto-learning progress; `None` when the backend doesn't report it.
     #[serde(default)]
     pub learner_progress: Option<LearnerProgress>,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -8977,6 +8977,29 @@ mod tests {
     }
 
     #[test]
+    fn classify_startup_error_recognises_a_blocked_stdlib_dll_on_windows() {
+        // RUST-BB verbatim shape: the proxy dies importing `_sqlite3` because
+        // Application Control blocked the DLL. No numeric code, localized
+        // prose, and the chain ALSO matches the generic "exited ... before
+        // opening port" branch -- which would have told the user to read a
+        // traceback instead of naming the policy.
+        let raw = "unable to keep headroom running in background: python.exe -m \
+                   headroom.proxy.server --port 6768 exited with status exit code: 1 \
+                   before opening port 6768\n--- log tail ---\n    from _sqlite3 import *\n\
+                   ImportError: DLL load failed while importing _sqlite3: Una directiva de \
+                   Control de aplicaciones bloqueó este archivo.\n--- end log ---";
+        let hint = classify_startup_error(raw).expect("blocked DLL should classify");
+        assert!(
+            hint.contains("endpoint protection"),
+            "expected the endpoint-protection hint, got: {hint}"
+        );
+        assert!(
+            !hint.contains("see the traceback"),
+            "generic branch won: {hint}"
+        );
+    }
+
+    #[test]
     fn classify_startup_error_endpoint_protection_takes_priority_over_port_path() {
         // SIGKILL while waiting on the port could surface as both a
         // port-timeout AND a kill signature. EDR wins because it points to

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -2683,6 +2683,7 @@ impl AppState {
                 session_estimated_tokens_saved: snapshot.session_estimated_tokens_saved,
                 session_savings_pct: snapshot.session_savings_pct,
                 output_reduction,
+                output_shaper_active: stats.as_ref().and_then(|s| s.output_shaper_active),
                 learner_progress,
                 reread_tokens: stats.as_ref().and_then(|s| s.reread_tokens),
                 reread_compressed_tokens: stats.as_ref().and_then(|s| s.reread_compressed_tokens),
@@ -5708,6 +5709,12 @@ struct HeadroomDashboardStats {
     session_total_tokens_sent: Option<u64>,
     savings_history: Vec<HeadroomSavingsHistoryPoint>,
     output_reduction: Option<OutputReduction>,
+    /// Whether the wheel's rollout gate actually enabled the output shaper
+    /// (`rollout.features[name=="proxy_output_shaper"].enabled`). The desktop
+    /// requests the shaper via HEADROOM_OUTPUT_SHAPER=1, but a wheel's rollout
+    /// registry can block it by channel (the 0.37.0 wheel gates it to beta,
+    /// silently disabling it on stable). None on wheels without the block.
+    output_shaper_active: Option<bool>,
     /// Tool-definition tokens the proxy kept out of the model's context by
     /// deferring heavy tool schemas. Process-cumulative (it resets when the
     /// backend restarts), and the backend never writes it to its rollups, so
@@ -6350,6 +6357,17 @@ fn parse_headroom_stats_from_json(body: &str) -> Option<HeadroomDashboardStats> 
         .unwrap_or_default();
 
     let output_reduction = parse_output_reduction(&root);
+    // Rollout truth for the shaper: a ledger-recomputed reduction is only a
+    // live claim while the wheel actually runs the shaper. Absent block => None
+    // (older wheels), and the report gate stays open.
+    let output_shaper_active = value_at_path(&root, &["rollout", "features"])
+        .and_then(Value::as_array)
+        .and_then(|features| {
+            features
+                .iter()
+                .find(|f| f.get("name").and_then(Value::as_str) == Some("proxy_output_shaper"))
+        })
+        .and_then(|f| f.get("enabled").and_then(Value::as_bool));
     // `summary.compression` carries the process-cumulative counter. The
     // `savings.by_layer` block reports the same layer but only over the recent
     // request window, so it is a fallback for shape, not a preferred source.
@@ -6398,6 +6416,7 @@ fn parse_headroom_stats_from_json(body: &str) -> Option<HeadroomDashboardStats> 
             session_total_tokens_sent,
             savings_history,
             output_reduction,
+            output_shaper_active,
             tool_schema_tokens_saved,
         })
     }
@@ -10337,6 +10356,7 @@ mod tests {
         // savings_history backfills the daily buckets the lifetime total (and
         // hence milestones) is derived from; a cumulative 1.5M crosses 100k+1M.
         let stats = HeadroomDashboardStats {
+            output_shaper_active: None,
             reread_tokens: None,
             reread_compressed_tokens: None,
             ccr_retrievals: None,
@@ -10385,6 +10405,7 @@ mod tests {
 
         let first = tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -10408,6 +10429,7 @@ mod tests {
 
         let second = tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -10435,6 +10457,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -10453,6 +10476,7 @@ mod tests {
 
         let reset = tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -10479,6 +10503,7 @@ mod tests {
         let mut tracker = make_tracker();
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -10550,6 +10575,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -10711,7 +10737,16 @@ mod tests {
                     "history_size": 12
                 },
                 "waste_signals": { "reread": 91000, "reread_compressed": 4500 },
-                "compression": { "ccr_retrievals": 6 }
+                "compression": { "ccr_retrievals": 6 },
+                "rollout": {
+                    "features": [
+                        {
+                            "name": "proxy_output_shaper",
+                            "enabled": false,
+                            "decision": "blocked_by_channel"
+                        }
+                    ]
+                }
             }"#,
         )
         .expect("contract fixture must parse");
@@ -10743,6 +10778,10 @@ mod tests {
         let learner = parsed.learner_progress.expect("learner parsed");
         assert_eq!(learner.pending_patterns, 3);
 
+        // The rollout block decides whether the shaper's reduction is a live
+        // claim; blocked_by_channel must parse as an explicit false.
+        assert_eq!(parsed.output_shaper_active, Some(false));
+
         // Retrieval-churn gauges ride the savings report to the server.
         assert_eq!(parsed.reread_tokens, Some(91000));
         assert_eq!(parsed.reread_compressed_tokens, Some(4500));
@@ -10758,6 +10797,9 @@ mod tests {
         )
         .expect("fallback fixture must parse");
         assert_eq!(fallback.tool_schema_tokens_saved, Some(555));
+        // No rollout block (older wheel) => unknown, and the report gate must
+        // stay open rather than mislabel the layer inactive.
+        assert_eq!(fallback.output_shaper_active, None);
     }
 
     #[test]
@@ -11059,6 +11101,7 @@ mod tests {
         // that was already starved.
         let state = AppState::new().expect("state");
         let good = HeadroomDashboardStats {
+            output_shaper_active: None,
             tool_schema_tokens_saved: Some(4_242),
             ..HeadroomDashboardStats::default()
         };
@@ -11676,6 +11719,7 @@ mod tests {
         let mut tracker = make_tracker();
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -11702,6 +11746,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -11724,6 +11769,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -11756,6 +11802,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -11777,6 +11824,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -11871,6 +11919,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -11902,6 +11951,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -11924,6 +11974,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -11955,6 +12006,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -11981,6 +12033,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -12047,6 +12100,7 @@ mod tests {
         ] {
             tracker
                 .observe(&HeadroomDashboardStats {
+                    output_shaper_active: None,
                     reread_tokens: None,
                     reread_compressed_tokens: None,
                     ccr_retrievals: None,
@@ -12078,6 +12132,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -12100,6 +12155,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -12132,6 +12188,7 @@ mod tests {
 
         tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -12150,6 +12207,7 @@ mod tests {
 
         let second = tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -12202,6 +12260,7 @@ mod tests {
 
         let snapshot = tracker
             .observe(&HeadroomDashboardStats {
+                output_shaper_active: None,
                 reread_tokens: None,
                 reread_compressed_tokens: None,
                 ccr_retrievals: None,
@@ -12735,6 +12794,7 @@ mod tests {
 
         // First observation: 1_000 tokens saved, history shows 0→1_000 across hours 9→10.
         tracker.observe(&HeadroomDashboardStats {
+            output_shaper_active: None,
             reread_tokens: None,
             reread_compressed_tokens: None,
             ccr_retrievals: None,
@@ -12757,6 +12817,7 @@ mod tests {
 
         // Second observation: 3_000 tokens saved, history adds hour 11.
         tracker.observe(&HeadroomDashboardStats {
+            output_shaper_active: None,
             reread_tokens: None,
             reread_compressed_tokens: None,
             ccr_retrievals: None,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -559,6 +559,12 @@ pub struct AppState {
     activity_facts: Mutex<ActivityFacts>,
     cached_clients: Mutex<Option<(Vec<ClientStatus>, Instant)>>,
     cached_headroom_stats: Mutex<Option<(Option<HeadroomDashboardStats>, Instant)>>,
+    /// Last `/stats` payload that actually arrived, with the time it did.
+    /// Kept apart from `cached_headroom_stats` so the miss backoff and the
+    /// retention window measure different things: that cache stamps the last
+    /// FETCH (and must expire fast on success, slowly on failure), this one
+    /// stamps the last real ANSWER.
+    last_good_headroom_stats: Mutex<Option<(HeadroomDashboardStats, Instant)>>,
     /// `(history, fetched_at, fresh)` — `fresh` is false when `history` is a
     /// retained last-good value served because the latest fetch failed (proxy
     /// paused/unreachable), so it re-probes on the short miss TTL.
@@ -718,6 +724,7 @@ impl AppState {
             activity_facts: Mutex::new(activity_facts),
             cached_clients: Mutex::new(None),
             cached_headroom_stats: Mutex::new(None),
+            last_good_headroom_stats: Mutex::new(None),
             cached_headroom_history: Mutex::new(None),
             cached_rtk_gain_summary: Mutex::new(None),
             cached_rtk_today_stats: Mutex::new(None),
@@ -2134,15 +2141,59 @@ impl AppState {
         persist_last_known_good_plan(&self.last_known_good_plan_path, &entry);
     }
 
+    /// How long a last-good `/stats` payload may stand in for a failed fetch.
+    ///
+    /// The layers only `/stats` reports (output shaping, tool schema) describe
+    /// configuration, which does not move between polls, so serving the
+    /// previous answer through a transient timeout is honest -- and blanking
+    /// them is the entire harm the warning names ("dashboard loses the
+    /// layers"). Bounded so a backend that is starved for good eventually
+    /// shows absent layers rather than an ever-staler snapshot presented as
+    /// live.
+    const HEADROOM_STATS_RETAIN_LAST_GOOD: Duration = Duration::from_secs(10 * 60);
+
     fn cached_headroom_stats(&self) -> Option<HeadroomDashboardStats> {
+        match self.polled_headroom_stats() {
+            Some(stats) => {
+                *self.last_good_headroom_stats.lock() = Some((stats.clone(), Instant::now()));
+                Some(stats)
+            }
+            // Retain the previous good payload rather than blanking the
+            // dashboard on one timeout. The stamp is the age of the DATA, not
+            // of the failed fetch, so the window counts from the last real
+            // answer and repeated failures cannot extend it.
+            None => self
+                .last_good_headroom_stats
+                .lock()
+                .as_ref()
+                .filter(|(_, at)| at.elapsed() < Self::HEADROOM_STATS_RETAIN_LAST_GOOD)
+                .map(|(stats, _)| stats.clone()),
+        }
+    }
+
+    /// The raw poll behind [`Self::cached_headroom_stats`]: cache lookup, then
+    /// a live fetch on miss. Returns `None` for "this poll had no answer",
+    /// which the caller may still cover with a retained payload.
+    fn polled_headroom_stats(&self) -> Option<HeadroomDashboardStats> {
         // Dashboard polls at 5s; a 4s TTL caused every poll to miss and
         // re-fetch from the proxy. 12s gives at least one cache hit between
         // dashboard refreshes while keeping session savings visibly fresh.
         const TTL: Duration = Duration::from_secs(12);
+        // A failure is held far longer than a success, which is the opposite of
+        // `cached_headroom_history` and deliberate: the dominant failure here
+        // is a `/stats` rebuild that outruns its 15s timeout on a backend busy
+        // serving a session. Re-probing that every 12s keeps a 15s blocking
+        // request in flight essentially all the time, so the poll itself
+        // becomes part of the starvation it is reporting -- RUST-86 shipped
+        // 1601 events that way. At 60s the probe still recovers within a few
+        // seconds of the backend freeing up, at a fifth of the load, and the
+        // retained payload above covers the gap.
+        const MISS_TTL: Duration = Duration::from_secs(60);
         {
             let cache = self.cached_headroom_stats.lock();
             if let Some((stats, at)) = cache.as_ref() {
-                if at.elapsed() < TTL {
+                let ttl = if stats.is_some() { TTL } else { MISS_TTL };
+                if at.elapsed() < ttl {
                     return stats.clone();
                 }
             }
@@ -10975,6 +11026,50 @@ mod tests {
 
         *STATS_FETCH_WARNED_AT.lock() = None;
         *STATS_FETCH_RECOVERED_AT.lock() = None;
+    }
+
+    #[test]
+    fn stats_miss_serves_the_last_good_payload_and_stops_hammering_the_backend() {
+        // RUST-86: a /stats rebuild that outruns its 15s timeout used to blank
+        // the dashboard layers AND get re-probed every 12s, so a 15s blocking
+        // request was in flight nearly all the time against the very backend
+        // that was already starved.
+        let state = AppState::new().expect("state");
+        let good = HeadroomDashboardStats {
+            tool_schema_tokens_saved: Some(4_242),
+            ..HeadroomDashboardStats::default()
+        };
+        *state.last_good_headroom_stats.lock() = Some((good.clone(), Instant::now()));
+        // A failed poll, cached as a miss.
+        *state.cached_headroom_stats.lock() = Some((None, Instant::now()));
+
+        let served = state
+            .cached_headroom_stats()
+            .expect("the retained payload covers a transient failure");
+        assert_eq!(served.tool_schema_tokens_saved, Some(4_242));
+
+        // The miss is still cached: no fetch was attempted, so the 15s probe
+        // is not re-armed on the next dashboard poll.
+        let (cached, _) = (*state.cached_headroom_stats.lock())
+            .clone()
+            .expect("miss stays cached");
+        assert!(
+            cached.is_none(),
+            "serving a retained payload must not \
+             overwrite the miss and reset the backoff"
+        );
+
+        // Past the retention window the layers go absent rather than being
+        // presented as live forever.
+        let stale = Instant::now()
+            .checked_sub(AppState::HEADROOM_STATS_RETAIN_LAST_GOOD + Duration::from_secs(1));
+        if let Some(stale) = stale {
+            *state.last_good_headroom_stats.lock() = Some((good, stale));
+            assert!(
+                state.cached_headroom_stats().is_none(),
+                "a retained payload must expire"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -323,16 +323,17 @@ bytes change mid-conversation and the provider prompt cache busts from
 the first changed byte -- measured 2026-09-01 as a 160-210k-token cache
 re-write every 1-2 requests, dollar cache-hit rate 90% -> 52%, billable
 input $/M up 2.2x, across the 0.35.0 -> 0.37.0 wheel swap. The guard
-ports #3380's reworked floor semantics: the provider-confirmed prefix
-is replayed unconditionally (declining there can only bust the cache),
-while beyond the floor a declined replay ships this turn's fresh bytes
-so background-compression improvements reach the wire, and a collapsed
-floor (cold cache) re-baselines the whole prefix. The confirmed count
-rides a side-channel -- the finalize path hands the overlay the exact
-list object get_last_forwarded_messages() returned, so the patched
-getter records id(list) -> (len, confirmed count) and the overlay
-wrapper pops it by identity; a missed lookup degrades to full replay,
-the cache-safe posture verified live on rc.2. Gated on the
+restores the 0.35.0 replay policy wholesale: v0.35.0's prefix_tracker
+carries NO size bound at all (`_compact_json_bytes` does not exist
+there), so it replayed the cached prefix whenever alignment allowed.
+The bound arrived with #3052 and is what declines -- and a decline over
+already-cached bytes IS the bust. A floor-limited port was shipped in
+0.9.4 and measured WORSE than no guard: replaying only up to the
+confirmed floor leaves every byte past it free to bust, and the fleet
+lost 22% of cache coverage (1.20 -> 0.94 reads/sent, n=17, p=0.007)
+against 4% for users who stayed on 0.9.3. Full replay is the state that
+measured 26% input savings on 0.35.0, so the guard reproduces exactly
+that and nothing cleverer. Gated on the
 runtime NOT having the fix's parameter (enforce_non_inflation in the
 first PR shape, confirmed_frozen_count in the reworked #3380 shape), so
 the first wheel that ships either keeps its own replay policy and this
@@ -906,18 +907,15 @@ if _hd_os.environ.get("HEADROOM_SDK") == "headroom-desktop-proxy":
 
     # Prefix-replay guard (upstream issue #3379 / PR #3380; remove once a
     # wheel ships the fix -- see the module docstring for the cache-bust loop
-    # this prevents and the floor semantics this ports). The confirmed count
-    # travels by object identity: the wheel's finalize path passes the exact
-    # list get_last_forwarded_messages() returned, so the patched getter
-    # records it and the overlay wrapper pops it one-shot; a miss degrades to
-    # full replay (the cache-safe posture verified live on rc.2). The size
-    # bound is probed by calling the original twice on DECLINED turns only:
-    # once bound-on (a shrinking repair is accepted as-is), once with
-    # _compact_json_bytes stubbed to equal-length bytes (inflation compare
-    # goes false; every alignment guard still runs), then spliced at the
-    # floor so improvements beyond the confirmed prefix ship while confirmed
-    # bytes stay byte-identical. Overlay is synchronous on the proxy's single
-    # event loop, so the stub swap cannot interleave. Gated on the runtime
+    # this prevents). Restores v0.35.0's policy: that release has no size
+    # bound at all, so it replayed the cached prefix whenever alignment
+    # allowed. The bound (#3052) declines instead, and declining over
+    # already-cached bytes is the bust. Probed by calling the original twice
+    # on DECLINED turns only: once bound-on (a shrinking repair is accepted
+    # as-is), once with _compact_json_bytes stubbed to equal-length bytes so
+    # the inflation compare goes false while every alignment guard still
+    # runs. Overlay is synchronous on the proxy's single event loop, so the
+    # stub swap cannot interleave. Gated on the runtime
     # NOT having the fix's parameter under either name shipped on #3380
     # (enforce_non_inflation / confirmed_frozen_count), so the first wheel
     # that ships the fix keeps its own replay policy and this block goes
@@ -932,73 +930,26 @@ if _hd_os.environ.get("HEADROOM_SDK") == "headroom-desktop-proxy":
                 name in _hd_pr_pt.overlay_cached_prefix.__code__.co_varnames
                 for name in ("enforce_non_inflation", "confirmed_frozen_count")
             )
-            if (
-                hasattr(_hd_pr_pt, "_compact_json_bytes")
-                and not _hd_pr_fixed
-                and hasattr(_hd_pr_pt, "PrefixCacheTracker")
-                and hasattr(_hd_pr_pt.PrefixCacheTracker, "get_last_forwarded_messages")
-                and hasattr(_hd_pr_pt.PrefixCacheTracker, "get_frozen_message_count")
-            ):
-                # id(list) -> (len, provider-confirmed count); one-shot pop.
-                _hd_pr_floors = {}
-                _hd_pr_orig_getter = (
-                    _hd_pr_pt.PrefixCacheTracker.get_last_forwarded_messages
-                )
-
-                def _hd_pr_getter(self):
-                    result = _hd_pr_orig_getter(self)
-                    try:
-                        if len(_hd_pr_floors) > 128:
-                            _hd_pr_floors.clear()
-                        _hd_pr_floors[id(result)] = (
-                            len(result),
-                            max(int(self.get_frozen_message_count() or 0), 0),
-                        )
-                    except Exception:
-                        pass
-                    return result
-
-                _hd_pr_pt.PrefixCacheTracker.get_last_forwarded_messages = _hd_pr_getter
+            if hasattr(_hd_pr_pt, "_compact_json_bytes") and not _hd_pr_fixed:
                 _hd_pr_orig_overlay = _hd_pr_pt.overlay_cached_prefix
 
                 def _hd_pr_overlay(*args, **kwargs):
                     optimized = args[0] if args else kwargs.get("optimized_messages")
-                    prev_fwd = (
-                        args[3]
-                        if len(args) > 3
-                        else kwargs.get("previous_forwarded_messages")
-                    )
-                    ent = (
-                        _hd_pr_floors.pop(id(prev_fwd), None)
-                        if prev_fwd is not None
-                        else None
-                    )
                     # Pass 1, bound enforced -- identical to stock. A repair
                     # that shrinks (freeze drift, #1850) is accepted as-is.
                     r1 = _hd_pr_orig_overlay(*args, **kwargs)
                     if r1 is not optimized:
                         return r1
-                    # Pass 2, bound neutered; alignment guards still run.
-                    # Only reached on declined turns (post-kompress, a few
-                    # per minute at most).
+                    # Pass 2, bound neutered; every alignment guard still
+                    # runs, so a replay that is not provably correct still
+                    # returns optimized untouched. Reached only on declined
+                    # turns (post-kompress, a few per minute at most).
                     _hd_pr_saved = _hd_pr_pt._compact_json_bytes
                     _hd_pr_pt._compact_json_bytes = lambda value: b""
                     try:
-                        r2 = _hd_pr_orig_overlay(*args, **kwargs)
+                        return _hd_pr_orig_overlay(*args, **kwargs)
                     finally:
                         _hd_pr_pt._compact_json_bytes = _hd_pr_saved
-                    if r2 is optimized:
-                        return optimized
-                    if ent is None or ent[0] != len(prev_fwd) or len(r2) != len(optimized):
-                        # No trustworthy floor: full replay, the verified
-                        # cache-safe fallback.
-                        return r2
-                    floor = min(ent[1], len(r2))
-                    # Confirmed region keeps last turn's forwarded bytes;
-                    # beyond it this turn's fresh output ships, so the
-                    # improvement that triggered the decline lands (and a
-                    # collapsed floor on a cold cache re-baselines fully).
-                    return list(r2[:floor]) + list(optimized[floor:])
 
                 _hd_pr_pt.overlay_cached_prefix = _hd_pr_overlay
     except Exception:
@@ -6275,7 +6226,7 @@ impl ToolManager {
                 &format!("markitdown[all]=={MARKITDOWN_PINNED_VERSION}"),
             ],
             &self.runtime.root_dir,
-            |line| log::info!("markitdown pip: {line}"),
+            |line| log_pip_line("markitdown pip", line),
         )?;
         if !self.markitdown_entrypoint().exists() {
             bail!(
@@ -6315,7 +6266,7 @@ impl ToolManager {
             &["-m", "pip", "uninstall", "-y", "markitdown"],
             &self.runtime.root_dir,
             Some(PIP_OUTPUT_SILENCE_TIMEOUT),
-            &mut |line: &str| log::info!("markitdown pip uninstall: {line}"),
+            &mut |line: &str| log_pip_line("markitdown pip uninstall", line),
         );
         let shim = self.markitdown_shim_path();
         if shim.symlink_metadata().is_ok() {
@@ -6381,7 +6332,7 @@ impl ToolManager {
                 &format!("serena-agent=={SERENA_PINNED_VERSION}"),
             ],
             &self.runtime.root_dir,
-            |line| log::info!("serena pip: {line}"),
+            |line| log_pip_line("serena pip", line),
         )?;
         if !self.serena_entrypoint().exists() {
             bail!(
@@ -8700,6 +8651,12 @@ impl PipOutputCapture {
     }
 
     pub(crate) fn push(&mut self, line: &str) {
+        // pip's `--progress-bar raw` byte counter fires ~4x/second, so 100 of
+        // them is 25 seconds of a single wheel -- it would evict every
+        // Collecting/ERROR line this ring exists to carry into Sentry.
+        if line.starts_with("Progress ") {
+            return;
+        }
         if self.lines.len() >= self.max_lines {
             self.lines.pop_front();
         }
@@ -9936,6 +9893,20 @@ fn build_command(binary: &Path, args: &[&str], cwd: &Path) -> Command {
         .env("LANG", "C.UTF-8")
         .env("PIP_DISABLE_PIP_VERSION_CHECK", "1")
         .env("PIP_NO_INPUT", "1")
+        // pip's default rich progress bar renders nothing at all to a pipe
+        // until a wheel finishes, so a large one is pure silence: torch is
+        // 123 MB and the RUST-9Y host was pulling at ~60 kB/s, i.e. 34 minutes
+        // with no output. That froze the wizard (reads as a hang, the user
+        // quits) and starved `PIP_OUTPUT_SILENCE_TIMEOUT`, which killed a
+        // download that was progressing fine. `raw` prints
+        // "Progress <bytes> of <total>" ~4x/second instead; `pip_line_to_progress`
+        // turns it into the MB counter and `PipOutputCapture` filters it out.
+        //
+        // `raw` needs pip >= 24.1 and an older pip rejects the value outright,
+        // failing every install. Safe here because every pip we run lives in a
+        // venv built from `PYTHON_STANDALONE_RELEASE`, whose ensurepip bundles
+        // pip 25.0.1. Re-check that if the interpreter pin ever moves back.
+        .env("PIP_PROGRESS_BAR", "raw")
         // A host-level pip config (`user = true` in pip.conf, or PIP_USER in
         // the environment) leaks into the managed venv's pip and fails every
         // install with "Can not perform a '--user' install. User site-packages
@@ -10019,6 +9990,16 @@ fn pip_line_to_progress(
         let name = file.rsplit('/').next().unwrap_or(file);
         let pkg = name.split('-').next().unwrap_or(name);
         (format!("Downloading {}...", pkg), false, false)
+    } else if let Some(message) = trimmed
+        .strip_prefix("Progress ")
+        .and_then(raw_progress_message)
+    {
+        // The only output pip produces while a single wheel downloads. It does
+        // not advance the package counter -- the same wheel is still in flight
+        // -- but it keeps the message moving and lets the ETA below re-project
+        // off the growing elapsed time, which is what turns a 34-minute torch
+        // download from "hung at 79%" into "slow".
+        (message, false, false)
     } else if trimmed.starts_with("Installing collected packages") {
         ("Installing packages...".to_string(), false, true)
     } else if let Some(rest) = trimmed.strip_prefix("Successfully installed ") {
@@ -10081,6 +10062,32 @@ fn pip_line_to_progress(
         message,
         eta_seconds: remaining,
         percent,
+    })
+}
+
+/// A pip line into the app log, minus the `PIP_PROGRESS_BAR=raw` byte counter.
+/// That fires ~4x/second per wheel, and the app log's tail is the evidence
+/// `bootstrap_abandoned` ships to Sentry -- one addon install would flush it.
+fn log_pip_line(label: &str, line: &str) {
+    if line.starts_with("Progress ") {
+        return;
+    }
+    log::info!("{label}: {line}");
+}
+
+/// Body of a pip `--progress-bar raw` line ("<bytes> of <total>") as a
+/// user-facing MB counter. `None` for anything that does not parse, so an
+/// unrelated line starting with "Progress " cannot fake download progress.
+/// pip reports 0 as the total when the server sends no Content-Length.
+fn raw_progress_message(rest: &str) -> Option<String> {
+    let (current, total) = rest.split_once(" of ")?;
+    let current: u64 = current.trim().parse().ok()?;
+    let total: u64 = total.trim().parse().ok()?;
+    let mb = |bytes: u64| bytes as f64 / 1_048_576.0;
+    Some(if total > 0 {
+        format!("Downloading {:.1} / {:.1} MB...", mb(current), mb(total))
+    } else {
+        format!("Downloading {:.1} MB...", mb(current))
     })
 }
 
@@ -10418,9 +10425,16 @@ fn plugin_install_failure_category(compact: &str) -> &'static str {
 /// user-facing progress updates instead of staring at a static message for
 /// the 60–90 seconds a large pip install takes.
 /// Kill a pip child that has produced no output at all for this long. pip
-/// streams constantly when healthy (Collecting/Downloading/Installing lines),
-/// so total silence this long means wedged, not slow. Generous enough for the
-/// quietest legitimate gap we ship (large wheel extract on a slow disk).
+/// streams constantly when healthy (Collecting/Downloading/Installing lines,
+/// plus the `PIP_PROGRESS_BAR=raw` byte counter ~4x/second while a wheel is in
+/// flight), so total silence this long means wedged, not slow. Generous enough
+/// for the quietest legitimate gap we ship (large wheel extract on a slow disk).
+///
+/// That env var is load-bearing here, not cosmetic: without it pip renders
+/// nothing to a pipe for the whole of a wheel transfer, so any wheel bigger
+/// than 600s of link -- opencv's 40 MB at the 60 kB/s of RUST-9Y, 11 minutes --
+/// tripped this watchdog and failed an install that was working. Do not drop
+/// the flag without raising this timeout.
 const PIP_OUTPUT_SILENCE_TIMEOUT: Duration = Duration::from_secs(600);
 
 fn run_pip_install_with_retries_streaming<F>(
@@ -10511,6 +10525,27 @@ where
 /// Like `run_command` but streams stdout + stderr line-by-line through
 /// `on_line` in real time. Captures everything for the structured failure
 /// payload so error reporting is unchanged.
+/// Upper bound on each captured stream. Every consumer (`CommandFailure`'s
+/// Display, which the retry path dumps into the app log, and
+/// `compact_pip_failure`) reads the tail, and pip's raw progress counter emits
+/// ~4 lines a second, so an unbounded buffer would hold -- and log -- megabytes
+/// of "Progress N of M" after an hour on a slow link.
+const STREAM_CAPTURE_CAP: usize = 64 * 1024;
+
+/// Drop the head of `sink` down to `STREAM_CAPTURE_CAP`, cutting at a line
+/// boundary (always a char boundary, so this can never split a UTF-8 sequence).
+fn cap_capture(sink: &mut String) {
+    if sink.len() <= STREAM_CAPTURE_CAP {
+        return;
+    }
+    let cut = sink.len() - STREAM_CAPTURE_CAP;
+    let start = sink.as_bytes()[cut..]
+        .iter()
+        .position(|byte| *byte == b'\n')
+        .map_or(sink.len(), |offset| cut + offset + 1);
+    sink.drain(..start);
+}
+
 fn run_command_streaming<F>(
     binary: &Path,
     args: &[&str],
@@ -10580,6 +10615,7 @@ where
                 };
                 sink.push_str(&streamed.line);
                 sink.push('\n');
+                cap_capture(sink);
             }
             // Pipes closed: the child is exiting; fall through to wait().
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
@@ -11261,20 +11297,24 @@ mod tests {
         // keeps its own replay policy.
         assert!(py.contains("in _hd_pr_pt.overlay_cached_prefix.__code__.co_varnames"));
         assert!(py.contains(r#""enforce_non_inflation", "confirmed_frozen_count""#));
-        // Floor side-channel: the getter records the exact returned list by
-        // identity, the overlay pops it ONE-SHOT (no stale reuse), and a
-        // miss degrades to full replay.
-        assert!(
-            py.contains("_hd_pr_pt.PrefixCacheTracker.get_last_forwarded_messages = _hd_pr_getter")
-        );
-        assert!(py.contains("_hd_pr_floors.pop(id(prev_fwd), None)"));
-        // Two-pass probe: bound-on first (shrinking repair accepted), then
-        // stubbed sizing, then the floor splice that lets improvements ship.
+        // Two-pass probe: bound-on first (a shrinking repair is accepted
+        // as-is), then stubbed sizing so the replay always wins -- v0.35.0's
+        // policy, which has no bound at all. The floor-limited variant
+        // shipped in 0.9.4 measured WORSE than no guard (fleet cache
+        // coverage 1.20 -> 0.94) because bytes past the floor still bust, so
+        // there must be no partial splice here.
         assert!(py.contains("if r1 is not optimized:"));
         assert!(py.contains(r#"_hd_pr_pt._compact_json_bytes = lambda value: b"""#));
         assert!(py.contains("_hd_pr_pt._compact_json_bytes = _hd_pr_saved"));
-        assert!(py.contains("return list(r2[:floor]) + list(optimized[floor:])"));
         assert!(py.contains("_hd_pr_pt.overlay_cached_prefix = _hd_pr_overlay"));
+        assert!(
+            !py.contains("_hd_pr_floors"),
+            "floor splice must not come back"
+        );
+        assert!(
+            !py.contains("r2[:floor]"),
+            "partial replay leaves busts past the floor"
+        );
     }
 
     #[test]
@@ -11809,6 +11849,87 @@ mod tests {
         // No more downloading, so the download rate must not be extrapolated
         // into a multi-hour estimate for an unpack.
         assert!(update.eta_seconds <= 60, "eta was {}", update.eta_seconds);
+    }
+
+    #[test]
+    fn pip_progress_keeps_moving_while_one_big_wheel_downloads() {
+        // torch is 123 MB; at the ~60 kB/s RUST-9Y measured that is 34 minutes
+        // in which pip prints no Collecting/Downloading line at all. The raw
+        // byte counter is the only thing keeping the wizard -- and the silence
+        // watchdog -- alive through it.
+        let mut counter = 84u32;
+        let first = pip_line_to_progress(
+            "Progress 47185920 of 128974848",
+            Duration::from_secs(1200),
+            &mut counter,
+            55,
+            80,
+            168,
+        )
+        .expect("a raw progress line is a progress line");
+        assert_eq!(first.message, "Downloading 45.0 / 123.0 MB...");
+        // The same wheel is still in flight, so the package count must not move.
+        assert_eq!(counter, 84);
+
+        let later = pip_line_to_progress(
+            "Progress 52428800 of 128974848",
+            Duration::from_secs(1800),
+            &mut counter,
+            55,
+            80,
+            168,
+        )
+        .expect("a raw progress line is a progress line");
+        assert!(
+            later.eta_seconds > first.eta_seconds,
+            "eta must grow while the same wheel drags on: {} -> {}",
+            first.eta_seconds,
+            later.eta_seconds
+        );
+    }
+
+    #[test]
+    fn pip_progress_ignores_prose_that_merely_starts_with_progress() {
+        let mut counter = 0u32;
+        assert!(pip_line_to_progress(
+            "Progress report written",
+            Duration::from_secs(10),
+            &mut counter,
+            55,
+            80,
+            168,
+        )
+        .is_none());
+        assert_eq!(counter, 0);
+    }
+
+    #[test]
+    fn stream_capture_keeps_the_tail_within_the_cap() {
+        // 4 lines/second for an hour would otherwise be held in memory and
+        // dumped into the app log by the first retry's CommandFailure Display.
+        let mut sink = String::new();
+        for i in 0..20_000 {
+            sink.push_str(&format!("Progress {i} of 128974848 \u{2713}\n"));
+            super::cap_capture(&mut sink);
+        }
+        assert!(sink.len() <= super::STREAM_CAPTURE_CAP);
+        assert!(sink.ends_with("Progress 19999 of 128974848 \u{2713}\n"));
+        // Cut on a line boundary, so a multi-byte char is never split.
+        assert!(sink.starts_with("Progress "));
+    }
+
+    #[test]
+    fn pip_output_capture_drops_raw_progress_lines() {
+        let mut capture = super::PipOutputCapture::new(3);
+        capture.push("Collecting torch==2.12.1");
+        for i in 0..50 {
+            capture.push(&format!("Progress {i} of 128974848"));
+        }
+        capture.push("ERROR: No matching distribution found for torch==2.12.1");
+        let out = capture.into_string();
+        assert!(out.contains("Collecting torch"), "{out}");
+        assert!(out.contains("ERROR: No matching"), "{out}");
+        assert!(!out.contains("Progress "), "{out}");
     }
 
     #[test]

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -3727,6 +3727,7 @@ impl ToolManager {
     {
         let requirements_lock = bootstrap_requirements_lock();
         let lock_path = self.write_headroom_requirements_lock(requirements_lock)?;
+        let dep_total = requirements_lock_package_count(requirements_lock);
 
         progress(BootstrapStepUpdate {
             step: "Repairing dependencies",
@@ -3759,9 +3760,14 @@ impl ToolManager {
             ],
             &self.runtime.root_dir,
             |line| {
-                if let Some(update) =
-                    pip_line_to_progress(line, deps_start.elapsed(), &mut dep_counter, 40, 82)
-                {
+                if let Some(update) = pip_line_to_progress(
+                    line,
+                    deps_start.elapsed(),
+                    &mut dep_counter,
+                    40,
+                    82,
+                    dep_total,
+                ) {
                     if let Ok(mut cb) = progress_ref.try_borrow_mut() {
                         (cb)(BootstrapStepUpdate {
                             step: "Repairing dependencies",
@@ -4271,6 +4277,7 @@ impl ToolManager {
     {
         let requirements_lock = bootstrap_requirements_lock();
         let lock_path = self.write_headroom_requirements_lock(requirements_lock)?;
+        let dep_total = requirements_lock_package_count(requirements_lock);
         let wheel_path = self.wheel_download_path(&release.wheel_url);
 
         progress(BootstrapStepUpdate {
@@ -4293,9 +4300,7 @@ impl ToolManager {
                     ));
                 }
                 Err(download_err) => {
-                    log::warn!(
-                    "headroom wheel download failed (will fall back to pip index): {download_err}"
-                );
+                    report_wheel_download_fallback(&release.wheel_url, &download_err);
                     false
                 }
             };
@@ -4340,9 +4345,14 @@ impl ToolManager {
                 if let Some(cap) = pip_capture {
                     cap.borrow_mut().push(line);
                 }
-                if let Some(update) =
-                    pip_line_to_progress(line, deps_start.elapsed(), &mut dep_counter, 55, 80)
-                {
+                if let Some(update) = pip_line_to_progress(
+                    line,
+                    deps_start.elapsed(),
+                    &mut dep_counter,
+                    55,
+                    80,
+                    dep_total,
+                ) {
                     if let Ok(mut cb) = deps_progress_ref.try_borrow_mut() {
                         (cb)(update);
                     }
@@ -5239,6 +5249,7 @@ impl ToolManager {
             });
 
             let requirements_lock = bootstrap_requirements_lock();
+            let dep_total = requirements_lock_package_count(requirements_lock);
             let lock_path = match self.write_headroom_requirements_lock(requirements_lock) {
                 Ok(p) => p,
                 Err(err) => {
@@ -5275,9 +5286,14 @@ impl ToolManager {
                 &self.runtime.root_dir,
                 |line| {
                     pip_capture.borrow_mut().push(line);
-                    if let Some(update) =
-                        pip_line_to_progress(line, deps_start.elapsed(), &mut dep_counter, 15, 55)
-                    {
+                    if let Some(update) = pip_line_to_progress(
+                        line,
+                        deps_start.elapsed(),
+                        &mut dep_counter,
+                        15,
+                        55,
+                        dep_total,
+                    ) {
                         if let Ok(mut cb) = deps_progress_ref.try_borrow_mut() {
                             (cb)(update);
                         }
@@ -5318,9 +5334,7 @@ impl ToolManager {
                 };
                 }
                 Err(download_err) => {
-                    log::warn!(
-                    "headroom wheel download failed (will fall back to pip index): {download_err}"
-                );
+                    report_wheel_download_fallback(&release.wheel_url, &download_err);
                     false
                 }
             };
@@ -9917,49 +9931,119 @@ fn run_pip_install_with_retries(python: &Path, args: &[&str], cwd: &Path) -> Res
     run_pip_install_with_retries_streaming(python, args, cwd, |_| {})
 }
 
+/// Number of requirement lines in a lock, i.e. how many packages pip will
+/// resolve. `requirements_lock_sha` already defines what counts as a
+/// requirement line (non-blank, non-comment); this is the same rule, so the
+/// two can never disagree about the file's contents.
+fn requirements_lock_package_count(lock: &str) -> u32 {
+    lock.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .count()
+        .try_into()
+        .unwrap_or(u32::MAX)
+}
+
 /// Translate a pip stdout/stderr line into a progress update, or None for
-/// noise. Counter-based monotonic advance inside `[base_percent, max_percent-1]`:
-/// we don't know the final dep count up-front, so each interesting line nudges
-/// the bar forward and it saturates just below the parent step's ceiling.
+/// noise. Monotonic advance inside `[base_percent, max_percent-1]`.
+///
+/// `total_packages` is the requirement count from the lock we handed pip, so
+/// the bar and the ETA track real progress. Pass 0 when it isn't known and the
+/// old counter heuristic applies: each interesting line nudges the bar forward
+/// and it saturates just below the parent step's ceiling.
+///
+/// Both numbers used to be fictional, and on a slow link that read as a hang.
+/// `remaining` was `90 - elapsed`, floored at 5, so past 90 seconds the UI said
+/// "5 seconds left" forever; the percent saturated at `max_percent - 1` after
+/// `span` lines, which ~170 packages cross in the first minute. The Windows
+/// host in RUST-9Y was pulling torch and opencv at ~60 kB/s -- hours of install
+/// behind a bar frozen at 79% claiming it was finishing up -- and quit. The
+/// funnel calls that `bootstrap_abandoned`; the user was told the wrong thing.
 fn pip_line_to_progress(
     line: &str,
     elapsed: Duration,
     counter: &mut u32,
     base_percent: u8,
     max_percent: u8,
+    total_packages: u32,
 ) -> Option<BootstrapStepUpdate> {
     let trimmed = line.trim();
     if trimmed.is_empty() {
         return None;
     }
 
-    let message = if let Some(rest) = trimmed.strip_prefix("Collecting ") {
+    // `resolved` marks the lines that mean every package has been fetched, so
+    // the fraction can jump to 1.0 instead of extrapolating a download rate
+    // through a phase that no longer downloads anything.
+    let (message, collected, resolved) = if let Some(rest) = trimmed.strip_prefix("Collecting ") {
         let spec = rest.split_whitespace().next().unwrap_or(rest);
         let pkg = spec
             .split(|c: char| matches!(c, '=' | '<' | '>' | '!' | '~' | ';' | '['))
             .next()
             .unwrap_or(spec);
-        format!("Fetching {}...", pkg)
+        (format!("Fetching {}...", pkg), true, false)
     } else if let Some(rest) = trimmed.strip_prefix("Downloading ") {
         let file = rest.split_whitespace().next().unwrap_or(rest);
         let name = file.rsplit('/').next().unwrap_or(file);
         let pkg = name.split('-').next().unwrap_or(name);
-        format!("Downloading {}...", pkg)
+        (format!("Downloading {}...", pkg), false, false)
     } else if trimmed.starts_with("Installing collected packages") {
-        "Installing packages...".to_string()
+        ("Installing packages...".to_string(), false, true)
     } else if let Some(rest) = trimmed.strip_prefix("Successfully installed ") {
         let count = rest.split_whitespace().count();
-        format!("Installed {} packages.", count)
+        (format!("Installed {} packages.", count), false, true)
     } else {
         return None;
     };
 
-    *counter = counter.saturating_add(1);
+    // Counts packages, not lines: pip prints a `Collecting` and a `Downloading`
+    // for each one, and counting both made the bar move at twice the true rate.
+    if collected {
+        *counter = counter.saturating_add(1);
+    }
     let span = max_percent.saturating_sub(base_percent).max(1) as u32;
-    let advance = (*counter).min(span.saturating_sub(1));
+
+    // Fraction of the dependency set pip has reached. Transitive deps that are
+    // not in our lock (pip resolves those too) can push the count past the
+    // total, hence the clamp.
+    let fraction = if resolved {
+        1.0
+    } else if total_packages > 0 {
+        (f64::from(*counter) / f64::from(total_packages)).clamp(0.0, 1.0)
+    } else {
+        // Unknown total: the old counter heuristic, which saturates just below
+        // the ceiling once enough packages have gone by.
+        f64::from((*counter).min(span.saturating_sub(1))) / f64::from(span.max(1))
+    };
+
+    let advance = (f64::from(span) * fraction) as u32;
     let percent = (base_percent as u32 + advance).min(max_percent as u32 - 1) as u8;
 
-    let remaining = 90_u64.saturating_sub(elapsed.as_secs()).max(5);
+    // Extrapolate from the rate this machine is actually achieving. A host on a
+    // 60 kB/s link gets an ETA in the hours, which is the truth and reads as
+    // "slow", where the old fixed 90-second budget read as "hung". Needs a real
+    // sample first: the first few packages land before any large wheel and
+    // would project absurdly low.
+    const INITIAL_ETA_SECS: u64 = 90;
+    const MIN_SAMPLE_SECS: u64 = 10;
+    const MIN_SAMPLE_FRACTION: f64 = 0.02;
+    // A whole day, so a genuinely stalled transfer still produces a finite
+    // number rather than saturating into nonsense.
+    const MAX_ETA_SECS: u64 = 24 * 3600;
+    let elapsed_secs = elapsed.as_secs();
+    let remaining = if resolved {
+        // Unpack and install of what is already on disk. Short and roughly
+        // machine-independent next to the download it follows.
+        15
+    } else if elapsed_secs >= MIN_SAMPLE_SECS && fraction >= MIN_SAMPLE_FRACTION {
+        let projected_total = elapsed.as_secs_f64() / fraction;
+        (projected_total - elapsed.as_secs_f64()).clamp(5.0, MAX_ETA_SECS as f64) as u64
+    } else {
+        // Too early to measure. Never floor at a near-zero value the way the
+        // old `.max(5)` did once the budget ran out -- that is what turned a
+        // slow install into an apparently finished one.
+        INITIAL_ETA_SECS.saturating_sub(elapsed_secs).max(30)
+    };
     Some(BootstrapStepUpdate {
         step: "Updating dependencies",
         message,
@@ -10160,6 +10244,102 @@ pub(crate) fn pip_failure_category_with_evidence(compact: &str, evidence: &str) 
     } else {
         "other"
     }
+}
+
+/// Cause class for a direct-wheel download that fell back to the pip index.
+///
+/// The failure's top context is `downloading <url>`, and that URL carries the
+/// wheel version, the platform tag and PyPI's content hash -- so a
+/// message-grouped report opens a NEW issue on every wheel bump and a separate
+/// one per platform for one underlying condition (RUST-22, reopened at 0.37.0
+/// after the same fallback was already triaged at earlier pins). The cause
+/// class is what triage acts on: a proxy blocking files.pythonhosted.org is a
+/// different problem from a 30-minute transfer timeout on a slow link, and
+/// neither changes when the pin does.
+fn wheel_download_failure_category(detail: &str) -> &'static str {
+    let lower = detail.to_ascii_lowercase();
+    if lower.contains("operation timed out") || lower.contains("timed out") {
+        "timeout"
+    } else if let Some(code) = http_status_code_in(&lower) {
+        // A status the CDN actually answered with: 403 is a corporate proxy
+        // or a geo block, 404 a pin whose wheel PyPI never published. Keep
+        // them apart -- only one of the two is ours to fix.
+        match code {
+            403 => "http-403",
+            404 => "http-404",
+            _ => "http-other",
+        }
+    } else if lower.contains("dns error")
+        || lower.contains("failed to lookup address")
+        || lower.contains("nodename nor servname")
+    {
+        "dns"
+    } else if lower.contains("certificate")
+        || lower.contains("tls")
+        || lower.contains("ssl")
+        || lower.contains("self-signed")
+    {
+        // A TLS-terminating corporate proxy without its CA in our trust store.
+        "tls"
+    } else if lower.contains("connection refused")
+        || lower.contains("connection reset")
+        || lower.contains("connection closed")
+        || lower.contains("error sending request")
+        || lower.contains("channel closed")
+    {
+        "connection"
+    } else if crate::is_disk_full_signal(&lower) {
+        "disk-full"
+    } else if lower.contains("permission denied") || lower.contains("access is denied") {
+        "permission"
+    } else {
+        "other"
+    }
+}
+
+/// First HTTP status code in a reqwest `error_for_status` message, which
+/// renders as `HTTP status client error (403 Forbidden) for url (...)`.
+fn http_status_code_in(lower: &str) -> Option<u16> {
+    let idx = lower.find("http status")?;
+    lower[idx..]
+        .split(|c: char| !c.is_ascii_digit())
+        .find(|tok| tok.len() == 3)
+        .and_then(|tok| tok.parse::<u16>().ok())
+}
+
+/// Report a direct-wheel download that fell back to the pip index.
+///
+/// Warning, not Error: the fallback install that follows normally succeeds, so
+/// this is a degraded path rather than a broken one. It still reports, because
+/// a category that shows up fleet-wide (a blocked CDN, an expired cert) is the
+/// early signal that the *next* release's bootstrap will fail outright.
+fn report_wheel_download_fallback(url: &str, err: &anyhow::Error) {
+    let detail = format!("{err:#}");
+    let category = wheel_download_failure_category(&detail);
+    sentry::with_scope(
+        |scope| {
+            scope.set_tag("wheel_download_failure", category);
+            scope.set_extra("wheel_url", url.to_string().into());
+            scope.set_extra(
+                "detail",
+                detail.chars().take(2000).collect::<String>().into(),
+            );
+            scope.set_fingerprint(Some(["wheel-download-fallback", category].as_slice()));
+        },
+        || {
+            sentry::capture_message(
+                &format!(
+                    "headroom wheel download failed ({category}); falling back to the pip index"
+                ),
+                sentry::Level::Warning,
+            );
+        },
+    );
+    // Local only: the fingerprinted capture above is the Sentry path, and the
+    // bridged warn would re-open the URL-grouped issue this replaced. The full
+    // URL and error chain stay in the file log, where triage can still read
+    // them per-machine.
+    log::warn!("headroom wheel download failed (will fall back to pip index): {detail}");
 }
 
 /// Cause class for a partial plugin install, so each shape gets its own Sentry
@@ -10675,18 +10855,18 @@ mod tests {
         looks_like_corrupt_venv_error, parse_lsof_listener, parse_major_minor_patch,
         parse_netstat_listener, parse_pid_from_lsof_detail, parse_ss_listener,
         parse_tasklist_image, path_with_binary_dir, pending_addon_update, pinned_headroom_release,
-        pip_failure_category, plugin_install_failure_category, pre_upstream_concurrency,
-        probe_backend_readyz_ok, proxy_argv_contains_expected_flags,
+        pip_failure_category, pip_line_to_progress, plugin_install_failure_category,
+        pre_upstream_concurrency, probe_backend_readyz_ok, proxy_argv_contains_expected_flags,
         purge_legacy_output_savings_control_arm_once, read_headroom_learn_metadata_from_path,
         receipt_requires_atomic_rebuild, reclaim_orphan_proxy, redact_sensitive,
-        requirements_lock_sha, rtk_distribution_artifact, run_command, sanitize_log_variant,
-        savings_profile_for_runtime, settle_unowned_port, sha256_bytes,
-        summarize_kompress_prefetch_failure, upstream_spawn_env, verify_sha256_file,
-        wait_for_port_free, CommandFailure, HeadroomRelease, ManagedRuntime, PipOutputCapture,
-        PortState, ToolManager, UpgradeOutcome, ATOMIC_REBUILD_FLOOR_VERSION,
-        HEADROOM_LINUX_REQUIREMENTS_LOCK, HEADROOM_PINNED_VERSION, HEADROOM_REQUIREMENTS_LOCK,
-        HEADROOM_WINDOWS_REQUIREMENTS_LOCK, MARKITDOWN_PINNED_VERSION, PLUGIN_ADDONS,
-        PLUGIN_DISPLAY_VERSION, RTK_VERSION, UNKNOWN_OCCUPANT,
+        requirements_lock_package_count, requirements_lock_sha, rtk_distribution_artifact,
+        run_command, sanitize_log_variant, savings_profile_for_runtime, settle_unowned_port,
+        sha256_bytes, summarize_kompress_prefetch_failure, upstream_spawn_env, verify_sha256_file,
+        wait_for_port_free, wheel_download_failure_category, CommandFailure, HeadroomRelease,
+        ManagedRuntime, PipOutputCapture, PortState, ToolManager, UpgradeOutcome,
+        ATOMIC_REBUILD_FLOOR_VERSION, HEADROOM_LINUX_REQUIREMENTS_LOCK, HEADROOM_PINNED_VERSION,
+        HEADROOM_REQUIREMENTS_LOCK, HEADROOM_WINDOWS_REQUIREMENTS_LOCK, MARKITDOWN_PINNED_VERSION,
+        PLUGIN_ADDONS, PLUGIN_DISPLAY_VERSION, RTK_VERSION, UNKNOWN_OCCUPANT,
     };
     use super::{is_python_interpreter, log_tail, path_without_dirs};
     use crate::backend_port;
@@ -11484,6 +11664,158 @@ mod tests {
             .context("configuring Headroom MCP integration")
             .unwrap_err();
         assert!(looks_like_corrupt_venv_error(&wrapped));
+    }
+
+    #[test]
+    fn requirements_lock_package_count_counts_only_requirement_lines() {
+        let lock =
+            "# header\n\nabsl-py==2.4.0\n# inline note\naiohttp==3.13.5\n  \ntorch==2.12.1\n";
+        assert_eq!(requirements_lock_package_count(lock), 3);
+        // Same rule as requirements_lock_sha, so the two never disagree about
+        // what a requirement line is.
+        assert_eq!(requirements_lock_package_count(""), 0);
+        assert_eq!(requirements_lock_package_count("# only comments\n\n"), 0);
+        // The shipped locks must produce a usable total; a zero here silently
+        // reverts pip progress to the old counter heuristic.
+        for lock in [
+            HEADROOM_REQUIREMENTS_LOCK,
+            HEADROOM_LINUX_REQUIREMENTS_LOCK,
+            HEADROOM_WINDOWS_REQUIREMENTS_LOCK,
+        ] {
+            assert!(requirements_lock_package_count(lock) > 10);
+        }
+    }
+
+    #[test]
+    fn pip_progress_eta_tracks_a_slow_link_instead_of_claiming_five_seconds() {
+        // RUST-9Y: 168 packages over a ~60 kB/s link. Ten minutes in, a tenth
+        // of the way through, the old code said "5 seconds" and pinned the bar
+        // just under the ceiling. Both numbers now follow the real rate.
+        let mut counter = 0u32;
+        let total = 168;
+        let mut last = None;
+        for _ in 0..17 {
+            last = pip_line_to_progress(
+                "Collecting torch==2.12.1",
+                Duration::from_secs(600),
+                &mut counter,
+                55,
+                80,
+                total,
+            );
+        }
+        let update = last.expect("Collecting is a progress line");
+        // ~10% done in 600s projects ~90 minutes remaining, not 5 seconds.
+        assert!(
+            update.eta_seconds > 3000 && update.eta_seconds < 7200,
+            "eta was {}",
+            update.eta_seconds
+        );
+        // And the bar reflects the tenth actually done, not the ceiling.
+        assert!(
+            (56..=60).contains(&update.percent),
+            "percent was {}",
+            update.percent
+        );
+    }
+
+    #[test]
+    fn pip_progress_never_reports_a_near_zero_eta_before_it_can_measure() {
+        // The old floor was `.max(5)`, which is what made an install that had
+        // outrun its 90s budget look finished.
+        let mut counter = 0u32;
+        let update = pip_line_to_progress(
+            "Collecting absl-py==2.4.0",
+            Duration::from_secs(300),
+            &mut counter,
+            55,
+            80,
+            0,
+        )
+        .expect("Collecting is a progress line");
+        assert!(update.eta_seconds >= 30, "eta was {}", update.eta_seconds);
+    }
+
+    #[test]
+    fn pip_progress_counts_packages_not_lines() {
+        // pip prints Collecting AND Downloading per package; counting both
+        // advanced the bar at twice the true rate.
+        let mut counter = 0u32;
+        let elapsed = Duration::from_secs(60);
+        pip_line_to_progress(
+            "Collecting torch==2.12.1",
+            elapsed,
+            &mut counter,
+            55,
+            80,
+            100,
+        );
+        pip_line_to_progress(
+            "Downloading torch-2.12.1-cp312-cp312-win_amd64.whl (31 kB)",
+            elapsed,
+            &mut counter,
+            55,
+            80,
+            100,
+        );
+        assert_eq!(counter, 1);
+    }
+
+    #[test]
+    fn pip_progress_resolves_to_the_ceiling_once_downloads_are_done() {
+        let mut counter = 0u32;
+        let update = pip_line_to_progress(
+            "Installing collected packages: absl-py, aiohttp",
+            Duration::from_secs(4000),
+            &mut counter,
+            55,
+            80,
+            168,
+        )
+        .expect("Installing is a progress line");
+        assert_eq!(update.percent, 79);
+        // No more downloading, so the download rate must not be extrapolated
+        // into a multi-hour estimate for an unpack.
+        assert!(update.eta_seconds <= 60, "eta was {}", update.eta_seconds);
+    }
+
+    #[test]
+    fn wheel_download_failure_category_splits_causes_not_urls() {
+        // RUST-22: one condition, a new Sentry issue per wheel version and
+        // platform, because the URL was the message.
+        let cases = [
+            ("downloading https://files.pythonhosted.org/a.whl: operation timed out", "timeout"),
+            (
+                "downloading https://files.pythonhosted.org/a.whl: HTTP status client error (403 Forbidden) for url (https://files.pythonhosted.org/a.whl)",
+                "http-403",
+            ),
+            (
+                "downloading https://files.pythonhosted.org/a.whl: HTTP status client error (404 Not Found) for url (https://files.pythonhosted.org/a.whl)",
+                "http-404",
+            ),
+            ("downloading https://x/a.whl: dns error: failed to lookup address information", "dns"),
+            ("downloading https://x/a.whl: invalid peer certificate: UnknownIssuer", "tls"),
+            ("downloading https://x/a.whl: error sending request", "connection"),
+            ("writing /tmp/a.partial: Permission denied (os error 13)", "permission"),
+            ("downloading https://x/a.whl: something new", "other"),
+        ];
+        for (detail, expected) in cases {
+            assert_eq!(
+                wheel_download_failure_category(detail),
+                expected,
+                "for: {detail}"
+            );
+        }
+        // Two different pins of the same platform wheel must land on one
+        // category -- that is the whole point.
+        assert_eq!(
+            wheel_download_failure_category(
+                "downloading https://files.pythonhosted.org/47/21/headroom_ai-0.37.0-cp310-abi3-macosx_11_0_arm64.whl: operation timed out"
+            ),
+            wheel_download_failure_category(
+                "downloading https://files.pythonhosted.org/99/aa/headroom_ai-0.38.0-cp310-abi3-win_amd64.whl: operation timed out"
+            )
+        );
     }
 
     #[test]

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -5812,7 +5812,22 @@ impl ToolManager {
             // (claude, codex, etc.) was detected on PATH, it wrote nothing --
             // but the direct JSON write path below can still configure the
             // integration. Fall through instead of surfacing a Sentry warning.
-            if !stdout.contains("not detected on this system") {
+            //
+            // A CLI that died importing its own runtime because the machine's
+            // security policy blocked a DLL is the proxy-start failure seen
+            // from a second angle (RUST-B9: same host, same minute, same
+            // `_sqlite3` block as RUST-BB). That block is reported once per
+            // session by `capture_headroom_start_failure`; a second issue
+            // here adds nothing to act on, and the error still propagates so
+            // the caller records the integration as not configured.
+            let blocked_by_policy = crate::is_endpoint_protection_signal(&stderr);
+            if blocked_by_policy {
+                log::warn!(
+                    "headroom mcp install died loading the runtime (endpoint protection); \
+                     reported via the proxy-start capture"
+                );
+            }
+            if !stdout.contains("not detected on this system") && !blocked_by_policy {
                 let detected = detected_claude
                     .as_ref()
                     .map(|p| p.display().to_string())

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -8156,7 +8156,7 @@ pub(crate) fn tail_log_file(path: &Path, max_lines: usize) -> String {
 /// `sk-ant-…` and replaces the entire `proxy_log_tail` field with `[Filtered]`,
 /// which is the single most diagnostic field in `proxy_unreachable_post_boot`.
 /// Pre-redact so the rest of the line survives the scrubber.
-fn redact_sensitive(line: &str) -> String {
+pub(crate) fn redact_sensitive(line: &str) -> String {
     let mut out = String::with_capacity(line.len());
     let bytes = line.as_bytes();
     let mut i = 0;

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -2820,6 +2820,23 @@ impl ToolManager {
                     // never toggles thinking.type, so it cannot 400 a model that
                     // lacks effort support.
                     .env("HEADROOM_OUTPUT_SHAPER", "1")
+                    // The 0.37.0 wheel added a rollout registry that gates
+                    // proxy_output_shaper to the beta channel and defaults the
+                    // channel to stable, which silently disabled the shaper on
+                    // every install despite the request above (/stats showed
+                    // decision: blocked_by_channel). Declaring the beta ring is
+                    // the sanctioned lever: this app pins and qualifies the
+                    // exact wheel it ships through its own rc pipeline, which
+                    // is what the wheel's "beta" ring means. Verified on the
+                    // pinned wheel: flips exactly proxy_output_shaper to
+                    // enabled (decision: legacy_alias); every other feature
+                    // stays not_requested, and qualification_eligible stays
+                    // true (unlike HEADROOM_UNSAFE_ALLOW_UNSTABLE_FEATURES,
+                    // which marks the install ineligible). Wheel Bump Rules:
+                    // diff the FEATURES registry on every bump - a new feature
+                    // with default_enabled_in <= beta would auto-enable for all
+                    // users because of this declaration.
+                    .env("HEADROOM_ROLLOUT_CHANNEL", "beta")
                     // Pin the steering level explicitly. An explicit env is the
                     // manual-override tier in the shaper's level resolution, so it
                     // wins over the per-user learned level written to verbosity.json

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.5-rc.1",
+  "version": "0.9.5-rc.2",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.5-rc.3",
+  "version": "0.9.5-rc.4",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.5-rc.2",
+  "version": "0.9.5-rc.3",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.5-rc.4",
+  "version": "0.9.5-rc.5",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.5-rc.5",
+  "version": "0.9.5",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.4",
+  "version": "0.9.5-rc.1",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1789,6 +1789,12 @@ export default function App() {
   const [stepSignature, setStepSignature] = useState("");
   const [stepStartedAtMs, setStepStartedAtMs] = useState<number | null>(null);
   const [stepEtaSeedSeconds, setStepEtaSeedSeconds] = useState(0);
+  // When the current ETA seed arrived. The backend re-estimates the dependency
+  // install continuously, so its ETA is time-remaining-from-that-update, not a
+  // budget measured from the start of the step -- counting it from
+  // stepStartedAtMs double-charged the elapsed time and pinned a long install
+  // at "finishing up" (RUST-9Y).
+  const [stepEtaSeedAtMs, setStepEtaSeedAtMs] = useState<number | null>(null);
   const [stepBasePercent, setStepBasePercent] = useState(0);
   const [chartResetSignal, setChartResetSignal] = useState(0);
   const [chartMode, setChartMode] = useState<SavingsChartMode>("usd");
@@ -2572,14 +2578,17 @@ export default function App() {
     }
 
     const signature = `${bootstrapProgress.currentStep}|${bootstrapProgress.running}|${bootstrapProgress.complete}|${bootstrapProgress.failed}`;
-    if (signature === stepSignature) {
-      return;
+    if (signature !== stepSignature) {
+      setStepSignature(signature);
+      setStepStartedAtMs(Date.now());
+      setStepBasePercent(bootstrapProgress.overallPercent);
     }
-
-    setStepSignature(signature);
-    setStepStartedAtMs(Date.now());
+    // Re-anchor on every new estimate, step change or not. "Updating
+    // dependencies" is one step for the whole install, so without this the
+    // seed froze at the first frame's 90s and every later, truthful estimate
+    // was discarded -- which is what a slow link saw as a hang.
     setStepEtaSeedSeconds(bootstrapProgress.currentStepEtaSeconds);
-    setStepBasePercent(bootstrapProgress.overallPercent);
+    setStepEtaSeedAtMs(Date.now());
   }, [bootstrapProgress, showInstallProgress, stepSignature]);
 
   // Reaching the final screen IS the end of onboarding, so satisfy the tray's
@@ -3546,7 +3555,12 @@ export default function App() {
       return 0;
     }
 
-    const elapsedSeconds = Math.max(0, (Date.now() - stepStartedAtMs) / 1000);
+    // Measured from the latest estimate, not from the start of the step: the
+    // backend's number is time remaining as of that update (see
+    // stepEtaSeedAtMs). Falling back to the step start keeps the old behaviour
+    // for steps that only ever report one, static ETA.
+    const anchorMs = stepEtaSeedAtMs ?? stepStartedAtMs;
+    const elapsedSeconds = Math.max(0, (Date.now() - anchorMs) / 1000);
     const eta = Math.max(8, stepEtaSeedSeconds || progress.currentStepEtaSeconds || 20);
     const linear = Math.min(0.96, elapsedSeconds / eta);
 
@@ -3580,8 +3594,9 @@ export default function App() {
       return "ETA: unavailable";
     }
 
-    const elapsedSeconds = stepStartedAtMs
-      ? Math.max(0, Math.round((Date.now() - stepStartedAtMs) / 1000))
+    const anchorMs = stepEtaSeedAtMs ?? stepStartedAtMs;
+    const elapsedSeconds = anchorMs
+      ? Math.max(0, Math.round((Date.now() - anchorMs) / 1000))
       : 0;
     const baselineEta = Math.max(stepEtaSeedSeconds, seconds);
     const remainingSeconds = Math.max(0, baselineEta - elapsedSeconds);
@@ -3597,6 +3612,12 @@ export default function App() {
     }
     const mins = Math.floor(remainingSeconds / 60);
     const secs = remainingSeconds % 60;
+    // Past an hour the seconds are noise and the minutes read as a wall of
+    // digits. A slow link legitimately lands here, and "1h 20m" is the number
+    // that stops someone concluding the install is wedged and quitting.
+    if (mins >= 60) {
+      return `ETA: ${Math.floor(mins / 60)}h ${mins % 60}m`;
+    }
     return `ETA: ${mins}m ${secs}s`;
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1795,6 +1795,13 @@ export default function App() {
   // stepStartedAtMs double-charged the elapsed time and pinned a long install
   // at "finishing up" (RUST-9Y).
   const [stepEtaSeedAtMs, setStepEtaSeedAtMs] = useState<number | null>(null);
+  // Highest fraction this step has shown. The ETA anchor above moves on every
+  // estimate, so the time-based fraction restarts near zero each time -- right
+  // for the ETA, wrong for a progress reading, which must never go backwards.
+  // Without this the dependency step reported "0% of this step" for its whole
+  // run, since a pip line (and so a re-anchor) lands more often than once a
+  // second.
+  const stepProgressFloorRef = useRef(0);
   const [stepBasePercent, setStepBasePercent] = useState(0);
   const [chartResetSignal, setChartResetSignal] = useState(0);
   const [chartMode, setChartMode] = useState<SavingsChartMode>("usd");
@@ -2582,6 +2589,7 @@ export default function App() {
       setStepSignature(signature);
       setStepStartedAtMs(Date.now());
       setStepBasePercent(bootstrapProgress.overallPercent);
+      stepProgressFloorRef.current = 0;
     }
     // Re-anchor on every new estimate, step change or not. "Updating
     // dependencies" is one step for the whole install, so without this the
@@ -3564,13 +3572,14 @@ export default function App() {
     const eta = Math.max(8, stepEtaSeedSeconds || progress.currentStepEtaSeconds || 20);
     const linear = Math.min(0.96, elapsedSeconds / eta);
 
-    if (elapsedSeconds <= eta) {
-      return linear;
+    let fraction = linear;
+    if (elapsedSeconds > eta) {
+      const overtime = elapsedSeconds - eta;
+      fraction = Math.min(0.995, linear + overtime / (eta * 10));
     }
 
-    const overtime = elapsedSeconds - eta;
-    const creep = Math.min(0.995, linear + overtime / (eta * 10));
-    return creep;
+    stepProgressFloorRef.current = Math.max(stepProgressFloorRef.current, fraction);
+    return stepProgressFloorRef.current;
   }
 
   function animatedOverallPercent(progress: BootstrapProgress) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,6 +76,7 @@ import {
 import { SetupStallModal } from "./components/SetupStallModal";
 import { UpstreamPanel } from "./components/UpstreamPanel";
 import {
+  authCodeSentMessage,
   buildInstallFailureMailto,
   buildSetupStallMailto,
   describeInvokeError,
@@ -1742,7 +1743,6 @@ export default function App() {
   const [authEmail, setAuthEmail] = useState("");
   const [authCode, setAuthCode] = useState("");
   const [authCodeRequestedFor, setAuthCodeRequestedFor] = useState<string | null>(null);
-  const [authCodeExpirySeconds, setAuthCodeExpirySeconds] = useState(authCodeExpiryFallbackSeconds);
   const [authRequestBusy, setAuthRequestBusy] = useState(false);
   const [authVerifyBusy, setAuthVerifyBusy] = useState(false);
   const [authFlowError, setAuthFlowError] = useState<string | null>(null);
@@ -4197,8 +4197,12 @@ export default function App() {
       });
       reportFunnelStep("email_code_requested");
       setAuthCodeRequestedFor(result.email);
-      setAuthCodeExpirySeconds(result.expiresInSeconds);
-      setAuthFlowSuccess(`We sent a sign-in code to ${result.email}.`);
+      setAuthFlowSuccess(
+        authCodeSentMessage(
+          result.email,
+          result.expiresInSeconds || authCodeExpiryFallbackSeconds
+        )
+      );
     } catch (error) {
       setAuthFlowError(describeInvokeError(error, "Could not send sign-in code."));
     } finally {

--- a/src/lib/appHelpers.test.ts
+++ b/src/lib/appHelpers.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  authCodeSentMessage,
   buildInstallFailureMailto,
   buildSetupStallMailto,
   describeInvokeError,
@@ -795,5 +796,18 @@ describe("scheduledPlanChange", () => {
         account({ subscriptionPendingTier: "max5x", subscriptionPendingEffectiveAt: "soon" })
       )
     ).toBeNull();
+  });
+});
+
+describe("authCodeSentMessage", () => {
+  it("states the expiry and that a resend invalidates the older code", () => {
+    const message = authCodeSentMessage("dev@example.com", 900);
+    expect(message).toContain("dev@example.com");
+    expect(message).toContain("15 minutes");
+    expect(message).toContain("only the newest code works");
+  });
+
+  it("never rounds a short expiry down to zero minutes", () => {
+    expect(authCodeSentMessage("dev@example.com", 20)).toContain("1 minute.");
   });
 });

--- a/src/lib/appHelpers.ts
+++ b/src/lib/appHelpers.ts
@@ -779,3 +779,18 @@ export function buildInstallFailureMailto(context: {
     subject
   )}&body=${encodeURIComponent(body)}`;
 }
+
+// The server keeps exactly one live sign-in code per user: `issue_sign_in_code!`
+// overwrites the previous digest, so a resend silently kills the code in the
+// email still in flight. A stale code then fails with the same "Invalid email
+// or code." as a typo, which is what sends people around the resend loop
+// (identity 3922 asked for eight codes in an hour before one worked). Saying
+// both facts up front is the whole fix.
+export function authCodeSentMessage(email: string, expirySeconds: number): string {
+  const minutes = Math.max(1, Math.round(expirySeconds / 60));
+  const unit = minutes === 1 ? "minute" : "minutes";
+  return (
+    `We sent a sign-in code to ${email}. It expires in ${minutes} ${unit}. ` +
+    "If you ask for another, only the newest code works."
+  );
+}


### PR DESCRIPTION
Promote staging to stable 0.9.5.

Carries everything on staging since v0.9.4: the full-prefix cache replay restore (a4c335e), beta rollout ring declaration, output-reduction reporting fix, learn/Sentry diagnosability fixes, and the monotonic install-step percent.

No release notes file (deliberate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)