### PR TITLE
Collapse the Provider card into an Advanced section

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7847,12 +7847,6 @@ export default function App() {
                 ) : null}
               </article>
 
-              {/* Provider settings ship dark for now: the backend default is
-                  Off and explicitly-configured setups keep working, but the
-                  panel stays hidden until the provider work is finished.
-                  Flip to true to restore Settings -> Provider. */}
-              <UpstreamPanel />
-
               <article className="soft-card panel-card">
                 <div className="panel-card__header">
                   <div>
@@ -8001,6 +7995,16 @@ export default function App() {
                   </div>
                 </div>
               </article>
+
+              {/* Power-user settings almost nobody needs, collapsed so they do
+                  not crowd out the ones people came here for. New ones go
+                  inside; the disclosure state is the browser's own. */}
+              <details className="advanced-section">
+                <summary>Advanced</summary>
+                <div className="advanced-section__body">
+                  <UpstreamPanel />
+                </div>
+              </details>
 
               <article className="soft-card panel-card">
                 <div className="panel-card__header">

--- a/src/styles.css
+++ b/src/styles.css
@@ -6368,6 +6368,24 @@ html.window-hiding {
   text-align: center;
 }
 
+/* Power-user settings, collapsed by default. Same disclosure idiom as
+   .savings-breakdown__models. */
+.advanced-section summary {
+  cursor: pointer;
+  font-size: var(--text-sm);
+  font-weight: 700;
+  color: var(--text-secondary);
+  padding: 4px 0;
+}
+
+/* Contents wrapped rather than laid out on the <details> itself: WebKit is
+   unreliable about grid applied directly to a disclosure element. */
+.advanced-section__body {
+  display: grid;
+  gap: 14px;
+  margin-top: 10px;
+}
+
 .upstream-panel {
   display: grid;
   gap: 14px;


### PR DESCRIPTION
Follow-up to #82. The Provider card is two fields plus two paragraphs of explanation for a setting almost nobody but Andrew will touch, and #82 left it open in the middle of Settings.

## What changed

Native `<details>`, collapsed by default, same idiom already used by `.savings-breakdown__models`. No state, no toggle handler, no new component, and the disclosure is keyboard-accessible and screen-reader-correct for free.

Placed after Open on login and before Uninstall: last of the real settings, ahead of the destructive footer. Future power-user settings go inside the section rather than growing the visible page.

Also drops the comment above `<UpstreamPanel />` that still described the `SHOW_PROVIDER_SETTINGS` flag #82 removed. My miss in that PR.

## Testing

`npx tsc --noEmit` clean, 418/418 vitest, `check-colors` at baseline 480 (the two new rules use `--text-sm` / `--text-secondary`).

No new test: the change is a `<details>` wrapper and two CSS rules, and the panel's own five tests still cover its behaviour.

Light mode verified from your screenshot of the expanded card. Dark mode still not verified by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
