### PR TITLE
Make the provider setting one field, and ship it

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -631,10 +631,6 @@ const CANCELLATION_REASONS: { value: string; label: string }[] = [
 const authCodeExpiryFallbackSeconds = 900;
 const APP_UPDATE_BACKGROUND_INITIAL_DELAY_MS = 12_000;
 const APP_UPDATE_BACKGROUND_CHECK_INTERVAL_MS = 60 * 60 * 1000;
-// Provider settings (Settings -> Provider) are hidden while the multi-provider
-// work gets its finishing touches; the upstream-override backend stays live so
-// already-configured setups keep working. Remove the flag when it ships.
-const SHOW_PROVIDER_SETTINGS = false;
 // Desktop activation is a one-shot "this device is live" ping to headroom-web.
 // It is not worth an unbounded retry: a machine that is offline now is usually
 // offline for a while, and every attempt costs a Sentry warning. Five attempts
@@ -7855,7 +7851,7 @@ export default function App() {
                   Off and explicitly-configured setups keep working, but the
                   panel stays hidden until the provider work is finished.
                   Flip to true to restore Settings -> Provider. */}
-              {SHOW_PROVIDER_SETTINGS ? <UpstreamPanel /> : null}
+              <UpstreamPanel />
 
               <article className="soft-card panel-card">
                 <div className="panel-card__header">

--- a/src/components/UpstreamPanel.test.tsx
+++ b/src/components/UpstreamPanel.test.tsx
@@ -36,7 +36,6 @@ describe("UpstreamPanel", () => {
     render(<UpstreamPanel />);
 
     await screen.findByLabelText("Provider base URL");
-    await user.click(screen.getByRole("radio", { name: /Override/ }));
     await user.type(screen.getByLabelText("Provider base URL"), "https://api.z.ai/api/anthropic");
     await user.type(screen.getByLabelText("Provider auth token"), "secret-token");
     await user.click(screen.getByRole("button", { name: "Save and restart" }));
@@ -102,7 +101,6 @@ describe("UpstreamPanel", () => {
     render(<UpstreamPanel />);
 
     await screen.findByLabelText("Provider base URL");
-    await user.click(screen.getByRole("radio", { name: /Fallback/ }));
     await user.type(screen.getByLabelText("Provider base URL"), "api.z.ai");
     await user.click(screen.getByRole("button", { name: "Save and restart" }));
 
@@ -110,13 +108,24 @@ describe("UpstreamPanel", () => {
     expect(screen.queryByText(/restarted/)).not.toBeInTheDocument();
   });
 
-  it("disables the fields until a provider mode is chosen", async () => {
-    respond(off);
+  /// Clearing the URL is the only way to turn the provider back off, so it has
+  /// to reach the backend as "off" -- that is what drops the stored token too.
+  it("turns the provider off when the URL is emptied", async () => {
+    respond(configured, off);
+    const user = userEvent.setup();
     render(<UpstreamPanel />);
 
+    await screen.findByDisplayValue("https://api.z.ai/api/anthropic");
+    await user.clear(screen.getByLabelText("Provider base URL"));
+    await user.click(screen.getByRole("button", { name: "Save and restart" }));
+
     await waitFor(() => {
-      expect(screen.getByLabelText("Provider base URL")).toBeDisabled();
-      expect(screen.getByLabelText("Provider auth token")).toBeDisabled();
+      expect(invokeMock).toHaveBeenCalledWith("save_upstream_override", {
+        mode: "off",
+        baseUrl: "",
+        token: null
+      });
     });
+    expect(await screen.findByText(/restarted on Anthropic/)).toBeInTheDocument();
   });
 });

--- a/src/components/UpstreamPanel.tsx
+++ b/src/components/UpstreamPanel.tsx
@@ -1,31 +1,14 @@
 import { useCallback, useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 
-import type { UpstreamMode, UpstreamOverrideView } from "../lib/types";
-
-const MODES: { id: UpstreamMode; label: string; help: string }[] = [
-  {
-    id: "off",
-    label: "Off",
-    help: "Use Anthropic, or whatever provider cc-switch selects.",
-  },
-  {
-    id: "fallback",
-    label: "Fallback",
-    help: "Start on this provider, but let a cc-switch provider switch take over.",
-  },
-  {
-    id: "override",
-    label: "Override",
-    help: "Always use this provider, even after a cc-switch provider switch.",
-  },
-];
+import type { UpstreamOverrideView } from "../lib/types";
 
 /// Settings for an Anthropic-compatible provider (GLM, Kimi, DeepSeek) that
-/// Headroom should route to. Saving restarts the proxy: the upstream is read
-/// at boot, so a running proxy keeps serving the previous one.
+/// Headroom should route to. The base URL is the whole switch: empty is
+/// Anthropic, anything else wins over a cc-switch provider change. Saving
+/// restarts the proxy -- the upstream is read at boot, so a running proxy
+/// keeps serving the previous one.
 export function UpstreamPanel() {
-  const [mode, setMode] = useState<UpstreamMode>("off");
   const [baseUrl, setBaseUrl] = useState("");
   const [hasToken, setHasToken] = useState(false);
   // Empty means "leave the stored token alone", which is why the field starts
@@ -38,7 +21,6 @@ export function UpstreamPanel() {
   const [notice, setNotice] = useState<string | null>(null);
 
   const apply = useCallback((next: UpstreamOverrideView) => {
-    setMode(next.mode);
     setBaseUrl(next.baseUrl);
     setHasToken(next.hasToken);
     setToken("");
@@ -68,20 +50,24 @@ export function UpstreamPanel() {
     };
   }, [apply]);
 
+  const configured = baseUrl.trim() !== "";
+
   const save = useCallback(async () => {
     setBusy(true);
     setError(null);
     setNotice(null);
     try {
       const saved = await invoke<UpstreamOverrideView>("save_upstream_override", {
-        mode,
+        // Off clears the stored URL and token backend-side, so an emptied
+        // field is how the user turns the provider back off.
+        mode: configured ? "override" : "off",
         baseUrl,
         token: tokenTouched ? token : null,
       });
       apply(saved);
       setNotice(
         saved.mode === "off"
-          ? "Provider override removed. Headroom restarted on the default upstream."
+          ? "Provider removed. Headroom restarted on Anthropic."
           : "Saved. Headroom restarted on this provider.",
       );
     } catch (err) {
@@ -89,9 +75,7 @@ export function UpstreamPanel() {
     } finally {
       setBusy(false);
     }
-  }, [apply, baseUrl, mode, token, tokenTouched]);
-
-  const fieldsDisabled = busy || mode === "off";
+  }, [apply, baseUrl, configured, token, tokenTouched]);
 
   return (
     <article className="soft-card panel-card">
@@ -100,6 +84,7 @@ export function UpstreamPanel() {
           <h3>Provider</h3>
           <p className="panel-card__subtitle">
             Route Headroom at an Anthropic-compatible endpoint instead of Anthropic.
+            Leave the URL empty to use Anthropic.
           </p>
         </div>
       </div>
@@ -108,32 +93,13 @@ export function UpstreamPanel() {
         <p className="upstream-panel__meta">Loading…</p>
       ) : (
         <div className="upstream-panel">
-          <fieldset className="upstream-panel__modes" disabled={busy}>
-            <legend className="upstream-panel__legend">When cc-switch changes provider</legend>
-            {MODES.map((option) => (
-              <label className="upstream-panel__mode" key={option.id}>
-                <input
-                  checked={mode === option.id}
-                  name="upstream-mode"
-                  onChange={() => setMode(option.id)}
-                  type="radio"
-                  value={option.id}
-                />
-                <span>
-                  <strong>{option.label}</strong>
-                  <span className="upstream-panel__mode-help">{option.help}</span>
-                </span>
-              </label>
-            ))}
-          </fieldset>
-
           <label className="upstream-field">
             <span>Base URL</span>
             <span className="upstream-field__input">
               <input
                 aria-label="Provider base URL"
                 autoComplete="off"
-                disabled={fieldsDisabled}
+                disabled={busy}
                 onChange={(event) => setBaseUrl(event.target.value)}
                 placeholder="https://api.z.ai/api/anthropic"
                 spellCheck={false}
@@ -149,7 +115,7 @@ export function UpstreamPanel() {
               <input
                 aria-label="Provider auth token"
                 autoComplete="off"
-                disabled={fieldsDisabled}
+                disabled={busy}
                 onChange={(event) => {
                   setToken(event.target.value);
                   setTokenTouched(true);
@@ -176,7 +142,7 @@ export function UpstreamPanel() {
             >
               {busy ? "Saving…" : "Save and restart"}
             </button>
-            {hasToken && mode !== "off" ? (
+            {hasToken && configured ? (
               <button
                 className="addon-card__link"
                 disabled={busy}
@@ -191,7 +157,7 @@ export function UpstreamPanel() {
             ) : null}
           </div>
 
-          {mode !== "off" ? (
+          {configured ? (
             <p className="upstream-panel__meta">
               Third-party endpoints run lossless compaction only, so payloads stay close
               to what your client sent.

--- a/src/styles.css
+++ b/src/styles.css
@@ -6375,39 +6375,6 @@ html.window-hiding {
   margin-top: 12px;
 }
 
-.upstream-panel__modes {
-  display: grid;
-  gap: 10px;
-  margin: 0;
-  padding: 0;
-  border: 0;
-}
-
-.upstream-panel__legend {
-  padding: 0;
-  font-size: var(--text-sm);
-  font-weight: 700;
-  color: var(--text-secondary);
-}
-
-.upstream-panel__mode {
-  display: flex;
-  gap: 10px;
-  align-items: flex-start;
-  font-size: var(--text-sm);
-  color: var(--text-primary);
-}
-
-.upstream-panel__mode > span {
-  display: grid;
-  gap: 2px;
-}
-
-.upstream-panel__mode-help {
-  font-size: var(--text-xs);
-  color: var(--text-secondary);
-}
-
 .upstream-field {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
Ships the provider setting that has been sitting hidden since 0.9.3-rc.5, cut down to the smallest surface that does the job.

## Why

Andrew runs GLM through Headroom. His `~/.claude/settings.json` hand-sets `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN`, plus all four `ANTHROPIC_DEFAULT_*_MODEL` slots to `glm-5.3[1m]`, and his original complaint was that Headroom rewrites that file out from under him.

The backend half landed in 41729b1. The UI it came with was three radio modes plus two fields, which is a lot of setting for something almost nobody but Andrew will touch, so it shipped hidden behind `SHOW_PROVIDER_SETTINGS` in 613e4f2 and has been dark since.

## What changed

The base URL is the switch. Empty is Anthropic, anything else is the provider, and clearing it turns it back off (which drops the stored token too, backend-side). The three mode radios are gone; what is left is the endpoint and token pair Andrew asked for, plus Save.

- `SHOW_PROVIDER_SETTINGS` removed, panel rendered unconditionally, per the note the flag carried.
- Five mode-only CSS rules deleted with their markup.
- Net -95/+33.

## What did not change

No Rust. `UpstreamOverrideMode::Fallback` stays in the enum and still deserializes from a profile that has it, it is just no longer offered. A beta profile saved as Fallback re-saves as Override the first time the panel is used, which is the stickier of the two and what typing an endpoint in means.

## Still open, deliberately

Andrew's Aug 28 mail asked for pass-through on providers whose payload shapes are not optimized yet. 41729b1 does the opposite, `HEADROOM_LOSSLESS=1`, on the reasoning that raw pass-through saves a token-priced provider nothing. That disagreement is unresolved and not touched here.

## Testing

`npx tsc --noEmit` clean, 418/418 vitest, `check-colors` at baseline 480, `check-no-console` clean. No Rust touched, so no cargo run.

Not visually verified in light/dark: launching the Tauri app was out of scope here. Risk is low, no new colors or tokens, and the two `.upstream-field` rows that remain were rendered against the real stylesheet in both themes when 41729b1 landed. Worth a look before the next stable regardless, since this is the first build where the panel is actually visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
