### PR TITLE
Re-release 0.9.7: silence /api/hello upstream-error capture (RUST-BS)

### DIFF
--- a/src-tauri/src/proxy_intercept.rs
+++ b/src-tauri/src/proxy_intercept.rs
@@ -1333,9 +1333,14 @@ async fn handle(
         let downstream = async {
             // Local proxy paths (/stats, /readyz probes) are our own traffic;
             // a 404 there is the squatter case (RUST-87), not a client error.
+            // /api/hello is Claude Code's connectivity probe: the Python
+            // backend has no route for it and 404s, Claude Code accepts any
+            // HTTP status as proof of reachability, so the error is expected
+            // noise (RUST-BS). Not in is_local_proxy_path: bypass mode must
+            // keep forwarding it upstream (where it 200s), not answer 503.
             let error_path = parsed_head
                 .as_ref()
-                .filter(|head| !is_local_proxy_path(&head.path))
+                .filter(|head| !is_local_proxy_path(&head.path) && head.path != "/api/hello")
                 .map(|head| head.path.clone());
             let mut stamped = ResponseSniffer::new(StampReader(backend_rd), client_key, error_path);
             let _ = tokio::io::copy(&mut stamped, &mut client_wr).await;


### PR DESCRIPTION
0.9.7 shipped the all-clients upstream-error capture, which reports the backend's own 404 on Claude Code's /api/hello connectivity probe. Every updated install emits these steadily (no throttle on this path) with zero user impact - the probe accepts any HTTP status. One-line filter at the capture site; full --lib suite green (1129 passed).

Same-version redo per the retrigger playbook: merge, then dispatch release-macos.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)