### PR TITLE
Pick a provider from a list instead of typing its config

### DIFF
--- a/src-tauri/src/client_adapters.rs
+++ b/src-tauri/src/client_adapters.rs
@@ -2782,19 +2782,70 @@ fn ensure_claude_settings_hook(
 /// `None` removes the key -- used when the override is cleared, so a stale
 /// provider token cannot outlive the endpoint it belonged to.
 pub fn apply_upstream_auth_token(token: Option<&str>) -> Result<()> {
-    match token {
+    set_or_clear_claude_settings_env("ANTHROPIC_AUTH_TOKEN", token)
+}
+
+/// Set one `env` key in the client's settings, or remove it when the value is
+/// absent or empty. Removal goes through `remove_claude_settings_env`, so a key
+/// the user has since changed by hand is left alone rather than deleted.
+fn set_or_clear_claude_settings_env(env_key: &str, value: Option<&str>) -> Result<()> {
+    match value {
         Some(value) if !value.is_empty() => {
-            configure_claude_settings_env("ANTHROPIC_AUTH_TOKEN", value)?;
+            configure_claude_settings_env(env_key, value)?;
             Ok(())
         }
-        _ => {
-            let existing = read_claude_settings_env("ANTHROPIC_AUTH_TOKEN")?;
-            match existing {
-                Some(current) => remove_claude_settings_env("ANTHROPIC_AUTH_TOKEN", &current, None),
-                None => Ok(()),
-            }
-        }
+        _ => match read_claude_settings_env(env_key)? {
+            Some(current) => remove_claude_settings_env(env_key, &current, None),
+            None => Ok(()),
+        },
     }
+}
+
+/// Client settings any third-party provider needs beyond the credential, taken
+/// from a working GLM setup.
+///
+/// Both are provider-agnostic. Anthropic-compatible endpoints are slower than
+/// Anthropic and the stock client timeout aborts long turns; nonessential
+/// traffic goes to Anthropic endpoints a third-party base URL does not serve,
+/// so leaving it on only produces errors.
+const PROVIDER_CLIENT_ENV: &[(&str, &str)] = &[
+    ("API_TIMEOUT_MS", "3000000"),
+    ("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1"),
+];
+
+/// Every model slot Claude Code reads (verified against the shipped binary).
+/// All four are written together: leaving one unset sends that slot's Claude
+/// model id to a provider that does not serve it the moment the user switches
+/// model.
+const PROVIDER_MODEL_SLOT_ENV: &[&str] = &[
+    "ANTHROPIC_DEFAULT_FABLE_MODEL",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+];
+
+/// The rest of the client config a configured provider needs, or a clear of all
+/// of it when `configured` is false -- a stale model id must not outlive the
+/// endpoint that served it, same rule as the token.
+///
+/// `model` and `context_window` stay optional even with a provider set: a
+/// provider that maps Claude model ids itself needs neither.
+pub fn apply_upstream_provider_env(
+    configured: bool,
+    model: Option<&str>,
+    context_window: Option<&str>,
+) -> Result<()> {
+    for (env_key, value) in PROVIDER_CLIENT_ENV {
+        set_or_clear_claude_settings_env(env_key, configured.then_some(*value))?;
+    }
+    let model = model.filter(|_| configured);
+    for env_key in PROVIDER_MODEL_SLOT_ENV {
+        set_or_clear_claude_settings_env(env_key, model)?;
+    }
+    set_or_clear_claude_settings_env(
+        "CLAUDE_CODE_AUTO_COMPACT_WINDOW",
+        context_window.filter(|_| configured),
+    )
 }
 
 /// Current value of one `env` key in `~/.claude/settings.json`, if any.
@@ -11456,5 +11507,47 @@ export ANTHROPIC_BASE_URL=http://127.0.0.1:6767
                 .any(|w| w.contains("~/.local/bin/headroom")),
             "absorbing the plugin hook must not hide a real OSS CLI"
         );
+    }
+    /// The provider env keys are what make a third-party endpoint actually
+    /// answer (Andrew's GLM setup). Clearing the provider must take all of
+    /// them back out again rather than leaving Claude Code pinned to a model
+    /// Anthropic has never heard of.
+    #[test]
+    #[serial_test::serial]
+    fn provider_env_round_trips_through_claude_settings() {
+        let home = TestHome::new();
+        let settings = home.path().join(".claude").join("settings.json");
+        fs::create_dir_all(settings.parent().unwrap()).unwrap();
+        fs::write(&settings, r#"{"env": {"USER_KEY": "keep me"}}"#).unwrap();
+
+        super::apply_upstream_provider_env(true, Some("glm-4.6"), Some("1000000")).unwrap();
+        let written = read_settings_json(&settings);
+        assert_eq!(written["env"]["API_TIMEOUT_MS"].as_str(), Some("3000000"));
+        assert_eq!(
+            written["env"]["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"].as_str(),
+            Some("1")
+        );
+        assert_eq!(
+            written["env"]["CLAUDE_CODE_AUTO_COMPACT_WINDOW"].as_str(),
+            Some("1000000")
+        );
+        for slot in super::PROVIDER_MODEL_SLOT_ENV {
+            assert_eq!(written["env"][slot].as_str(), Some("glm-4.6"), "{slot}");
+        }
+
+        super::apply_upstream_provider_env(false, None, None).unwrap();
+        let cleared = read_settings_json(&settings);
+        let env = cleared["env"].as_object().expect("env survives");
+        for key in super::PROVIDER_MODEL_SLOT_ENV.iter().chain(
+            [
+                "API_TIMEOUT_MS",
+                "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+                "CLAUDE_CODE_AUTO_COMPACT_WINDOW",
+            ]
+            .iter(),
+        ) {
+            assert!(!env.contains_key(*key), "{key} still set after clearing");
+        }
+        assert_eq!(env["USER_KEY"].as_str(), Some("keep me"));
     }
 }

--- a/src-tauri/src/client_adapters.rs
+++ b/src-tauri/src/client_adapters.rs
@@ -2813,38 +2813,103 @@ const PROVIDER_CLIENT_ENV: &[(&str, &str)] = &[
     ("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1"),
 ];
 
-/// Every model slot Claude Code reads (verified against the shipped binary).
-/// All four are written together: leaving one unset sends that slot's Claude
-/// model id to a provider that does not serve it the moment the user switches
-/// model.
+/// The model slots Claude Code reads for its big tiers (verified against the
+/// shipped binary). All are written together: leaving one unset sends that
+/// slot's Claude model id to a provider that does not serve it the moment the
+/// user switches model.
 const PROVIDER_MODEL_SLOT_ENV: &[&str] = &[
     "ANTHROPIC_DEFAULT_FABLE_MODEL",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
     "ANTHROPIC_DEFAULT_OPUS_MODEL",
     "ANTHROPIC_DEFAULT_SONNET_MODEL",
 ];
 
-/// The rest of the client config a configured provider needs, or a clear of all
-/// of it when `configured` is false -- a stale model id must not outlive the
-/// endpoint that served it, same rule as the token.
+/// The cheap tier Claude Code uses for background work (file summaries, title
+/// generation). Kept separate from the big slots because every provider below
+/// serves a smaller, faster model for it, and pointing it at the big model
+/// costs real money and latency on work the user never reads.
+const PROVIDER_SMALL_MODEL_SLOT_ENV: &str = "ANTHROPIC_DEFAULT_HAIKU_MODEL";
+
+/// A provider Headroom can configure from a token alone.
 ///
-/// `model` and `context_window` stay optional even with a provider set: a
-/// provider that maps Claude model ids itself needs neither.
-pub fn apply_upstream_provider_env(
-    configured: bool,
-    model: Option<&str>,
-    context_window: Option<&str>,
-) -> Result<()> {
+/// Every value is from that vendor's own Claude Code documentation, read
+/// 2026-09-02. Model ids age faster than releases do, which is why the panel
+/// also offers Custom: a stale preset is escapable without an app update.
+pub struct ProviderPreset {
+    pub id: &'static str,
+    pub label: &'static str,
+    pub base_url: &'static str,
+    /// Opus, Sonnet and Fable slots.
+    pub model: &'static str,
+    /// Haiku slot.
+    pub small_model: &'static str,
+    pub context_window: &'static str,
+}
+
+pub const PROVIDER_PRESETS: &[ProviderPreset] = &[
+    ProviderPreset {
+        id: "glm",
+        label: "GLM (Z.ai)",
+        base_url: "https://api.z.ai/api/anthropic",
+        model: "glm-5.3[1m]",
+        small_model: "glm-4.7",
+        context_window: "1000000",
+    },
+    ProviderPreset {
+        id: "kimi",
+        label: "Kimi (Moonshot)",
+        base_url: "https://api.moonshot.ai/anthropic",
+        model: "kimi-k3[1m]",
+        small_model: "kimi-k2.7-code",
+        context_window: "1000000",
+    },
+    ProviderPreset {
+        id: "minimax",
+        label: "MiniMax",
+        base_url: "https://api.minimax.io/anthropic",
+        model: "MiniMax-M3",
+        small_model: "MiniMax-M3",
+        context_window: "512000",
+    },
+    ProviderPreset {
+        id: "deepseek",
+        label: "DeepSeek",
+        base_url: "https://api.deepseek.com/anthropic",
+        model: "deepseek-v4-pro[1m]",
+        small_model: "deepseek-v4-flash",
+        context_window: "786432",
+    },
+];
+
+pub fn provider_preset(id: &str) -> Option<&'static ProviderPreset> {
+    PROVIDER_PRESETS.iter().find(|preset| preset.id == id)
+}
+
+/// The client config a configured provider needs beyond the credential. An
+/// empty field means "do not write that key", which is what a provider that
+/// maps Claude model ids itself wants.
+pub struct ProviderClientEnv<'a> {
+    pub model: &'a str,
+    pub small_model: &'a str,
+    pub context_window: &'a str,
+}
+
+/// Write the rest of the client config a configured provider needs, or clear
+/// all of it with `None` -- a stale model id must not outlive the endpoint that
+/// served it, same rule as the token.
+pub fn apply_upstream_provider_env(env: Option<ProviderClientEnv<'_>>) -> Result<()> {
     for (env_key, value) in PROVIDER_CLIENT_ENV {
-        set_or_clear_claude_settings_env(env_key, configured.then_some(*value))?;
+        set_or_clear_claude_settings_env(env_key, env.is_some().then_some(*value))?;
     }
-    let model = model.filter(|_| configured);
     for env_key in PROVIDER_MODEL_SLOT_ENV {
-        set_or_clear_claude_settings_env(env_key, model)?;
+        set_or_clear_claude_settings_env(env_key, env.as_ref().map(|env| env.model))?;
     }
     set_or_clear_claude_settings_env(
+        PROVIDER_SMALL_MODEL_SLOT_ENV,
+        env.as_ref().map(|env| env.small_model),
+    )?;
+    set_or_clear_claude_settings_env(
         "CLAUDE_CODE_AUTO_COMPACT_WINDOW",
-        context_window.filter(|_| configured),
+        env.as_ref().map(|env| env.context_window),
     )
 }
 
@@ -11520,7 +11585,13 @@ export ANTHROPIC_BASE_URL=http://127.0.0.1:6767
         fs::create_dir_all(settings.parent().unwrap()).unwrap();
         fs::write(&settings, r#"{"env": {"USER_KEY": "keep me"}}"#).unwrap();
 
-        super::apply_upstream_provider_env(true, Some("glm-4.6"), Some("1000000")).unwrap();
+        let glm = super::provider_preset("glm").expect("glm preset exists");
+        super::apply_upstream_provider_env(Some(super::ProviderClientEnv {
+            model: glm.model,
+            small_model: glm.small_model,
+            context_window: glm.context_window,
+        }))
+        .unwrap();
         let written = read_settings_json(&settings);
         assert_eq!(written["env"]["API_TIMEOUT_MS"].as_str(), Some("3000000"));
         assert_eq!(
@@ -11529,13 +11600,18 @@ export ANTHROPIC_BASE_URL=http://127.0.0.1:6767
         );
         assert_eq!(
             written["env"]["CLAUDE_CODE_AUTO_COMPACT_WINDOW"].as_str(),
-            Some("1000000")
+            Some(glm.context_window)
         );
         for slot in super::PROVIDER_MODEL_SLOT_ENV {
-            assert_eq!(written["env"][slot].as_str(), Some("glm-4.6"), "{slot}");
+            assert_eq!(written["env"][slot].as_str(), Some(glm.model), "{slot}");
         }
+        // The cheap tier must NOT be pointed at the big model.
+        assert_eq!(
+            written["env"][super::PROVIDER_SMALL_MODEL_SLOT_ENV].as_str(),
+            Some(glm.small_model)
+        );
 
-        super::apply_upstream_provider_env(false, None, None).unwrap();
+        super::apply_upstream_provider_env(None).unwrap();
         let cleared = read_settings_json(&settings);
         let env = cleared["env"].as_object().expect("env survives");
         for key in super::PROVIDER_MODEL_SLOT_ENV.iter().chain(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4537,6 +4537,8 @@ struct UpstreamOverrideView {
     mode: &'static str,
     base_url: String,
     has_token: bool,
+    model: String,
+    context_window: String,
 }
 
 impl From<crate::state::UpstreamOverride> for UpstreamOverrideView {
@@ -4550,6 +4552,8 @@ impl From<crate::state::UpstreamOverride> for UpstreamOverrideView {
             },
             base_url: value.base_url,
             has_token: value.has_token,
+            model: value.model,
+            context_window: value.context_window,
         }
     }
 }
@@ -4565,12 +4569,18 @@ async fn get_upstream_override(app: AppHandle) -> UpstreamOverrideView {
 /// `token`: `None` leaves the stored one alone (the field renders as "set" and
 /// is only sent when the user types a new one), `Some("")` clears it, anything
 /// else replaces it.
+///
+/// `model` and `context_window` are optional even with a provider configured;
+/// empty means "do not write that key", which leaves a provider that maps
+/// Claude model ids itself alone.
 #[tauri::command]
 async fn save_upstream_override(
     app: AppHandle,
     mode: String,
     base_url: String,
     token: Option<String>,
+    model: Option<String>,
+    context_window: Option<String>,
 ) -> Result<UpstreamOverrideView, String> {
     use crate::state::{UpstreamOverride, UpstreamOverrideMode};
 
@@ -4619,10 +4629,36 @@ async fn save_upstream_override(
         }
     };
 
+    // Same rule as base_url and the token: Off keeps nothing, so a stale model
+    // id cannot outlive the endpoint that served it.
+    let configured = mode != UpstreamOverrideMode::Off;
+    let model = if configured {
+        model.unwrap_or_default().trim().to_string()
+    } else {
+        String::new()
+    };
+    let context_window = if configured {
+        let raw = context_window.unwrap_or_default().trim().to_string();
+        if !raw.is_empty() && !raw.chars().all(|c| c.is_ascii_digit()) {
+            return Err("The context window must be a whole number of tokens.".into());
+        }
+        raw
+    } else {
+        String::new()
+    };
+    client_adapters::apply_upstream_provider_env(
+        configured,
+        Some(model.as_str()).filter(|value| !value.is_empty()),
+        Some(context_window.as_str()).filter(|value| !value.is_empty()),
+    )
+    .map_err(|err| err.to_string())?;
+
     let next = UpstreamOverride {
         mode,
         base_url,
         has_token,
+        model,
+        context_window,
     };
     let state: tauri::State<'_, AppState> = app.state();
     state.set_upstream_override(next.clone());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4537,8 +4537,21 @@ struct UpstreamOverrideView {
     mode: &'static str,
     base_url: String,
     has_token: bool,
+    provider: String,
     model: String,
     context_window: String,
+    /// The presets the dropdown offers. Shipped with the view so the labels and
+    /// the values that get written can never drift apart.
+    providers: Vec<ProviderPresetView>,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ProviderPresetView {
+    id: &'static str,
+    label: &'static str,
+    base_url: &'static str,
+    model: &'static str,
 }
 
 impl From<crate::state::UpstreamOverride> for UpstreamOverrideView {
@@ -4552,8 +4565,18 @@ impl From<crate::state::UpstreamOverride> for UpstreamOverrideView {
             },
             base_url: value.base_url,
             has_token: value.has_token,
+            provider: value.provider,
             model: value.model,
             context_window: value.context_window,
+            providers: client_adapters::PROVIDER_PRESETS
+                .iter()
+                .map(|preset| ProviderPresetView {
+                    id: preset.id,
+                    label: preset.label,
+                    base_url: preset.base_url,
+                    model: preset.model,
+                })
+                .collect(),
         }
     }
 }
@@ -4570,15 +4593,18 @@ async fn get_upstream_override(app: AppHandle) -> UpstreamOverrideView {
 /// is only sent when the user types a new one), `Some("")` clears it, anything
 /// else replaces it.
 ///
-/// `model` and `context_window` are optional even with a provider configured;
-/// empty means "do not write that key", which leaves a provider that maps
-/// Claude model ids itself alone.
+/// `provider` is a preset id from `client_adapters::PROVIDER_PRESETS`, and when
+/// set it supplies the URL, the model ids and the context window -- the user
+/// only brings a token. Empty means the endpoint was entered by hand, in which
+/// case `model` and `context_window` are optional: empty means "do not write
+/// that key", which leaves a provider that maps Claude model ids itself alone.
 #[tauri::command]
 async fn save_upstream_override(
     app: AppHandle,
     mode: String,
     base_url: String,
     token: Option<String>,
+    provider: Option<String>,
     model: Option<String>,
     context_window: Option<String>,
 ) -> Result<UpstreamOverrideView, String> {
@@ -4591,12 +4617,24 @@ async fn save_upstream_override(
         other => return Err(format!("unknown upstream mode: {other}")),
     };
 
+    let provider = provider.unwrap_or_default().trim().to_string();
+    let preset = match provider.as_str() {
+        "" => None,
+        id => Some(
+            client_adapters::provider_preset(id)
+                .ok_or_else(|| format!("unknown provider: {id}"))?,
+        ),
+    };
+
     // Off keeps neither URL nor token: a cleared override must not leave a
     // provider credential behind in the client config for the next launch.
     let base_url = if mode == UpstreamOverrideMode::Off {
         String::new()
     } else {
-        crate::state::normalize_upstream_base_url(&base_url)?
+        match preset {
+            Some(preset) => preset.base_url.to_string(),
+            None => crate::state::normalize_upstream_base_url(&base_url)?,
+        }
     };
 
     let has_token = if mode == UpstreamOverrideMode::Off {
@@ -4632,31 +4670,39 @@ async fn save_upstream_override(
     // Same rule as base_url and the token: Off keeps nothing, so a stale model
     // id cannot outlive the endpoint that served it.
     let configured = mode != UpstreamOverrideMode::Off;
-    let model = if configured {
-        model.unwrap_or_default().trim().to_string()
-    } else {
-        String::new()
-    };
-    let context_window = if configured {
-        let raw = context_window.unwrap_or_default().trim().to_string();
-        if !raw.is_empty() && !raw.chars().all(|c| c.is_ascii_digit()) {
-            return Err("The context window must be a whole number of tokens.".into());
+    let (model, small_model, context_window) = match (configured, preset) {
+        (false, _) => (String::new(), String::new(), String::new()),
+        (true, Some(preset)) => (
+            preset.model.to_string(),
+            preset.small_model.to_string(),
+            preset.context_window.to_string(),
+        ),
+        (true, None) => {
+            // A hand-entered endpoint gets the one model id the user gave us in
+            // every slot, cheap tier included: we have no way to know which
+            // smaller model it serves.
+            let model = model.unwrap_or_default().trim().to_string();
+            let window = context_window.unwrap_or_default().trim().to_string();
+            if !window.is_empty() && !window.chars().all(|c| c.is_ascii_digit()) {
+                return Err("The context window must be a whole number of tokens.".into());
+            }
+            (model.clone(), model, window)
         }
-        raw
-    } else {
-        String::new()
     };
-    client_adapters::apply_upstream_provider_env(
-        configured,
-        Some(model.as_str()).filter(|value| !value.is_empty()),
-        Some(context_window.as_str()).filter(|value| !value.is_empty()),
-    )
+    client_adapters::apply_upstream_provider_env(configured.then_some(
+        client_adapters::ProviderClientEnv {
+            model: &model,
+            small_model: &small_model,
+            context_window: &context_window,
+        },
+    ))
     .map_err(|err| err.to_string())?;
 
     let next = UpstreamOverride {
         mode,
         base_url,
         has_token,
+        provider: if configured { provider } else { String::new() },
         model,
         context_window,
     };
@@ -4686,6 +4732,9 @@ async fn save_upstream_override(
             // a token are set.
             "has_base_url": !next.base_url.is_empty(),
             "has_token": next.has_token,
+            // Which preset, or "custom" -- enough to see whether the dropdown
+            // covers what people actually run without logging endpoints.
+            "provider": if next.provider.is_empty() { "custom" } else { next.provider.as_str() },
         })),
     );
     Ok(next.into())

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -4118,6 +4118,12 @@ pub struct UpstreamOverride {
     /// Normalized by `normalize_upstream_base_url`; empty when unset.
     pub base_url: String,
     pub has_token: bool,
+    /// Model id the provider serves, written to every `ANTHROPIC_DEFAULT_*_MODEL`
+    /// slot. Empty when unset, which leaves the provider to map Claude ids.
+    pub model: String,
+    /// Context window in tokens for `CLAUDE_CODE_AUTO_COMPACT_WINDOW`. Kept as
+    /// a string because empty means unset; digits are validated on save.
+    pub context_window: String,
 }
 
 impl UpstreamOverride {
@@ -9306,6 +9312,7 @@ mod tests {
                 mode: super::UpstreamOverrideMode::Override,
                 base_url: "https://api.z.ai/api/anthropic".into(),
                 has_token: true,
+                ..Default::default()
             },
             onboarding_recovery_notified: true,
             first_savings_notified: true,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -4118,7 +4118,11 @@ pub struct UpstreamOverride {
     /// Normalized by `normalize_upstream_base_url`; empty when unset.
     pub base_url: String,
     pub has_token: bool,
-    /// Model id the provider serves, written to every `ANTHROPIC_DEFAULT_*_MODEL`
+    /// Id of the preset in `client_adapters::PROVIDER_PRESETS` this came from,
+    /// or empty for a hand-entered endpoint. Only the dropdown reads it: the
+    /// URL and model below are already resolved.
+    pub provider: String,
+    /// Model id the provider serves, written to every big `ANTHROPIC_DEFAULT_*_MODEL`
     /// slot. Empty when unset, which leaves the provider to map Claude ids.
     pub model: String,
     /// Context window in tokens for `CLAUDE_CODE_AUTO_COMPACT_WINDOW`. Kept as

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -13934,6 +13934,7 @@ S(('127.0.0.1', int(sys.argv[1])), H).serve_forever()
             mode: UpstreamOverrideMode::Fallback,
             base_url: "https://api.z.ai/api/anthropic".into(),
             has_token: true,
+            ..Default::default()
         });
         assert_eq!(fallback.target_api_url, "https://api.z.ai/api/anthropic");
         // Fallback boots at the endpoint but lets a cc-switch capture win.
@@ -13944,6 +13945,7 @@ S(('127.0.0.1', int(sys.argv[1])), H).serve_forever()
             mode: UpstreamOverrideMode::Override,
             base_url: "https://api.z.ai/api/anthropic".into(),
             has_token: true,
+            ..Default::default()
         });
         assert_eq!(overridden.pin_upstream, "1");
         assert_eq!(overridden.lossless, "1");
@@ -13954,6 +13956,7 @@ S(('127.0.0.1', int(sys.argv[1])), H).serve_forever()
             mode: UpstreamOverrideMode::Override,
             base_url: String::new(),
             has_token: false,
+            ..Default::default()
         });
         assert_eq!(empty.target_api_url, "");
         assert_eq!(empty.pin_upstream, "0");

--- a/src-tauri/src/upstream_override.rs
+++ b/src-tauri/src/upstream_override.rs
@@ -75,6 +75,7 @@ mod tests {
             mode: UpstreamOverrideMode::Override,
             base_url: "https://api.z.ai/api/anthropic".into(),
             has_token: true,
+            ..Default::default()
         });
         assert_eq!(
             get().configured_upstream(),

--- a/src/components/UpstreamPanel.test.tsx
+++ b/src/components/UpstreamPanel.test.tsx
@@ -10,11 +10,19 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: (...args: unknown[]) => invokeMock(...args)
 }));
 
-const off: UpstreamOverrideView = { mode: "off", baseUrl: "", hasToken: false };
+const off: UpstreamOverrideView = {
+  mode: "off",
+  baseUrl: "",
+  hasToken: false,
+  model: "",
+  contextWindow: ""
+};
 const configured: UpstreamOverrideView = {
   mode: "override",
   baseUrl: "https://api.z.ai/api/anthropic",
-  hasToken: true
+  hasToken: true,
+  model: "",
+  contextWindow: ""
 };
 
 function respond(current: UpstreamOverrideView, saved?: UpstreamOverrideView) {
@@ -44,7 +52,9 @@ describe("UpstreamPanel", () => {
       expect(invokeMock).toHaveBeenCalledWith("save_upstream_override", {
         mode: "override",
         baseUrl: "https://api.z.ai/api/anthropic",
-        token: "secret-token"
+        token: "secret-token",
+        model: "",
+        contextWindow: ""
       });
     });
     expect(await screen.findByText(/restarted on this provider/)).toBeInTheDocument();
@@ -69,7 +79,9 @@ describe("UpstreamPanel", () => {
       expect(invokeMock).toHaveBeenCalledWith("save_upstream_override", {
         mode: "override",
         baseUrl: "https://api.z.ai/api/anthropic",
-        token: null
+        token: null,
+        model: "",
+        contextWindow: ""
       });
     });
   });
@@ -87,7 +99,9 @@ describe("UpstreamPanel", () => {
       expect(invokeMock).toHaveBeenCalledWith("save_upstream_override", {
         mode: "override",
         baseUrl: "https://api.z.ai/api/anthropic",
-        token: ""
+        token: "",
+        model: "",
+        contextWindow: ""
       });
     });
   });
@@ -123,9 +137,35 @@ describe("UpstreamPanel", () => {
       expect(invokeMock).toHaveBeenCalledWith("save_upstream_override", {
         mode: "off",
         baseUrl: "",
-        token: null
+        token: null,
+        model: "",
+        contextWindow: ""
       });
     });
     expect(await screen.findByText(/restarted on Anthropic/)).toBeInTheDocument();
+  });
+  /// The model slots and compact window are what make a provider actually
+  /// answer; they are optional, so an empty field must stay empty rather than
+  /// being sent as a value.
+  it("sends the model and context window when they are filled in", async () => {
+    respond(off, { ...configured, model: "glm-4.6", contextWindow: "1000000" });
+    const user = userEvent.setup();
+    render(<UpstreamPanel />);
+
+    await screen.findByLabelText("Provider base URL");
+    await user.type(screen.getByLabelText("Provider base URL"), "https://api.z.ai/api/anthropic");
+    await user.type(screen.getByLabelText("Provider model"), "glm-4.6");
+    await user.type(screen.getByLabelText("Provider context window"), "1000000");
+    await user.click(screen.getByRole("button", { name: "Save and restart" }));
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith("save_upstream_override", {
+        mode: "override",
+        baseUrl: "https://api.z.ai/api/anthropic",
+        token: null,
+        model: "glm-4.6",
+        contextWindow: "1000000"
+      });
+    });
   });
 });

--- a/src/components/UpstreamPanel.test.tsx
+++ b/src/components/UpstreamPanel.test.tsx
@@ -10,19 +10,38 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: (...args: unknown[]) => invokeMock(...args)
 }));
 
+const providers = [
+  {
+    id: "glm",
+    label: "GLM (Z.ai)",
+    baseUrl: "https://api.z.ai/api/anthropic",
+    model: "glm-5.3[1m]"
+  },
+  {
+    id: "kimi",
+    label: "Kimi (Moonshot)",
+    baseUrl: "https://api.moonshot.ai/anthropic",
+    model: "kimi-k3[1m]"
+  }
+];
+
 const off: UpstreamOverrideView = {
   mode: "off",
   baseUrl: "",
   hasToken: false,
+  provider: "",
   model: "",
-  contextWindow: ""
+  contextWindow: "",
+  providers
 };
 const configured: UpstreamOverrideView = {
   mode: "override",
   baseUrl: "https://api.z.ai/api/anthropic",
   hasToken: true,
-  model: "",
-  contextWindow: ""
+  provider: "glm",
+  model: "glm-5.3[1m]",
+  contextWindow: "1000000",
+  providers
 };
 
 function respond(current: UpstreamOverrideView, saved?: UpstreamOverrideView) {
@@ -38,26 +57,41 @@ describe("UpstreamPanel", () => {
     invokeMock.mockReset();
   });
 
-  it("sends what the user typed, and restarts onto it", async () => {
-    respond(off, { ...configured, hasToken: true });
+  /// The whole point of the dropdown: a preset needs a token and nothing else,
+  /// and the URL and model ids come from the backend that writes them.
+  it("sends the picked preset and a token, and restarts onto it", async () => {
+    respond(off, configured);
     const user = userEvent.setup();
     render(<UpstreamPanel />);
 
-    await screen.findByLabelText("Provider base URL");
-    await user.type(screen.getByLabelText("Provider base URL"), "https://api.z.ai/api/anthropic");
+    await screen.findByLabelText("Provider");
+    await user.selectOptions(screen.getByLabelText("Provider"), "glm");
     await user.type(screen.getByLabelText("Provider auth token"), "secret-token");
     await user.click(screen.getByRole("button", { name: "Save and restart" }));
 
     await waitFor(() => {
       expect(invokeMock).toHaveBeenCalledWith("save_upstream_override", {
         mode: "override",
-        baseUrl: "https://api.z.ai/api/anthropic",
+        provider: "glm",
+        baseUrl: "",
         token: "secret-token",
         model: "",
         contextWindow: ""
       });
     });
     expect(await screen.findByText(/restarted on this provider/)).toBeInTheDocument();
+  });
+
+  /// A preset asks for a token and nothing else -- the fields it fills in for
+  /// the user must not be on screen.
+  it("hides the URL and model fields behind a preset", async () => {
+    respond(configured);
+    render(<UpstreamPanel />);
+
+    await screen.findByLabelText("Provider auth token");
+    expect(screen.queryByLabelText("Provider base URL")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Provider model")).not.toBeInTheDocument();
+    expect(screen.getByText(/glm-5.3\[1m\]/)).toBeInTheDocument();
   });
 
   /// The token field starts blank even when one is stored, so an untouched
@@ -78,10 +112,11 @@ describe("UpstreamPanel", () => {
     await waitFor(() => {
       expect(invokeMock).toHaveBeenCalledWith("save_upstream_override", {
         mode: "override",
+        provider: "glm",
         baseUrl: "https://api.z.ai/api/anthropic",
         token: null,
-        model: "",
-        contextWindow: ""
+        model: "glm-5.3[1m]",
+        contextWindow: "1000000"
       });
     });
   });
@@ -96,12 +131,35 @@ describe("UpstreamPanel", () => {
     await user.click(screen.getByRole("button", { name: "Save and restart" }));
 
     await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith(
+        "save_upstream_override",
+        expect.objectContaining({ provider: "glm", token: "" })
+      );
+    });
+  });
+
+  /// An endpoint the presets do not cover still has to be reachable, with its
+  /// own model id -- otherwise a stale preset would be a dead end.
+  it("takes a hand-entered endpoint under Other", async () => {
+    respond(off, { ...configured, provider: "", model: "custom-model" });
+    const user = userEvent.setup();
+    render(<UpstreamPanel />);
+
+    await screen.findByLabelText("Provider");
+    await user.selectOptions(screen.getByLabelText("Provider"), "custom");
+    await user.type(screen.getByLabelText("Provider base URL"), "https://api.example.com/anthropic");
+    await user.type(screen.getByLabelText("Provider model"), "custom-model");
+    await user.type(screen.getByLabelText("Provider context window"), "200000");
+    await user.click(screen.getByRole("button", { name: "Save and restart" }));
+
+    await waitFor(() => {
       expect(invokeMock).toHaveBeenCalledWith("save_upstream_override", {
         mode: "override",
-        baseUrl: "https://api.z.ai/api/anthropic",
-        token: "",
-        model: "",
-        contextWindow: ""
+        provider: "",
+        baseUrl: "https://api.example.com/anthropic",
+        token: null,
+        model: "custom-model",
+        contextWindow: "200000"
       });
     });
   });
@@ -114,7 +172,8 @@ describe("UpstreamPanel", () => {
     const user = userEvent.setup();
     render(<UpstreamPanel />);
 
-    await screen.findByLabelText("Provider base URL");
+    await screen.findByLabelText("Provider");
+    await user.selectOptions(screen.getByLabelText("Provider"), "custom");
     await user.type(screen.getByLabelText("Provider base URL"), "api.z.ai");
     await user.click(screen.getByRole("button", { name: "Save and restart" }));
 
@@ -122,50 +181,23 @@ describe("UpstreamPanel", () => {
     expect(screen.queryByText(/restarted/)).not.toBeInTheDocument();
   });
 
-  /// Clearing the URL is the only way to turn the provider back off, so it has
-  /// to reach the backend as "off" -- that is what drops the stored token too.
-  it("turns the provider off when the URL is emptied", async () => {
+  /// Picking Anthropic is the only way back off, so it has to reach the backend
+  /// as "off" -- that is what drops the stored token and model ids too.
+  it("turns the provider off when Anthropic is picked", async () => {
     respond(configured, off);
     const user = userEvent.setup();
     render(<UpstreamPanel />);
 
-    await screen.findByDisplayValue("https://api.z.ai/api/anthropic");
-    await user.clear(screen.getByLabelText("Provider base URL"));
+    await screen.findByLabelText("Provider");
+    await user.selectOptions(screen.getByLabelText("Provider"), "");
     await user.click(screen.getByRole("button", { name: "Save and restart" }));
 
     await waitFor(() => {
-      expect(invokeMock).toHaveBeenCalledWith("save_upstream_override", {
-        mode: "off",
-        baseUrl: "",
-        token: null,
-        model: "",
-        contextWindow: ""
-      });
+      expect(invokeMock).toHaveBeenCalledWith(
+        "save_upstream_override",
+        expect.objectContaining({ mode: "off", provider: "" })
+      );
     });
     expect(await screen.findByText(/restarted on Anthropic/)).toBeInTheDocument();
-  });
-  /// The model slots and compact window are what make a provider actually
-  /// answer; they are optional, so an empty field must stay empty rather than
-  /// being sent as a value.
-  it("sends the model and context window when they are filled in", async () => {
-    respond(off, { ...configured, model: "glm-4.6", contextWindow: "1000000" });
-    const user = userEvent.setup();
-    render(<UpstreamPanel />);
-
-    await screen.findByLabelText("Provider base URL");
-    await user.type(screen.getByLabelText("Provider base URL"), "https://api.z.ai/api/anthropic");
-    await user.type(screen.getByLabelText("Provider model"), "glm-4.6");
-    await user.type(screen.getByLabelText("Provider context window"), "1000000");
-    await user.click(screen.getByRole("button", { name: "Save and restart" }));
-
-    await waitFor(() => {
-      expect(invokeMock).toHaveBeenCalledWith("save_upstream_override", {
-        mode: "override",
-        baseUrl: "https://api.z.ai/api/anthropic",
-        token: null,
-        model: "glm-4.6",
-        contextWindow: "1000000"
-      });
-    });
   });
 });

--- a/src/components/UpstreamPanel.tsx
+++ b/src/components/UpstreamPanel.tsx
@@ -10,6 +10,8 @@ import type { UpstreamOverrideView } from "../lib/types";
 /// keeps serving the previous one.
 export function UpstreamPanel() {
   const [baseUrl, setBaseUrl] = useState("");
+  const [model, setModel] = useState("");
+  const [contextWindow, setContextWindow] = useState("");
   const [hasToken, setHasToken] = useState(false);
   // Empty means "leave the stored token alone", which is why the field starts
   // blank even when one is set. Only a touched field is ever sent.
@@ -22,6 +24,8 @@ export function UpstreamPanel() {
 
   const apply = useCallback((next: UpstreamOverrideView) => {
     setBaseUrl(next.baseUrl);
+    setModel(next.model);
+    setContextWindow(next.contextWindow);
     setHasToken(next.hasToken);
     setToken("");
     setTokenTouched(false);
@@ -63,6 +67,8 @@ export function UpstreamPanel() {
         mode: configured ? "override" : "off",
         baseUrl,
         token: tokenTouched ? token : null,
+        model,
+        contextWindow,
       });
       apply(saved);
       setNotice(
@@ -75,7 +81,7 @@ export function UpstreamPanel() {
     } finally {
       setBusy(false);
     }
-  }, [apply, baseUrl, configured, token, tokenTouched]);
+  }, [apply, baseUrl, configured, contextWindow, model, token, tokenTouched]);
 
   return (
     <article className="soft-card panel-card">
@@ -127,6 +133,44 @@ export function UpstreamPanel() {
               />
             </span>
           </label>
+          <label className="upstream-field">
+            <span>Model (optional)</span>
+            <span className="upstream-field__input">
+              <input
+                aria-label="Provider model"
+                autoComplete="off"
+                disabled={busy}
+                onChange={(event) => setModel(event.target.value)}
+                placeholder="glm-5.3[1m]"
+                spellCheck={false}
+                type="text"
+                value={model}
+              />
+            </span>
+          </label>
+
+          <label className="upstream-field">
+            <span>Context window (optional)</span>
+            <span className="upstream-field__input">
+              <input
+                aria-label="Provider context window"
+                autoComplete="off"
+                disabled={busy}
+                inputMode="numeric"
+                onChange={(event) => setContextWindow(event.target.value)}
+                placeholder="1000000"
+                spellCheck={false}
+                type="text"
+                value={contextWindow}
+              />
+            </span>
+          </label>
+          <p className="upstream-panel__meta">
+            Leave both empty if your provider already answers to Claude model names.
+            Filling them in sets every model slot and the auto-compact window, the way
+            a hand-configured setup does.
+          </p>
+
           <p className="upstream-panel__meta">
             Kept in your OS keychain and written to ~/.claude/settings.json, which is
             where your client reads it from. Headroom forwards the token your client

--- a/src/components/UpstreamPanel.tsx
+++ b/src/components/UpstreamPanel.tsx
@@ -1,14 +1,20 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 
-import type { UpstreamOverrideView } from "../lib/types";
+import type { ProviderPresetView, UpstreamOverrideView } from "../lib/types";
 
-/// Settings for an Anthropic-compatible provider (GLM, Kimi, DeepSeek) that
-/// Headroom should route to. The base URL is the whole switch: empty is
-/// Anthropic, anything else wins over a cc-switch provider change. Saving
-/// restarts the proxy -- the upstream is read at boot, so a running proxy
-/// keeps serving the previous one.
+/// Sentinel for "an endpoint the presets do not cover", where the user brings
+/// the URL and model ids themselves.
+const CUSTOM = "custom";
+
+/// Settings for an Anthropic-compatible provider (GLM, Kimi, MiniMax, DeepSeek)
+/// that Headroom should route to. Picking one writes its URL, model slots and
+/// context window, so the user only supplies a token; picking Anthropic clears
+/// all of it. Saving restarts the proxy -- the upstream is read at boot, so a
+/// running proxy keeps serving the previous one.
 export function UpstreamPanel() {
+  const [providers, setProviders] = useState<ProviderPresetView[]>([]);
+  const [provider, setProvider] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
   const [model, setModel] = useState("");
   const [contextWindow, setContextWindow] = useState("");
@@ -23,6 +29,9 @@ export function UpstreamPanel() {
   const [notice, setNotice] = useState<string | null>(null);
 
   const apply = useCallback((next: UpstreamOverrideView) => {
+    setProviders(next.providers);
+    // A saved endpoint with no preset id was entered by hand.
+    setProvider(next.provider || (next.baseUrl ? CUSTOM : ""));
     setBaseUrl(next.baseUrl);
     setModel(next.model);
     setContextWindow(next.contextWindow);
@@ -54,7 +63,12 @@ export function UpstreamPanel() {
     };
   }, [apply]);
 
-  const configured = baseUrl.trim() !== "";
+  const preset = useMemo(
+    () => providers.find((entry) => entry.id === provider),
+    [provider, providers],
+  );
+  // Custom without a URL is not a provider, same as picking Anthropic.
+  const configured = preset !== undefined || (provider === CUSTOM && baseUrl.trim() !== "");
 
   const save = useCallback(async () => {
     setBusy(true);
@@ -62,9 +76,12 @@ export function UpstreamPanel() {
     setNotice(null);
     try {
       const saved = await invoke<UpstreamOverrideView>("save_upstream_override", {
-        // Off clears the stored URL and token backend-side, so an emptied
-        // field is how the user turns the provider back off.
+        // Off clears the stored URL, token and model ids backend-side, so
+        // picking Anthropic is how the user turns the provider back off.
         mode: configured ? "override" : "off",
+        // A preset supplies the URL and models; these fields only carry a
+        // hand-entered endpoint.
+        provider: preset ? preset.id : "",
         baseUrl,
         token: tokenTouched ? token : null,
         model,
@@ -81,7 +98,7 @@ export function UpstreamPanel() {
     } finally {
       setBusy(false);
     }
-  }, [apply, baseUrl, configured, contextWindow, model, token, tokenTouched]);
+  }, [apply, baseUrl, configured, contextWindow, model, preset, token, tokenTouched]);
 
   return (
     <article className="soft-card panel-card">
@@ -90,7 +107,7 @@ export function UpstreamPanel() {
           <h3>Provider</h3>
           <p className="panel-card__subtitle">
             Route Headroom at an Anthropic-compatible endpoint instead of Anthropic.
-            Leave the URL empty to use Anthropic.
+            Pick one and paste its token; pick Anthropic to switch back.
           </p>
         </div>
       </div>
@@ -100,82 +117,117 @@ export function UpstreamPanel() {
       ) : (
         <div className="upstream-panel">
           <label className="upstream-field">
-            <span>Base URL</span>
-            <span className="upstream-field__input">
-              <input
-                aria-label="Provider base URL"
-                autoComplete="off"
-                disabled={busy}
-                onChange={(event) => setBaseUrl(event.target.value)}
-                placeholder="https://api.z.ai/api/anthropic"
-                spellCheck={false}
-                type="text"
-                value={baseUrl}
-              />
-            </span>
+            <span>Provider</span>
+            {/* Native select: it picks up the system light/dark chrome and
+                keyboard behaviour without any styling of our own. */}
+            <select
+              aria-label="Provider"
+              disabled={busy}
+              onChange={(event) => setProvider(event.target.value)}
+              value={provider}
+            >
+              <option value="">Anthropic (default)</option>
+              {providers.map((entry) => (
+                <option key={entry.id} value={entry.id}>
+                  {entry.label}
+                </option>
+              ))}
+              <option value={CUSTOM}>Other (enter a URL)</option>
+            </select>
           </label>
 
-          <label className="upstream-field">
-            <span>Auth token</span>
-            <span className="upstream-field__input">
-              <input
-                aria-label="Provider auth token"
-                autoComplete="off"
-                disabled={busy}
-                onChange={(event) => {
-                  setToken(event.target.value);
-                  setTokenTouched(true);
-                }}
-                placeholder={hasToken ? "Stored — type to replace" : "Paste the provider token"}
-                spellCheck={false}
-                type="password"
-                value={token}
-              />
-            </span>
-          </label>
-          <label className="upstream-field">
-            <span>Model (optional)</span>
-            <span className="upstream-field__input">
-              <input
-                aria-label="Provider model"
-                autoComplete="off"
-                disabled={busy}
-                onChange={(event) => setModel(event.target.value)}
-                placeholder="glm-5.3[1m]"
-                spellCheck={false}
-                type="text"
-                value={model}
-              />
-            </span>
-          </label>
+          {provider === CUSTOM ? (
+            <>
+              <label className="upstream-field">
+                <span>Base URL</span>
+                <span className="upstream-field__input">
+                  <input
+                    aria-label="Provider base URL"
+                    autoComplete="off"
+                    disabled={busy}
+                    onChange={(event) => setBaseUrl(event.target.value)}
+                    placeholder="https://api.z.ai/api/anthropic"
+                    spellCheck={false}
+                    type="text"
+                    value={baseUrl}
+                  />
+                </span>
+              </label>
 
-          <label className="upstream-field">
-            <span>Context window (optional)</span>
-            <span className="upstream-field__input">
-              <input
-                aria-label="Provider context window"
-                autoComplete="off"
-                disabled={busy}
-                inputMode="numeric"
-                onChange={(event) => setContextWindow(event.target.value)}
-                placeholder="1000000"
-                spellCheck={false}
-                type="text"
-                value={contextWindow}
-              />
-            </span>
-          </label>
-          <p className="upstream-panel__meta">
-            Leave both empty if your provider already answers to Claude model names.
-            Filling them in sets every model slot and the auto-compact window, the way
-            a hand-configured setup does.
-          </p>
+              <label className="upstream-field">
+                <span>Model (optional)</span>
+                <span className="upstream-field__input">
+                  <input
+                    aria-label="Provider model"
+                    autoComplete="off"
+                    disabled={busy}
+                    onChange={(event) => setModel(event.target.value)}
+                    placeholder="glm-5.3[1m]"
+                    spellCheck={false}
+                    type="text"
+                    value={model}
+                  />
+                </span>
+              </label>
 
-          <p className="upstream-panel__meta">
-            Kept in your OS keychain and written to ~/.claude/settings.json, which is
-            where your client reads it from. Headroom forwards the token your client
-            sends and never adds one of its own.
-          </p>
+              <label className="upstream-field">
+                <span>Context window (optional)</span>
+                <span className="upstream-field__input">
+                  <input
+                    aria-label="Provider context window"
+                    autoComplete="off"
+                    disabled={busy}
+                    inputMode="numeric"
+                    onChange={(event) => setContextWindow(event.target.value)}
+                    placeholder="1000000"
+                    spellCheck={false}
+                    type="text"
+                    value={contextWindow}
+                  />
+                </span>
+              </label>
+              <p className="upstream-panel__meta">
+                Leave the model empty if your provider already answers to Claude model
+                names.
+              </p>
+            </>
+          ) : null}
+
+          {provider === "" ? null : (
+            <label className="upstream-field">
+              <span>Auth token</span>
+              <span className="upstream-field__input">
+                <input
+                  aria-label="Provider auth token"
+                  autoComplete="off"
+                  disabled={busy}
+                  onChange={(event) => {
+                    setToken(event.target.value);
+                    setTokenTouched(true);
+                  }}
+                  placeholder={hasToken ? "Stored — type to replace" : "Paste the provider token"}
+                  spellCheck={false}
+                  type="password"
+                  value={token}
+                />
+              </span>
+            </label>
+          )}
+
+          {preset ? (
+            <p className="upstream-panel__meta">
+              Sets {preset.baseUrl} and {preset.model} in ~/.claude/settings.json. If your
+              plan serves a different model, pick Other and name it.
+            </p>
+          ) : null}
+
+          {provider === "" ? null : (
+            <p className="upstream-panel__meta">
+              The token is kept in your OS keychain and written to ~/.claude/settings.json,
+              which is where your client reads it from. Headroom forwards the token your
+              client sends and never adds one of its own.
+            </p>
+          )}
 
           <div className="upstream-panel__actions">
             <button

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -729,12 +729,23 @@ export type UpstreamMode = "off" | "fallback" | "override";
  * itself, only whether one is stored: the token lives in the OS keychain and
  * in the client's own settings.json.
  */
+export interface ProviderPresetView {
+  id: string;
+  label: string;
+  baseUrl: string;
+  model: string;
+}
+
 export interface UpstreamOverrideView {
   mode: UpstreamMode;
   baseUrl: string;
   hasToken: boolean;
+  /** Preset id this came from; empty for a hand-entered endpoint. */
+  provider: string;
   /** Written to every ANTHROPIC_DEFAULT_*_MODEL slot; empty leaves them unset. */
   model: string;
   /** CLAUDE_CODE_AUTO_COMPACT_WINDOW in tokens; empty leaves it unset. */
   contextWindow: string;
+  /** Presets the dropdown offers, supplied by the backend that writes them. */
+  providers: ProviderPresetView[];
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -733,4 +733,8 @@ export interface UpstreamOverrideView {
   mode: UpstreamMode;
   baseUrl: string;
   hasToken: boolean;
+  /** Written to every ANTHROPIC_DEFAULT_*_MODEL slot; empty leaves them unset. */
+  model: string;
+  /** CLAUDE_CODE_AUTO_COMPACT_WINDOW in tokens; empty leaves it unset. */
+  contextWindow: string;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -6429,6 +6429,13 @@ html.window-hiding {
   color: var(--text-secondary);
 }
 
+.upstream-field select {
+  justify-self: start;
+  min-height: 32px;
+  font: inherit;
+  color: var(--text-primary);
+}
+
 .upstream-panel__actions {
   display: flex;
   gap: 12px;


### PR DESCRIPTION
## What

Follows #82/#83. Setting a base URL + token routed traffic to a third-party
endpoint, but Claude Code kept asking it for Anthropic model ids and timed out
waiting for the slower first token. Andrew's working GLM `settings.json` hand-sets
six env keys; we were writing one (`ANTHROPIC_AUTH_TOKEN`).

Rather than add fields for the other five, the panel now asks one question:

**Provider:** Anthropic (default) / GLM (Z.ai) / Kimi (Moonshot) / MiniMax /
DeepSeek / Other (enter a URL) — plus a token field, and nothing else.

Picking a provider writes its whole client config into `~/.claude/settings.json`:
base URL, `API_TIMEOUT_MS`, `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, all four
`ANTHROPIC_DEFAULT_*_MODEL` slots and `CLAUDE_CODE_AUTO_COMPACT_WINDOW`. Picking
Anthropic clears every one of them and drops the stored token. The URL / model /
context window inputs only appear under **Other**.

## Preset values

From each vendor's own Claude Code doc, read 2026-09-02:

| Provider | Base URL | Big slots | Haiku slot | Auto-compact |
|---|---|---|---|---|
| GLM (Z.ai) | `https://api.z.ai/api/anthropic` | `glm-5.3[1m]` | `glm-4.7` | 1000000 |
| Kimi (Moonshot) | `https://api.moonshot.ai/anthropic` | `kimi-k3[1m]` | `kimi-k2.7-code` | 1000000 |
| MiniMax | `https://api.minimax.io/anthropic` | `MiniMax-M3` | `MiniMax-M3` | 512000 |
| DeepSeek | `https://api.deepseek.com/anthropic` | `deepseek-v4-pro[1m]` | `deepseek-v4-flash` | 786432 |

The haiku slot is separate from opus/sonnet/fable: Claude Code uses it for
background work, so pinning it to the big model spends the expensive model on
output the user never reads.

The table lives in Rust next to the code that writes it, and the dropdown is
populated from it over `get_upstream_override`, so labels and written values
cannot drift.

## Known ceiling

Model ids age faster than releases do (GLM alone went 4.5 -> 4.7 -> 5.3 in a
few months), and Z.ai's docs explicitly discourage pinning a model at all because
it blocks their server-side upgrades. A stale preset fails at request time on the
provider's side. **Other** is the escape hatch: same fields as before this PR, so
nobody is stuck waiting for an app update. If a preset goes stale in the wild,
the fix is a one-line table edit.

Also worth knowing: presets pin the top model, so a user on a cheaper plan tier
that does not include it will get an error rather than a downgrade. Andrew runs
exactly the GLM config in the table, so that one is proven.

## Tests

- `provider_env_round_trips_through_claude_settings` (Rust): apply the GLM
  preset, assert all seven keys land and the haiku slot is NOT the big model;
  clear, assert all seven are gone and an unrelated user key survives.
- `UpstreamPanel.test.tsx`: 7 cases — preset + token round trip, preset hides the
  URL/model fields, untouched token, token removal, hand-entered endpoint under
  Other, rejected URL, and picking Anthropic turning it off.
- Gates: `cargo test --lib` 1118 passed, `cargo fmt --check`, `tsc --noEmit`,
  `vitest` 421 passed, `check-colors` at baseline 480, `check-no-console`.

Not verified: a real request against a live provider key. The dropdown is a
native `<select>` with no custom styling, so it follows system light/dark on its
own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
