### PR TITLE
0.9.11

### DIFF
--- a/.github/release-notes/0.9.11.md
+++ b/.github/release-notes/0.9.11.md
@@ -1,0 +1,1 @@
+Fixes the false "ran without Headroom" alert, keeps ChatGPT-subscription Codex working while the backend is still starting, and stops Claude Code's trailing system reminders from busting the prompt cache. Plus Windows startup and ChatGPT plan-detection fixes.

--- a/docs/beta-smoke-test.md
+++ b/docs/beta-smoke-test.md
@@ -1,5 +1,7 @@
 # Beta smoke test
 
+Most of this is automated. `./scripts/smoke-test.sh` runs every non-Codex check a shell can drive and prints a PASS/FAIL table; `--quick` skips the three that restart the app. Run that first - this doc is the reference for what each check means and how to read a failure, and the script deliberately reuses the commands below so the two cannot drift. Checks 4, 7 and the visual half of 5 and 16 still need a client session or an eyeball; the script reports those as MANUAL/PENDING with the exact follow-up.
+
 After installing a new beta (`-rc.N`) build, paste this file into Claude Code and ask it to run the checks. Each check has a single expected signal — if any fail, stop and investigate before promoting to stable.
 
 ## Setup
@@ -43,9 +45,27 @@ Have Claude call `mcp__headroom__headroom_retrieve` with any small query and exp
 ### 5. Tray → Dashboard renders
 Click the tray icon, open the dashboard. Expect savings chart and per-client stats render without a blank/error state.
 
-### 6. Pause / resume cleanly strips and restores interception
-In Settings, toggle Pause then Resume (restore runs on a background thread, so give it a second), checking after each:
+This does not need a human. The tray menu and the whole dashboard are exposed to the accessibility API, so checks 5, 6 and 16's visual step can all be driven headlessly (verified on the 0.9.11-rc.4 pass). Note the process name is `headroom-desktop`, the tray lives on menu bar 2, and the webview's own controls resolve as real AX elements (`button Home of group Tray navigation of ...`), so `click at` hits them:
 ```bash
+AX() { osascript -e "tell application \"System Events\" to tell process \"Headroom\" $1"; }
+AX 'to click menu bar item 1 of menu bar 2'                                    # open tray menu
+AX 'to get name of every menu item of menu 1 of menu bar item 1 of menu bar 2' # Show/Pause|Resume/Quit
+AX 'to click menu item "Show Headroom" of menu 1 of menu bar item 1 of menu bar 2'
+AX 'to get {name, size, position} of every window'                             # empty list = no window open
+```
+Then screenshot just the window rather than the whole screen - `screencapture -x -o -R<x>,<y>,<w>,<h> shot.png` using the position/size from the last line above.
+
+### 6. Pause / resume cleanly strips and restores interception
+In Settings (or via the tray menu, see check 5), toggle Pause then Resume, checking after each:
+```bash
+grep -c 'headroom:claude_code' ~/.zprofile ~/.zshrc
+```
+Restore is **not** quick, and the reason matters. Resume is `start_headroom` (lib.rs), which calls `resume_runtime` -> `ensure_headroom_running` *first* and only then spawns the `restore_client_setups` thread, so the wait you are measuring is the backend's cold Python boot, not the file writes. That ordering is deliberate: the shell blocks point at 6767, so writing them before something listens there would hand the user connection-refused instead of a merely unoptimized session. Measured 15-20s on the 0.9.11-rc.4 pass (Resume clicked 13:56:0x, files rewritten 13:56:21). Treat 15-20s as normal and a minute-plus as a backend that failed to come up - check `/livez`, not the config. A fixed `sleep` of a few seconds reads `0` and scores a healthy build as a FAIL, so poll for the restore instead of sleeping through it:
+```bash
+for _ in $(seq 1 40); do
+  [ "$(cat ~/.zprofile ~/.zshrc | grep -c 'headroom:claude_code')" = "4" ] && break
+  sleep 1
+done
 grep -c 'headroom:claude_code' ~/.zprofile ~/.zshrc
 ```
 Expect: after Pause both files print `0`; after Resume both print `2` (the `# >>> headroom:claude_code >>>` and `# <<< headroom:claude_code <<<` marker lines). Do *not* grep `~/.claude/settings.json` for `headroom-rtk-rewrite` — that hook only exists when the RTK addon is installed, so on an install with RTK off (check 3) it reads `0` in both states and the check looks like a FAIL on a healthy build. The managed shell block is the RTK-independent marker. If RTK *is* installed, `grep -c headroom-rtk-rewrite ~/.claude/settings.json` is a valid extra signal: `0` after Pause, `1` after Resume.
@@ -72,7 +92,12 @@ Generate the payload with a real `Read` tool call. Dumping the file through Bash
 2. End the turn with a large Read in flight — e.g. ask Claude to read a long file like `src-tauri/src/lib.rs` with as large an offset/limit window as the Read tool allows (the 25k-token cap means you cannot read it whole; ~1300-1500 lines is plenty).
 3. On the *next* turn, re-run the same `jq` command.
 
-Expect: `primary_model` is a `claude-*` model, `cache_savings_usd` is strictly greater (the cached prefix was preserved, not busted), `total_tokens_before` jumped by at least the size of the Read, and `prefix_frozen` + `requests_compressed` together increased by at least 1. The large Read all but guarantees live-zone savings, so in practice the increment lands in `requests_compressed`; `prefix_frozen` only counts requests returned fully unchanged, so it can legitimately stay flat for a whole session (observed on a healthy 0.6.9-rc.1: `prefix_frozen` flat at 17 while cache savings climbed). A bumped mtime on `activity-facts.json` is not enough — interception alone would still touch that file without delivering savings.
+`primary_model` is the single most-served model of the session, so on a box with a Codex session running alongside it can legitimately read `gpt-*` while Claude traffic is healthy (observed on the 0.9.11-rc.4 pass: `gpt-6-astra` with 17 gpt requests against 26 `claude-*` ones). Do not FAIL on it. Confirm Claude traffic directly instead - this key is present regardless of which model won the tiebreak, and its count must increase across the Read:
+```bash
+curl -s http://127.0.0.1:6767/stats | jq '.requests.by_model | with_entries(select(.key|startswith("claude-")))'
+```
+
+Expect: at least one `claude-*` entry whose count increased, `cache_savings_usd` is strictly greater (the cached prefix was preserved, not busted), `total_tokens_before` jumped by at least the size of the Read, and `prefix_frozen` + `requests_compressed` together increased by at least 1. The large Read all but guarantees live-zone savings, so in practice the increment lands in `requests_compressed`; `prefix_frozen` only counts requests returned fully unchanged, so it can legitimately stay flat for a whole session (observed on a healthy 0.6.9-rc.1: `prefix_frozen` flat at 17 while cache savings climbed). A bumped mtime on `activity-facts.json` is not enough — interception alone would still touch that file without delivering savings.
 
 **Pay-per-token API-key traffic** (classified `PAYG`/`OAUTH` — this is also the branch Codex hits; the Codex pass below adds a Codex-attributed version):
 1. Capture the baseline:
@@ -154,20 +179,27 @@ Checks 2 and 7 confirm the proxy *reports* savings. They cannot tell you the opt
 
 The proxy log settles it on a single line. `source=` is the bytes actually forwarded and `mutation_reasons=` is what the pipeline changed, so `body_mutated=true ... source=passthrough` is a literal contradiction: work was done and the original bytes went out anyway.
 
-**11a. The empty-200 class must be gone (hard FAIL).** Scope to the *current* log - rotated logs still hold pre-fix history and will report non-zero forever.
+Every count in checks 11 and 13 has to be scoped to the current backend boot. `proxy.log` persists across backend restarts, so a whole-file grep keeps reporting pre-fix history forever (observed on the 0.9.4-rc.1 pass: 148 `output_shaper` discards from the same morning's 0.35.0 run, 0 since the rc boot). Define the filter once and pipe every count through it - the `on` state carries across untimestamped continuation lines, so a traceback under a matching line is not silently dropped:
 ```bash
-grep -c 'ccr_streaming_retrieve_buffered[^ ]* source=passthrough' \
-  ~/.headroom/logs/proxy.log
+BOOT=$(date -j -f "%a %b %e %T %Y" \
+  "$(ps -o lstart= -p "$(lsof -ti TCP:6768 -sTCP:LISTEN | head -1)")" +"%Y-%m-%d %H:%M:%S")
+since_boot() { awk -v B="$BOOT" '/^[0-9-]{10} /{on=(substr($0,1,19)>=B)} on' ~/.headroom/logs/proxy.log; }
+```
+Use the live backend port from check 9 if it fell back off `6768`.
+
+**11a. The empty-200 class must be gone (hard FAIL).**
+```bash
+since_boot | grep -c 'ccr_streaming_retrieve_buffered[^ ]* source=passthrough'
 ```
 Expect: `0`. Anything above zero means a streaming CCR request forwarded `stream:true` bytes on a buffered path, and the client is about to receive an unparseable, unretryable 200. Verified discriminating: `0` on the current log, `6` across the pre-fix rotated logs.
 
 **11b. General discard rate (hard FAIL since the headroom-ai 0.37.0 wheel).**
 ```bash
-grep -c 'body_mutated=true.*source=passthrough' ~/.headroom/logs/proxy.log
-grep 'body_mutated=true.*source=passthrough' ~/.headroom/logs/proxy.log \
+since_boot | grep -c 'body_mutated=true.*source=passthrough'
+since_boot | grep 'body_mutated=true.*source=passthrough' \
   | sed -n 's/.*mutation_reasons=\([^ ]*\).*/\1/p' | tr ',' '\n' | sort | uniq -c
 ```
-Expect: `0` on the current wheel - the signed-thinking discard fix (upstream #3015, merged upstream in v0.36.0) ships here since the headroom-ai 0.37.0 bump in 0.9.4-rc.1. Scope the count to lines timestamped after the current backend booted: `proxy.log` persists across backend restarts, so pre-bump history keeps the whole-file grep non-zero forever (observed on the 0.9.4-rc.1 pass: 148 `output_shaper` discards from the same morning's 0.35.0 run, 0 since the rc boot). Boot time via `ps -o lstart= -p $(lsof -ti TCP:6768 -sTCP:LISTEN | head -1)`, then filter on the log timestamp before counting.
+Expect: `0` on the current wheel - the signed-thinking discard fix (upstream #3015, merged upstream in v0.36.0) ships here since the headroom-ai 0.37.0 bump in 0.9.4-rc.1.
 
 `structural_diff_vs_original` is the one to read first, not last. The core compression pipeline never calls `mark_mutated` - grep the package and the reason vocabulary has no entry for it - so compression is only ever noticed by the structural safety net at the end of `handle_anthropic_messages`, which fires when no transform reported a mutation but the final body differs from the parsed original bytes. That makes this reason the label core compression lands under by omission, and a discard under it is the pipeline's own work being thrown away, which costs more than losing a shaping pass. It also means the share is not fixed: measured 7.6%-60% of mutated requests across six logs on 0.8.5-rc.1, tracking how much real compression happened. Do not read a ~3% reading as the `HEADROOM_OUTPUT_HOLDOUT=0.03` control arm - the arm gate and this one are unrelated, and the resemblance is a coincidence of whichever subset you counted.
 
@@ -197,8 +229,8 @@ The definitive probe of whether `sitecustomize.py` was actually *imported* (rath
 The response-side half of check 11. A request can be optimized, accounted, and still hand the client something unusable - the proxy records a 200 and moves on. Two signatures, both one-liners, both scoped to the current log:
 
 ```bash
-grep -c 'PERF model=claude-[^ ]* .*tok_out=0 ' ~/.headroom/logs/proxy.log
-grep -c 'response_cache_store_refused' ~/.headroom/logs/proxy.log
+since_boot | grep -c 'PERF model=claude-[^ ]* .*tok_out=0 '
+since_boot | grep -c 'response_cache_store_refused'
 ```
 Expect: `0` and `0`.
 
@@ -210,7 +242,7 @@ Line 2 is the desktop's own `SemanticCache.set` guard in `SITECUSTOMIZE_PY` refu
 
 If the cache ever does replay a poisoned body, the signature is a `/v1/messages` 200 in under 20ms with `tok_out=0`:
 ```bash
-grep 'PERF model=claude-' ~/.headroom/logs/proxy.log | awk '{for(i=1;i<=NF;i++){if($i~/^total_ms=/)t=substr($i,10)+0; if($i~/^tok_out=/)o=substr($i,9)+0} if(t<20&&o==0)n++} END{print n+0}'
+since_boot | grep 'PERF model=claude-' | awk '{for(i=1;i<=NF;i++){if($i~/^total_ms=/)t=substr($i,10)+0; if($i~/^tok_out=/)o=substr($i,9)+0} if(t<20&&o==0)n++} END{print n+0}'
 ```
 Expect: `0`. Only a proxy restart clears a poisoned entry, so this stays non-zero until the backend is bounced.
 
@@ -218,34 +250,23 @@ Expect: `0`. Only a proxy restart clears a poisoned entry, so this stays non-zer
 
 Checks 1-13 all describe a working install. None of them notice that the upgrade silently reset it, because a wiped state file looks exactly like a healthy fresh one. Every persisted file here is read back through `serde`, so one field added or renamed in the new build is enough to fail a parse and hand the user a default: a restarted grace clock, an empty savings history, or a client-setup record that no longer knows which shell files we wrote (which is also what uninstall reads to clean up).
 
-From 0.9.3 on, the app takes this snapshot itself: on the first launch of a new version, `snapshot_state_on_version_change` (storage.rs) copies the three state files raw into `config/pre-update/` - before anything parses them - with a `meta.json` naming the from/to versions. When the build being replaced is >= 0.9.3, verify `meta.json`'s `from_version` is that build and diff against `config/pre-update/` instead of a manual snapshot. The manual block below remains for upgrades from older builds and as a cross-check. One expected asymmetry: the auto-snapshot's `client-setup.json` is captured in the post-quit state, where `clear_client_setups()` has already emptied `configuredClients`/`managedShellFiles` - the surviving client set lives under `rememberedClients` there. Compare that key, not the configured sets (observed and verified on the rc.5 -> rc.7 pass).
+From 0.9.3 on, the app takes this snapshot itself: on the first launch of a new version, `snapshot_state_on_version_change` (storage.rs) copies the three state files raw into `config/pre-update/` - before anything parses them - with a `meta.json` naming the from/to versions. Verify `meta.json`'s `from_version` is the build you replaced, then diff against `config/pre-update/`. One expected asymmetry: the auto-snapshot's `client-setup.json` is captured in the post-quit state, where `clear_client_setups()` has already emptied `configuredClients`/`managedShellFiles` - the surviving client set lives under `rememberedClients` there. Compare that key, not the configured sets (observed and verified on the rc.5 -> rc.7 pass).
 
-**Run this block BEFORE installing the rc**, on the build you are upgrading from:
+**After installing and launching the rc**, diff the live files against the snapshot the app took for you:
 ```bash
 S=~/Library/Application\ Support/Headroom
-mkdir -p /tmp/hr-preupgrade
-jq '{first_seen_at,paywall_first}' "$S/config/headroom-pricing-state.json" > /tmp/hr-preupgrade/pricing.json
-jq '{configured:(.configuredClients|keys),shell:(.managedShellFiles|keys)}' "$S/config/client-setup.json" > /tmp/hr-preupgrade/setup.json
-jq '{tokens:.allTimeRecordTokens,recap:.lastWeeklyRecapWeekKey,schema:.schemaVersion}' "$S/config/activity-facts.json" > /tmp/hr-preupgrade/facts.json
-# For check 15: the user's own CLAUDE.md content, excluding our managed blocks.
-awk '/headroom:(learn:start|markitdown_office >>>)/{skip=1} !skip{n+=length($0)+1} /headroom:(learn:end|markitdown_office <<<)/{skip=0} END{print FILENAME, n+0}' \
-  ~/.claude/CLAUDE.md > /tmp/hr-preupgrade/claude-md.txt
-cat /tmp/hr-preupgrade/*.json /tmp/hr-preupgrade/claude-md.txt
-```
-
-**After installing and launching the rc**, re-run the same three `jq` expressions and diff:
-```bash
-S=~/Library/Application\ Support/Headroom
-stat -f '%Sm %N' /tmp/hr-preupgrade/*   # must predate THIS install, not an older one
-[ /tmp/hr-preupgrade -nt /Applications/Headroom.app ] && echo 'NOT RUN - snapshot is NEWER than the installed app; it was taken after this install'
-diff <(jq '{first_seen_at,paywall_first}' "$S/config/headroom-pricing-state.json") /tmp/hr-preupgrade/pricing.json
-diff <(jq '{configured:(.configuredClients|keys),shell:(.managedShellFiles|keys)}' "$S/config/client-setup.json") /tmp/hr-preupgrade/setup.json
-jq '{tokens:.allTimeRecordTokens,recap:.lastWeeklyRecapWeekKey,schema:.schemaVersion}' "$S/config/activity-facts.json"
+P="$S/config/pre-update"
+jq -r '.from_version + " -> " + .to_version' "$P/meta.json"   # must name the build you just replaced
+diff <(jq '.first_seen_at' "$S/config/headroom-pricing-state.json") <(jq '.first_seen_at' "$P/headroom-pricing-state.json")
+diff <(jq '.rememberedClients|keys' "$S/config/client-setup.json") <(jq '.rememberedClients|keys' "$P/client-setup.json")
+diff <(jq '{t:.allTimeRecordTokens,r:.lastWeeklyRecapWeekKey}' "$S/config/activity-facts.json") <(jq '{t:.allTimeRecordTokens,r:.lastWeeklyRecapWeekKey}' "$P/activity-facts.json")
 ls "$S/config/" | grep -c '\.corrupt$'
 ```
-Expect: `first_seen_at` byte-identical (`paywall_first` may legitimately change - the server owns it), the configured-client and shell-file key sets unchanged, and `0` quarantine files. (Use `grep -c`, not `ls *.corrupt`: zsh aborts the whole line with `no matches found` when the glob is empty, which is the healthy case.)
+Expect: `meta.json` reads `<the build you replaced> -> <the build now installed>`, all three diffs empty, and `0` quarantine files. (Use `grep -c`, not `ls *.corrupt`: zsh aborts the whole line with `no matches found` when the glob is empty, which is the healthy case.) `paywall_first` is deliberately not compared - the server owns it and may legitimately change it.
 
-Check the snapshot's mtime before trusting a clean diff. `/tmp/hr-preupgrade` survives across rcs, so a run that forgot the pre-install step silently diffs against a snapshot from two builds ago - which passes, but tests the wrong upgrade. If the mtime predates the build you just replaced, say so in the report rather than claiming this rc preserved state.
+Check `meta.json`'s `to_version` against the running build before trusting a clean diff. The snapshot is only rewritten on a version *change*, so re-running against the same rc diffs that rc against itself: it passes while testing nothing.
+
+A manual `/tmp/hr-preupgrade` block used to live here, to be run before installing. It is gone. `snapshot_state_on_version_change` has covered every upgrade since 0.9.3, and the manual step failed open - on the 0.9.11-rc.4 pass `/tmp/hr-preupgrade` existed from an earlier rc but was empty, so a run that skipped the pre-install step would have diffed nothing and reported a pass. A step that fails silently is worse than no step.
 
 `activity-facts.json` is the deliberate exception: a `schemaVersion` bump intentionally drops the tile slots, so it needs its own comparison rather than a `diff`. What must survive a bump is `allTimeRecordTokens` and `lastWeeklyRecapWeekKey` - wiping those re-fires the weekly recap and resets all-time records for every user, which has happened on four bumps so far.
 
@@ -263,7 +284,7 @@ for f in ~/.claude/CLAUDE.md ~/Code/headroom-desktop/CLAUDE.md; do
   awk '/headroom:(learn:start|markitdown_office >>>)/{skip=1} !skip{n+=length($0)+1} /headroom:(learn:end|markitdown_office <<<)/{skip=0} END{print "  user bytes outside managed blocks: " n+0}' "$f"
 done
 ```
-Expect: every pair is `0/0` or `1/1` - never `2/2` (duplicated block) and never `1/0` (truncated mid-write). The user-bytes figure has no fixed value; capture it in the check 14 pre-install snapshot and confirm it does not shrink across the upgrade. On this machine it is 81 for the global file (which is nearly all managed blocks) and ~3,000 for the desktop project file.
+Expect: every pair is `0/0` or `1/1` - never `2/2` (duplicated block) and never `1/0` (truncated mid-write). The user-bytes figure has no fixed value and nothing captures it across an upgrade (the auto-snapshot in check 14 covers the three state files, not CLAUDE.md), so treat it as a tripwire you read rather than diff: a figure far below the one recorded here means content was eaten, and the marker pairs above are what actually prove the writers behaved. On this machine it is 81 for the global file (which is nearly all managed blocks) and ~10,100 for the desktop project file (that one grows as CLAUDE.md is edited - it read ~3,000 when this check was written, so refresh the figure rather than reading growth as damage; only a *shrink* across an upgrade is the failure).
 
 A `2/2` is the duplicate-block bug: `strip_marker_block` loops for exactly this reason, and `upsert_managed_block` treats reordered `end`-before-`start` markers as absent and appends fresh rather than rebuilding around them. Both behaviours have unit tests (`managed_block_upsert_replaces_existing_block_without_duplication`, `managed_block_upsert_treats_reordered_markers_as_absent`, `updating_one_managed_block_does_not_touch_other_blocks_or_user_content`), so a failure here means a new writer, not a regression in those.
 

--- a/docs/fable-cache-2026-09-07.md
+++ b/docs/fable-cache-2026-09-07.md
@@ -1,0 +1,167 @@
+# Fable cache-loss investigation, September 7, 2026
+
+## Finding
+
+Claude Code's temporary trailing system messages make Headroom 0.37.0 lose the
+existing conversation tracker. This reproduced offline against the actual last
+good request and first bad request, and explains all 27 repeated cache-loss turns
+in the large Fable session between 09:02 and 09:54 Europe/Amsterdam (UTC+02:00).
+
+This is a compatibility defect in Headroom's conversation matching. The trigger
+comes from Claude Code, but Headroom amplifies a change at the end of the prompt
+into changes near the beginning of the cached history. It is not simply normal
+cache expiry, a large-token display, or a failure to attach cache breakpoints.
+
+No live Claude requests or subscription usage were needed for this investigation.
+The fix is now in the desktop source. No running configuration was changed.
+
+## Evidence
+
+The proxy retained the original and forwarded messages. Three relevant captures:
+
+| Response time, Amsterdam | Proxy request ID | Cache read | Cache write |
+| --- | --- | ---: | ---: |
+| 09:02:17 | `hr_1788764464_000134` | 0 | 490,996 |
+| 09:04:20 | `hr_1788764590_000155` | 490,996 | 12,509 |
+| 09:05:39 | `hr_1788764673_000174` | 7,259 | 491,260 |
+
+The 09:04 request contains 862 messages. Its last message is a temporary
+`role: system` reminder to plan independent tool calls and request them together.
+The exact reminder text is present in the installed Claude Code 2.1.259 native
+binary and absent from the searched Headroom runtime and desktop source.
+
+On the next request, the first 861 original messages are semantically identical.
+The temporary system message at index 861 is replaced by the next assistant
+response; a fresh system reminder appears at the new end of the request.
+
+Headroom's recorded forwarded messages nevertheless differ at 100 historical
+positions under its own canonical comparison. The first difference is at index
+3: a previously forwarded compressed Read marker becomes the original longer
+tool result. The incoming message at that index did not change. That explains
+why reuse collapses near the start of the conversation rather than only at the
+temporary reminder near its end.
+
+Across the 30 successful large Fable requests in the window:
+
+- One initial cold request.
+- Two `message_append` continuations: 1,066,873 cache-read tokens and 18,314 writes.
+- Twenty-seven `diverged` continuations after a temporary trailing system
+  reminder: 195,993 cache-read tokens and 15,183,730 writes.
+- Each of the 27 becomes `message_append` when only the previous temporary
+  trailing system message is excluded from the comparison. Twenty-three use the
+  batching reminder alone; four combine it with progress or changed-file notices.
+- Overall: 1,262,866 cache-read tokens, 15,693,040 cache-write tokens, and 4,291
+  uncached input tokens. Cache reuse is 7.4% of provider-reported input.
+- The same requests report 450,271 message-compression tokens saved out of
+  15,343,345 pre-compression tokens, or 2.93%. These are Headroom's estimates,
+  not a measurement of a hypothetical no-proxy provider bill.
+
+After the switch to Opus, the captured requests do not carry the batching
+reminder and resume append-only matching. The first seven warm Opus requests
+have 98.53% provider cache reuse. That is an observed contrast, not a controlled
+model benchmark.
+
+## Mechanism and offline reproduction
+
+The installed wheel is `headroom-ai==0.37.0`. The running proxy started on
+September 6 at 17:28:28 Amsterdam time, before September 7's desktop commits.
+The installed desktop prefix-floor vendor is bound to that wheel.
+
+1. `headroom/cache/prefix_tracker.py::_classify_history_canonical` accepts exact
+   history, message appends, block appends, and a narrow same-message-count tail
+   rewrite. It rejects replacement of a previous trailing system message.
+2. `SessionTrackerStore.resolve_tracker` therefore allocates a fresh tracker
+   despite the unchanged session ID, model/tools/thinking affinity, and historical
+   prefix. The tracker has no previous forwarded messages and freezes zero.
+3. The Anthropic handler then processes old history again. Background compression,
+   stale-read handling, and other transformations can change previously cached
+   bytes. `finalize_turn` has no previous tracker state to replay.
+4. The provider reports a near-full cache rewrite. The temporary reminder moves
+   again next turn, so the cycle repeats.
+
+The reproducer holds cache affinity constant to isolate the disappearing system
+suffix. It seeds confirmed cache state without any provider calls, then verifies
+that the next real request gets a different tracker with zero frozen messages.
+
+As a counterfactual, supplying the previous tracker to the installed vendor's
+existing `overlay_cached_prefix` restores all 861 unchanged historical messages
+and leaves the current tail, including its current reminder, untouched. The
+vendor already stops replay at the first actual divergence. Its replay algorithm
+does not need to be rewritten to demonstrate the missing tracker state.
+
+Run the synthetic reproducer using a Python environment with Headroom 0.37.0:
+
+```sh
+python scripts/reproduce-transient-system-cache.py
+```
+
+To exercise the exact installed desktop vendor, add
+`--sitecustomize /path/to/headroom/pyinject/sitecustomize.py`. To replay the private
+three-request capture, also add `--capture /path/to/three-requests.json`.
+The capture is stored outside the repository because it contains conversation
+contents. The default synthetic fixture contains no private user data.
+
+The script exits zero when the historical failure and the counterfactual are
+both demonstrated. This is a diagnostic reproducer, not a passing assertion that
+the installed runtime is fixed. It blocks socket connections and name resolution.
+
+## Fix boundary and limitations
+
+The fix belongs in conversation-tracker selection: recognize a continuation of
+an unchanged prefix when a temporary trailing system message is replaced, without
+discarding its previous replay state. Keep the current system message on the
+wire, preserve genuinely changed historical instructions, keep different tool
+affinities isolated, and reject ambiguous sibling-conversation matches.
+
+Do not indiscriminately remove all system messages or force unrelated histories
+onto one tracker. Do not replace the sanctioned prefix-floor vendor with another
+splice. Add the transient-system case to tracker-selection regression coverage
+and exercise the existing replay with a moving and changing system suffix.
+
+## Implemented fix and validation
+
+`src-tauri/src/tool_manager.rs` now injects a narrow resolver fallback for the
+0.37.0 wheel. Existing exact, append, block-append, and block-rewrite matching
+take precedence. Otherwise, a previous trailing system message may be excluded
+from matching only when its entire preceding history matches the current
+prefix and includes a user or assistant message. The uniquely longest candidate
+wins; equal-length sibling candidates remain separate. Cache affinity, expiry,
+and capacity still follow the wheel's existing rules. OpenAI is unaffected.
+
+The original resolver records the full current snapshot. No instruction is
+removed from the request, and the sanctioned #3380 overlay is unchanged.
+`HEADROOM_TRANSIENT_SYSTEM_LINEAGE=0` disables this compatibility fallback.
+Reassess/remove the exact-pin shim when upgrading the wheel.
+
+The diagnostic now supports `--expect-fixed`, which requires tracker retention
+and runs isolation checks. The Rust test
+`transient_system_lineage_behaves_against_the_installed_wheel` loads the actual
+embedded injection and runs that mode against the installed managed Python.
+
+Validation on September 7, 2026:
+
+- Synthetic regression and real 862-to-864-message capture pass. The latter
+  preserves all 861 unchanged historical messages under the runtime's canonical
+  comparison and leaves the current tail untouched.
+- Disabling the shim makes `--expect-fixed` fail at tracker retention, proving
+  the regression check detects the original defect.
+- All 27 successful cache-loss transitions pass pairwise offline replay. One
+  later captured transition without successful provider usage also passes.
+- Different affinities, changed historical/leading system messages, other
+  providers, ordinary appends, moving/changing reminders, full stored snapshots,
+  ambiguous siblings, exact-match precedence, expiry, and capacity are checked.
+- Existing prefix-floor checks pass, including allowing compression improvements
+  beyond the confirmed floor.
+- Across the 28 pairwise replays, the runtime's rough character-based token
+  estimator measures 9,267,797 original tokens, 8,788,206 recorded-output tokens,
+  and 8,800,746 replayed-output tokens. Estimated compression is 5.17% before
+  versus 5.04% after replay: preserving the prior compressed bytes trades a small
+  amount of additional compression for cache stability. These estimates use a
+  different accounting method from the recorded 2.93% above.
+
+Pairwise replay seeds a confirmed floor and uses captured compressor output; it
+does not rerun the entire pipeline or measure actual provider cache reads. The
+patch is not installed into the running proxy, released, or provider-soaked.
+The required full staging day and fleet DiD remain release-promotion gates.
+The investigation does not establish the date this client behavior first rolled
+out or the exact extra subscription quota charged.

--- a/docs/fable-cache-2026-09-07.md
+++ b/docs/fable-cache-2026-09-07.md
@@ -63,6 +63,15 @@ model benchmark.
 
 ## Mechanism and offline reproduction
 
+Follow-up chronology check: the incident conversation records Claude Code
+2.1.241 on September 2 and 2.1.259 from September 3 at 10:29 Amsterdam onward.
+The retained proxy captures already contain the batching reminder on September 6
+at 17:29:46 Amsterdam, the start of the retained capture window. It therefore
+predates the reported September 7 hour; this retention window cannot establish
+its first-ever appearance. The exact string is also present in the currently
+available desktop-bundled 2.1.258 and 2.1.260 binaries. The specific release or
+feature rollout that activated it remains unverified.
+
 The installed wheel is `headroom-ai==0.37.0`. The running proxy started on
 September 6 at 17:28:28 Amsterdam time, before September 7's desktop commits.
 The installed desktop prefix-floor vendor is bound to that wheel.
@@ -160,8 +169,72 @@ Validation on September 7, 2026:
   different accounting method from the recorded 2.93% above.
 
 Pairwise replay seeds a confirmed floor and uses captured compressor output; it
-does not rerun the entire pipeline or measure actual provider cache reads. The
-patch is not installed into the running proxy, released, or provider-soaked.
-The required full staging day and fleet DiD remain release-promotion gates.
+does not rerun the entire pipeline or measure actual provider cache reads.
+The live test below subsequently verified the installed lineage fix. The required
+full staging day and fleet DiD remain release-promotion gates.
 The investigation does not establish the date this client behavior first rolled
 out or the exact extra subscription quota charged.
+
+## Live verification, September 7, 11:28-11:34 Amsterdam
+
+The restarted proxy contains the transient-system lineage repair. The user's
+three test prompts produced 13 main Fable model requests, with input growing
+from about 32k to 82k estimated tokens. Nine transitions replaced a trailing
+system reminder. Across 157 unchanged historical message positions, there were
+zero canonical changes to forwarded content.
+
+The 12 requests after the initial cold request report 664,386 cache-read tokens,
+49,646 cache-write tokens, and 472 uncached input tokens: 92.99% provider cache
+reuse. Absolute reads grow from 32,789 to 80,423 per request. The proxy records
+7,002 gross compression tokens removed across 715,612 original input tokens
+(0.98%); this repeats historical removals and is not first-appearance savings.
+This verifies cache retention at the tested size, not the entire fleet or the
+earlier 500k-token size band.
+
+## Fleet investigation and new Sentry diagnostic
+
+Read-only production queries used daily aggregates, with no user IDs or request
+contents exported. During September 1-7 (September 7 incomplete), 248 non-admin
+accounts had at least one day with >=1 million tokens sent and reported cache
+counts. Twelve had at least one day where cache reads / tokens sent was below
+0.2, comprising 14 user-days. One such user-day falls on September 6 and none
+on September 7 so far. Fleet daily median coverage remained around 0.91-0.93
+over September 3-7. The daily keys can mix local and UTC attribution; they are
+not exact UTC windows. This coverage metric is not provider cache-hit rate.
+
+These are low-coverage candidates, not confirmed instances of this defect.
+Existing fleet data combines models and conversations and lacks the historical
+prefix comparisons needed for attribution. Searching recent Sentry cache issues
+did not identify a report diagnosing this mechanism.
+
+The new observer in `SITECUSTOMIZE_PY` independently watches tracker selection
+and successful response accounting. It records a diagnostic when an unchanged
+original message inside the prior confirmed cache floor has different forwarded
+content, cache reads fell below the previous cached amount, and new cache writes
+occurred before the conservative TTL deadline. It checks retained trackers and
+can recover evidence after a reset for the proven system-tail shape. Arbitrary
+new sibling lineages are intentionally not classified as regressions.
+
+Only counters, positions, a reason enum, and a random proxy boot identifier
+leave the observer through `prefix_cache.desktop_integrity` in `/stats`. The
+desktop parses an allowlist and emits the Warning-level Sentry message
+`Headroom rewrote an unchanged cached prefix`, grouped by
+`cache-prefix-integrity` plus `tracker_reset` or `prefix_rewrite`. The first
+observation reports on the next successful dashboard stats poll. Unchanged
+snapshots are deduplicated; additional observations are limited to one event
+per hour per desktop process, even across proxy restarts.
+
+The observer neither changes traffic nor sends network requests. It is gated
+to wheel 0.37.0 with kill switch `HEADROOM_CACHE_INTEGRITY=0`; wheel upgrades
+must revalidate the hook. It does not diagnose provider eviction, changed tools
+or system headers, all possible lineage resets, or failures that never produce
+usage. Its in-memory diagnostics do not survive a proxy restart before polling.
+
+Validation: synthetic checks pass with the repair on and off; the captured
+original failure is detected at message index 3. Stable replay, beyond-floor
+compression, uncached assistant responses, changed originals/affinity, expiry,
+concurrent contexts, and
+observer exceptions are checked. A local Sentry transport test captures one
+properly grouped event with no prompt text and no network delivery. Relevant
+Rust tests, formatting, and cross-module `cargo check` pass. The new observer
+and desktop Sentry reporter are implemented in source, not yet deployed.

--- a/docs/responses-compression-budget-2026-09-07.md
+++ b/docs/responses-compression-budget-2026-09-07.md
@@ -1,0 +1,69 @@
+# Responses compression timeout follow-up
+
+The rc3 verification exposed a separate worker timeout problem. A verified
+SIGUSR1 stack dump from the running managed proxy showed the parent Responses
+compression worker waiting in `as_completed`, while its unit workers were either
+running Kompress ONNX inference or waiting for Kompress's execution semaphore.
+It was still processing small batches after the outer request timed out.
+
+The pinned 0.37.0 wheel starts a new 20-second deadline for each Kompress call.
+A large Responses request can contain hundreds of these calls. Its outer
+30-second timeout stops waiting but does not stop the worker; outstanding work
+then activates compression quarantine for unrelated requests. Raising that
+timeout or disabling quarantine would leave the underlying work unbounded.
+
+## Change
+
+The desktop injection now carries one cooperative deadline through the Responses
+request executor and its nested unit executor. It uses the existing configured
+compression budget, capped at 75% of the outer timeout to leave cleanup margin.
+Kompress receives that same deadline for its native chunk and semaphore checks.
+After expiry, router calls return the original content. Completed compression
+survives, and cancellation signals the remaining unit calls to pass through.
+
+The patch is exact-pin gated to 0.37.0. `HEADROOM_RESPONSES_SHARED_BUDGET=0`
+disables it, and the existing `HEADROOM_COMPRESSION_DEADLINE_MS=0` opt-out is
+respected. Unmarked compression executor calls retain their previous behavior.
+The sanctioned prefix-floor vendor is unchanged.
+
+## Offline validation
+
+`scripts/verify-responses-budget.py` runs against the installed wheel's real
+Responses unit adapter, batching, result reconstruction, and compression
+executors. Inference is replaced with a deterministic 25ms operation; the
+whole-payload method is narrowed to the unit adapter. Network calls are blocked.
+These are regression simulations, not ONNX or provider performance measurements.
+
+With a 120ms shared budget and 500ms outer timeout, representative results were:
+
+| Workload | Parallelism | Elapsed | Units compressed | Estimated tokens saved / before |
+| --- | --- | --- | --- | --- |
+| 100 large units | 1 | 133ms | 4 | 688 / 18,000 |
+| 100 large units | 4 | 132ms | 16 | 2,752 / 18,000 |
+| 1,000 small units batched by the adapter | 1 | 141ms | 25 | 425 / 25,000 |
+| 1,000 small units batched by the adapter | 4 | 153ms | 97 | 1,649 / 25,000 |
+
+The same four workloads with the fix disabled exceeded the outer timeout,
+activated timeout debt, and continued compression afterward. With the fix,
+all returned partial results with no remaining worker debt; untouched outputs
+and call IDs were preserved. Fast output and estimated savings matched the
+unbounded control. Cancellation, context isolation through both executor hops,
+native nested deadline propagation, keyword arguments, and opt-outs passed.
+
+All seven `behaves_against_the_installed_wheel` Rust checks passed, including
+the transient reminder repair, cache observer, and sanctioned prefix-floor
+vendor. The offline cache checks confirm stable historical replay; they cannot
+measure actual provider cache reads. No Claude/Fable quota was used.
+
+## Limits and rollout
+
+A native inference already in progress cannot safely be interrupted. A single
+hung native call can still time out and trigger the existing quarantine. The
+fix prevents the observed chain of fresh inference calls from continuing for
+minutes; it is not hard process isolation.
+
+This is a source change, not an installed rc3 update. Before stable promotion,
+run the required full staging day and fleet DiD gate in CLAUDE.md. Check both
+absolute provider cache reads and cache reads / forwarded input, plus tokens
+saved / original tokens for large requests. Offline tests do not replace that
+production validation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.11-rc.5",
+  "version": "0.9.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.11-rc.5",
+      "version": "0.9.11",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.11-rc.4",
+  "version": "0.9.11-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.11-rc.4",
+      "version": "0.9.11-rc.5",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.11-rc.1",
+  "version": "0.9.11-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.11-rc.1",
+      "version": "0.9.11-rc.2",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.11-rc.2",
+  "version": "0.9.11-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.11-rc.2",
+      "version": "0.9.11-rc.3",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.10-rc.3",
+  "version": "0.9.11-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.10-rc.3",
+      "version": "0.9.11-rc.1",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.11-rc.3",
+  "version": "0.9.11-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.11-rc.3",
+      "version": "0.9.11-rc.4",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.11-rc.1",
+  "version": "0.9.11-rc.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.11-rc.2",
+  "version": "0.9.11-rc.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.11-rc.3",
+  "version": "0.9.11-rc.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.11-rc.4",
+  "version": "0.9.11-rc.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.11-rc.5",
+  "version": "0.9.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.10-rc.3",
+  "version": "0.9.11-rc.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/reproduce-transient-system-cache.py
+++ b/scripts/reproduce-transient-system-cache.py
@@ -1,0 +1,193 @@
+"""Offline diagnostic for the September 7 Fable cache-loss incident.
+
+Run with the managed Headroom Python. By default this uses synthetic messages;
+--capture accepts the three captured transformations from the investigation
+and compares the last good request with the first bad request. Private request
+bodies are never printed. No provider calls are made: socket access is blocked.
+
+By default exit 0 means the historical bug was reproduced. --expect-fixed
+instead requires tracker retention and runs the isolation regression checks.
+--sitecustomize optionally loads the installed desktop vendor before probing.
+This probes tracker selection and byte replay, not provider cache billing.
+"""
+
+import argparse
+import copy
+import inspect
+import json
+import os
+from pathlib import Path
+import runpy
+import socket
+
+
+def deny_network(*args, **kwargs):
+    raise AssertionError("This reproducer must remain offline")
+
+
+def synthetic_pair():
+    history = [
+        {"role": "user", "content": "Inspect example.py."},
+        {"role": "assistant", "content": "Reading the file."},
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "read-1",
+                         "content": "original source line\n" * 400}],
+        },
+    ]
+    reminder = {"role": "system", "content": "Batch independent tools this turn."}
+    previous = history + [reminder]
+    current = history + [
+        {"role": "assistant", "content": "Now run the checks."},
+        {"role": "user", "content": "The checks passed."},
+        copy.deepcopy(reminder),
+    ]
+    forwarded = copy.deepcopy(previous)
+    processed = copy.deepcopy(current)
+    forwarded[2]["content"][0]["content"] = "previously cached compressed result"
+    processed[2]["content"][0]["content"] = "a different compressed result that rewrites old history"
+    return previous, forwarded, current, processed
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--capture", type=Path)
+    parser.add_argument("--sitecustomize", type=Path)
+    parser.add_argument("--expect-fixed", action="store_true")
+    args = parser.parse_args()
+
+    socket.socket.connect = deny_network
+    socket.socket.connect_ex = deny_network
+    socket.create_connection = deny_network
+    socket.getaddrinfo = deny_network
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    if args.sitecustomize:
+        os.environ["HEADROOM_SDK"] = "headroom-desktop-proxy"
+        runpy.run_path(str(args.sitecustomize))
+
+    from headroom.cache.prefix_tracker import (
+        SessionTrackerStore,
+        _canonicalize_for_prefix_compare as canonical,
+        classify_history_relation,
+        overlay_cached_prefix,
+    )
+
+    if args.capture:
+        previous_capture, current_capture = json.loads(args.capture.read_text())[-2:]
+        previous = previous_capture["request_messages"]
+        forwarded = previous_capture["compressed_messages"]
+        current = current_capture["request_messages"]
+        processed = current_capture["compressed_messages"]
+    else:
+        previous, forwarded, current, processed = synthetic_pair()
+
+    assert previous[-1]["role"] == "system"
+    stable_length = len(previous) - 1
+    assert canonical(current[:stable_length]) == canonical(previous[:-1])
+    assert classify_history_relation(current, previous).kind == "diverged"
+    assert classify_history_relation(current, previous[:-1]).kind == "message_append"
+
+    store = SessionTrackerStore()
+    prior = store.resolve_tracker("same-session", "anthropic", messages=previous,
+                                  cache_affinity="same-model-tools-thinking")
+    # Seed a confirmed cache, without pretending these synthetic counts are
+    # provider measurements. The question is whether selection retains it.
+    prior.update_from_response(
+        cache_read_tokens=0, cache_write_tokens=1_000_000,
+        messages=forwarded, original_messages=previous,
+        message_token_counts=[100] * len(previous),
+    )
+    assert prior.get_frozen_message_count() > 0
+    following = store.resolve_tracker("same-session", "anthropic", messages=current,
+                                      cache_affinity="same-model-tools-thinking")
+    if args.expect_fixed:
+        assert following is prior, "unchanged history lost its tracker"
+        assert following.get_frozen_message_count() == prior.get_frozen_message_count() > 0
+        verify_isolation()
+    else:
+        assert following is not prior
+        assert following.get_frozen_message_count() == 0
+
+    kwargs = {}
+    if "confirmed_frozen_count" in inspect.signature(overlay_cached_prefix).parameters:
+        kwargs["confirmed_frozen_count"] = prior.get_frozen_message_count()
+    # The existing overlay must stop before the replaced reminder.
+    repaired = overlay_cached_prefix(copy.deepcopy(processed), current,
+                                     previous, forwarded, **kwargs)
+    assert canonical(repaired[:stable_length]) == canonical(forwarded[:-1])
+    assert repaired[stable_length:] == processed[stable_length:]
+    assert canonical(processed[:stable_length]) != canonical(forwarded[:-1])
+    print("PASS: tracker retention and isolation" if args.expect_fixed else
+          "REPRODUCED: temporary system tail loses confirmed tracker state")
+    print("PASS: unchanged forwarded prefix restored; current tail preserved")
+    print(f"Unchanged historical messages: {stable_length}; no network calls")
+
+
+def verify_isolation():
+    from headroom.cache import prefix_tracker as pt
+
+    previous, _, current, _ = synthetic_pair()
+
+    def resolve(store, messages, affinity="same", provider="anthropic"):
+        return store.resolve_tracker("session", provider, messages, affinity)
+
+    def seeded():
+        store = pt.SessionTrackerStore()
+        return store, resolve(store, previous)
+
+    store, prior = seeded()
+    assert resolve(store, current, "different-tools") is not prior
+    store, prior = seeded()
+    changed = copy.deepcopy(current)
+    changed[0]["content"] = "Different conversation"
+    assert resolve(store, changed) is not prior
+    store, prior = seeded()
+    assert resolve(store, current, provider="openai") is not prior
+    store, prior = seeded()
+    assert resolve(store, previous + [{"role": "assistant", "content": "append"}]) is prior
+
+    # Leading and historical system instructions remain part of identity.
+    for index in (0, 2):
+        before, after = copy.deepcopy(previous), copy.deepcopy(current)
+        before.insert(index, {"role": "system", "content": "original instruction"})
+        after.insert(index, {"role": "system", "content": "changed instruction"})
+        store = pt.SessionTrackerStore()
+        prior = resolve(store, before)
+        assert resolve(store, after) is not prior
+
+    # Store full snapshots even while the reminder moves and changes.
+    store, prior = seeded()
+    for i in range(4):
+        current[-1]["content"] = f"Current instruction {i}"
+        assert resolve(store, current) is prior
+        assert store._lineages["session"]["session"] == pt._lineage_snapshot(
+            pt._canonicalize_for_prefix_compare(current))
+        current = current[:-1] + [{"role": "assistant", "content": f"reply {i}"},
+                                 {"role": "system", "content": "next reminder"}]
+
+    # Existing sibling snapshots can predate the shim.
+    store, prior = seeded()
+    sibling = copy.deepcopy(previous)
+    sibling[-1]["content"] = "other reminder"
+    other = store.get_or_create("session\x00sibling", "anthropic")
+    store._lineages["session"]["session\x00sibling"] = pt._lineage_snapshot(
+        pt._canonicalize_for_prefix_compare(sibling))
+    store._lineage_affinities["session\x00sibling"] = "same"
+    assert resolve(store, current) not in (prior, other), "ambiguous siblings merged"
+    assert resolve(store, sibling) is other, "exact match must win"
+
+    store, prior = seeded()
+    prior._last_activity = 0
+    store._last_cleanup = 0
+    assert resolve(store, current) is not prior, "expired tracker resurrected"
+
+    store = pt.SessionTrackerStore(pt.PrefixFreezeConfig(max_lineages_per_session=1))
+    prior = resolve(store, previous)
+    assert resolve(store, current) is prior, "continuation at capacity overflowed"
+    assert resolve(store, changed) is not prior
+    print("PASS: affinity/history/provider isolation, append, moving reminders, "
+          "full snapshots, ambiguity, exact precedence, expiry, capacity")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,433 @@
+#!/usr/bin/env bash
+# Runs the non-Codex half of docs/beta-smoke-test.md and prints a PASS/FAIL table.
+#
+# The doc stays the "why" reference - every past false-FAIL it records (the
+# 0.9.1-rc.2 rtkDisabled gate, the 0.8.1-rc.2 lsof pid, the 0.7.6-rc.1 hung
+# curl, the 0.9.11-rc.4 resume sleep) was someone re-implementing a step the
+# doc already spelled out and getting it subtly wrong. Those steps live here
+# now so they cannot drift.
+#
+#   ./scripts/smoke-test.sh           full pass (restarts the app twice)
+#   ./scripts/smoke-test.sh --quick   skip checks 6, 9 and 12's SIGUSR1 probe
+#
+# Checks 4, 7 and the visual half of 5/16 cannot be driven from a shell; they
+# are reported as MANUAL/PENDING with the exact follow-up.
+
+set -uo pipefail
+
+QUICK=0
+[ "${1:-}" = "--quick" ] && QUICK=1
+
+APP="/Applications/Headroom.app"
+SUP="$HOME/Library/Application Support/Headroom"
+CFG="$SUP/config"
+HR="$SUP/headroom"
+PROXY_LOG="$HOME/.headroom/logs/proxy.log"
+BASELINE="${TMPDIR:-/tmp}/hr-smoke-baseline.json"
+SHOTS="${TMPDIR:-/tmp}/hr-smoke-shots"
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+FAILED=0
+ROWS=()
+row() { # status, check, detail
+  ROWS+=("$1|$2|$3")
+  [ "$1" = "FAIL" ] && FAILED=1
+  printf '  %-7s %-34s %s\n' "$1" "$2" "$3"
+  return 0   # called as `cond && row PASS || row FAIL`; must never fire the || branch
+}
+have() { command -v "$1" >/dev/null 2>&1; }
+
+AX() { osascript -e "tell application \"System Events\" to tell process \"Headroom\" $1" 2>&1; }
+
+# The backend listens on 6768 by default but scans up to 6790 (check 9). 6767 is
+# the desktop's own intercept listener, never the backend, so start the window
+# above it.
+backend_port() {
+  lsof -iTCP -sTCP:LISTEN -nP 2>/dev/null \
+    | awk '$1 ~ /(python|headroom)/ && $9 ~ /:(67[6-9][0-9]|6790)$/ {
+             split($9, a, ":"); if (a[2] >= 6768) print a[2] }' \
+    | sort -n | head -1
+}
+
+# Resolve the pid exactly as the doc insists: a bare `lsof -ti :PORT` also
+# matches the desktop's client connection and head -1 then returns the desktop.
+backend_pid() { lsof -ti "TCP:${1}" -sTCP:LISTEN 2>/dev/null | head -1; }
+
+livez() { curl -sS --max-time 3 -o /dev/null -w '%{http_code}' "http://127.0.0.1:6767/livez" 2>/dev/null; }
+
+wait_livez() { # seconds
+  local code=""
+  for _ in $(seq 1 "$1"); do
+    code=$(livez)
+    [ "$code" = "200" ] && break
+    sleep 1
+  done
+  echo "$code"
+}
+
+# `open -a` against a still-dying instance just activates it, so poll for the
+# process to actually go away. The executable is headroom-desktop, not Headroom.
+quit_app() {
+  osascript -e 'quit app "Headroom"' >/dev/null 2>&1
+  for _ in $(seq 1 30); do pgrep -xq headroom-desktop || break; sleep 0.5; done
+}
+
+# proxy.log survives backend restarts, so every count in checks 11 and 13 has to
+# be scoped to the current boot or pre-fix history keeps them non-zero forever.
+# Untimestamped continuation lines inherit the state of the line above them.
+since_boot() {
+  [ -f "$PROXY_LOG" ] || return 0
+  awk -v B="$BOOT_TS" '
+    /^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] /{ on = (substr($0,1,19) >= B) }
+    on' "$PROXY_LOG"
+}
+count_since_boot() { since_boot | grep -c "$1"; }
+
+set_boot_ts() {
+  local pid lstart
+  pid=$(backend_pid "$PORT")
+  BOOT_TS="0000-00-00 00:00:00"
+  [ -n "$pid" ] || return 0
+  lstart=$(ps -o lstart= -p "$pid" 2>/dev/null)
+  [ -n "$lstart" ] || return 0
+  BOOT_TS=$(date -j -f "%a %b %e %T %Y" "$lstart" +"%Y-%m-%d %H:%M:%S" 2>/dev/null || echo "0000-00-00 00:00:00")
+}
+
+mkdir -p "$SHOTS"
+PORT=$(backend_port)
+[ -n "$PORT" ] || PORT=6768
+set_boot_ts
+
+echo "Headroom beta smoke test (non-Codex)"
+echo "  backend port $PORT, booted $BOOT_TS$([ "$QUICK" = 1 ] && echo ', --quick')"
+echo
+
+# --- 1. version -------------------------------------------------------------
+installed=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$APP/Contents/Info.plist" 2>/dev/null)
+expected=$(jq -r '.version // empty' "$REPO/src-tauri/tauri.conf.json" 2>/dev/null)
+if [ -z "$installed" ]; then
+  row FAIL "1 version" "Info.plist unreadable"
+elif [ -n "$expected" ] && [ "$installed" != "$expected" ]; then
+  row FAIL "1 version" "installed $installed, repo says $expected"
+else
+  row PASS "1 version" "$installed${expected:+ (matches repo)}"
+fi
+
+# --- 2. proxy is intercepting ----------------------------------------------
+if [ -f "$CFG/activity-facts.json" ]; then
+  age=$(( $(date +%s) - $(stat -f %m "$CFG/activity-facts.json") ))
+  if [ "$age" -lt 120 ]; then
+    row PASS "2 intercepting" "activity-facts ${age}s old"
+  else
+    row FAIL "2 intercepting" "activity-facts ${age}s old (needs a live client session)"
+  fi
+else
+  row FAIL "2 intercepting" "activity-facts.json missing"
+fi
+
+# --- 3. RTK (opt-in addon; absent is the correct state) ---------------------
+if [ -x "$HR/bin/rtk" ]; then
+  if zsh -lc 'rtk --version' >/dev/null 2>&1; then
+    row PASS "3 rtk" "$(zsh -lc 'rtk --version' 2>/dev/null | head -1)"
+  else
+    row FAIL "3 rtk" "installed but not on a login shell's PATH"
+  fi
+else
+  row SKIP "3 rtk" "not installed (opt-in addon)"
+fi
+
+# --- 4. MCP retrieve --------------------------------------------------------
+row MANUAL "4 mcp retrieve" "call mcp__headroom__headroom_retrieve; any structured payload passes"
+
+# --- 8. bundled runtime -----------------------------------------------------
+venv="$HR/runtime/venv"
+ver=$("$venv/bin/headroom" --version 2>&1 | head -1)
+mod=$("$venv/bin/python3" -c "import headroom; print(headroom.__file__)" 2>&1 | head -1)
+if [[ "$ver" == *"version"* ]] && [[ "$mod" == *"/site-packages/headroom/__init__.py" ]]; then
+  row PASS "8 runtime" "$ver"
+else
+  row FAIL "8 runtime" "$ver / $mod"
+fi
+rec=$(jq -r .version "$HR/tools/markitdown.json" 2>/dev/null)
+art=$("$HR/bin/markitdown" --version 2>&1 | awk '{print $NF}')
+if [ -n "$rec" ] && [ "$rec" = "$art" ]; then
+  row PASS "8 addon receipts" "markitdown $rec == $art"
+else
+  row FAIL "8 addon receipts" "markitdown receipt $rec != artifact $art"
+fi
+# Plugin addons track a marketplace, so a receipt lagging is expected; they only
+# have to resolve to a version string at all.
+unresolved=$(jq -r '.plugins | to_entries[] | select((.value[0].version // "?") == "?") | .key' \
+  "$HOME/.claude/plugins/installed_plugins.json" 2>/dev/null)
+if [ -z "$unresolved" ]; then
+  row PASS "8 plugins resolve" "$(jq -r '.plugins | length' "$HOME/.claude/plugins/installed_plugins.json" 2>/dev/null) plugins"
+else
+  row FAIL "8 plugins resolve" "unresolved: $(echo "$unresolved" | tr '\n' ' ')"
+fi
+
+# --- 10. auth / pricing -----------------------------------------------------
+if security find-generic-password -s com.extraheadroom.headroom.account -a session-token >/dev/null 2>&1; then
+  seen=$(jq -r '.first_seen_at // empty' "$CFG/headroom-pricing-state.json" 2>/dev/null)
+  if [ -n "$seen" ] && [ "$seen" != "null" ]; then
+    row PASS "10 auth/pricing" "signed in, first_seen_at $seen"
+  else
+    row FAIL "10 auth/pricing" "signed in but first_seen_at missing"
+  fi
+else
+  row FAIL "10 auth/pricing" "not signed in (regression if this build was)"
+fi
+
+# --- 11. computed transforms reached the wire -------------------------------
+if [ -f "$PROXY_LOG" ]; then
+  c11a=$(count_since_boot 'ccr_streaming_retrieve_buffered[^ ]* source=passthrough')
+  c11b=$(count_since_boot 'body_mutated=true.*source=passthrough')
+  [ "$c11a" = "0" ] && row PASS "11a empty-200 class" "0" \
+    || row FAIL "11a empty-200 class" "$c11a streaming CCR passthroughs since boot"
+  if [ "$c11b" = "0" ]; then
+    row PASS "11b discard rate" "0"
+  else
+    reasons=$(since_boot | grep 'body_mutated=true.*source=passthrough' \
+      | sed -n 's/.*mutation_reasons=\([^ ]*\).*/\1/p' | tr ',' '\n' | sort | uniq -c \
+      | sort -rn | head -3 | awk '{printf "%s x%s ", $2, $1}')
+    row FAIL "11b discard rate" "$c11b discarded since boot: $reasons"
+  fi
+else
+  row FAIL "11 wire truth" "proxy.log missing at $PROXY_LOG"
+fi
+
+# --- 13. billed for an unusable response ------------------------------------
+if [ -f "$PROXY_LOG" ]; then
+  c13a=$(count_since_boot 'PERF model=claude-[^ ]* .*tok_out=0 ')
+  c13b=$(count_since_boot 'response_cache_store_refused')
+  c13c=$(since_boot | grep 'PERF model=claude-' | awk '
+    { for (i = 1; i <= NF; i++) {
+        if ($i ~ /^total_ms=/) t = substr($i, 10) + 0
+        if ($i ~ /^tok_out=/)  o = substr($i, 9) + 0 }
+      if (t < 20 && o == 0) n++ } END { print n + 0 }')
+  # tok_out=0 carries no status, so an upstream error passed through looks the
+  # same. Non-zero is a tripwire to go read the matching inbound_response line.
+  [ "$c13a" = "0" ] && row PASS "13 tok_out=0" "0" \
+    || row FAIL "13 tok_out=0" "$c13a since boot - join to inbound_response by timestamp; 200 = bug, 4xx/5xx = benign"
+  [ "$c13b" = "0" ] && row PASS "13 cache store guard" "0" \
+    || row FAIL "13 cache store guard" "$c13b refusals - treat as a wheel-bump regression"
+  [ "$c13c" = "0" ] && row PASS "13 poisoned replay" "0" \
+    || row FAIL "13 poisoned replay" "$c13c sub-20ms empty 200s (only a restart clears one)"
+fi
+
+# --- 14. user state survived the upgrade ------------------------------------
+PRE="$CFG/pre-update"
+if [ -f "$PRE/meta.json" ]; then
+  from=$(jq -r '.from_version // "?"' "$PRE/meta.json")
+  to=$(jq -r '.to_version // "?"' "$PRE/meta.json")
+  if [ "$to" != "$installed" ]; then
+    row FAIL "14 snapshot freshness" "snapshot is $from -> $to but $installed is installed"
+  else
+    row PASS "14 snapshot freshness" "$from -> $to"
+    a=$(jq -c '.first_seen_at' "$CFG/headroom-pricing-state.json" 2>/dev/null)
+    b=$(jq -c '.first_seen_at' "$PRE/headroom-pricing-state.json" 2>/dev/null)
+    [ "$a" = "$b" ] && row PASS "14 first_seen_at" "$a" \
+      || row FAIL "14 first_seen_at" "now $a, was $b"
+    # The auto-snapshot is taken post-quit, where clear_client_setups() has
+    # already emptied configuredClients - rememberedClients is the surviving set.
+    a=$(jq -c '.rememberedClients|keys' "$CFG/client-setup.json" 2>/dev/null)
+    b=$(jq -c '.rememberedClients|keys' "$PRE/client-setup.json" 2>/dev/null)
+    [ "$a" = "$b" ] && row PASS "14 remembered clients" "$a" \
+      || row FAIL "14 remembered clients" "now $a, was $b"
+    # A schemaVersion bump intentionally drops tile slots, so diff only the two
+    # fields that must survive one: wiping them re-fires the weekly recap and
+    # resets all-time records for every user.
+    a=$(jq -c '{t:.allTimeRecordTokens,r:.lastWeeklyRecapWeekKey}' "$CFG/activity-facts.json" 2>/dev/null)
+    b=$(jq -c '{t:.allTimeRecordTokens,r:.lastWeeklyRecapWeekKey}' "$PRE/activity-facts.json" 2>/dev/null)
+    [ "$a" = "$b" ] && row PASS "14 records/recap" "$a" \
+      || row FAIL "14 records/recap" "now $a, was $b"
+  fi
+else
+  row FAIL "14 snapshot freshness" "no $PRE/meta.json (build <0.9.3, or first launch never happened)"
+fi
+# grep -c, not `ls *.corrupt`: zsh aborts the line on an empty glob, which is
+# the healthy case.
+corrupt=$(ls "$CFG" 2>/dev/null | grep -c '\.corrupt$')
+[ "$corrupt" = "0" ] && row PASS "14 quarantine files" "0" \
+  || row FAIL "14 quarantine files" "$corrupt - jq the .corrupt file, fix goes on the struct"
+
+# --- 15. CLAUDE.md intact ---------------------------------------------------
+for f in "$HOME/.claude/CLAUDE.md" "$REPO/CLAUDE.md"; do
+  [ -f "$f" ] || continue
+  ms=$(grep -c '^# >>> headroom:markitdown_office >>>' "$f")
+  me=$(grep -c '^# <<< headroom:markitdown_office <<<' "$f")
+  ls_=$(grep -c '<!-- headroom:learn:start -->' "$f")
+  le=$(grep -c '<!-- headroom:learn:end -->' "$f")
+  bytes=$(awk '/headroom:(learn:start|markitdown_office >>>)/{skip=1} !skip{n+=length($0)+1} /headroom:(learn:end|markitdown_office <<<)/{skip=0} END{print n+0}' "$f")
+  label="15 $(basename "$(dirname "$f")")/CLAUDE.md"
+  if [ "$ms" = "$me" ] && [ "$ls_" = "$le" ] && [ "$ms" -le 1 ] && [ "$ls_" -le 1 ]; then
+    row PASS "$label" "markitdown $ms/$me, learn $ls_/$le, ${bytes}B user content"
+  else
+    row FAIL "$label" "markitdown $ms/$me, learn $ls_/$le (2/2 = duplicated block, 1/0 = truncated write)"
+  fi
+done
+
+# --- 16. lifetime card covers saved today -----------------------------------
+ring=$(curl -s "http://127.0.0.1:6767/stats-history" \
+  | jq -r --arg d "$(date -u +%Y-%m-%d)" \
+      '[.series.daily[] | select(.timestamp | startswith($d)) | .compression_savings_usd_delta] | add // 0' 2>/dev/null)
+if [ -n "$ring" ]; then
+  row PASS "16 ring today (UTC)" "\$$ring compression - chart's 'saved today' must be this plus shaping, not a fraction of it"
+else
+  row FAIL "16 ring today (UTC)" "/stats-history unreadable"
+fi
+
+# --- 5. dashboard opens -----------------------------------------------------
+open -a Headroom >/dev/null 2>&1
+sleep 2
+AX 'to click menu bar item 1 of menu bar 2' >/dev/null
+sleep 1
+menu=$(AX 'to get name of every menu item of menu 1 of menu bar item 1 of menu bar 2')
+AX 'to click menu item "Show Headroom" of menu 1 of menu bar item 1 of menu bar 2' >/dev/null
+sleep 5
+geom=$(AX 'to get {position, size} of window 1' | tr -d ' ')
+if [[ "$menu" == *"Headroom"* ]] && [[ "$geom" =~ ^([0-9-]+),([0-9-]+),([0-9]+),([0-9]+)$ ]]; then
+  x=${BASH_REMATCH[1]}; y=${BASH_REMATCH[2]}; w=${BASH_REMATCH[3]}; h=${BASH_REMATCH[4]}
+  shot="$SHOTS/dashboard-$(date +%H%M%S).png"
+  screencapture -x -o -R"$x,$y,$w,$h" "$shot" 2>/dev/null
+  row PASS "5 dashboard opens" "${w}x${h} window; eyeball $shot"
+  row MANUAL "16 lifetime >= today" "in that screenshot: 'Total costs saved' >= chart's 'saved today'"
+else
+  row FAIL "5 dashboard opens" "no window after Show Headroom (menu: $menu)"
+fi
+
+# --- 7. actively optimizing (needs a large Read between two runs) -----------
+snap=$(curl -s "http://127.0.0.1:6767/stats" | jq -c '{
+  frozen: (.summary.uncompressed_requests.prefix_frozen // 0),
+  compressed: (.summary.compression.requests_compressed // 0),
+  cache_usd: (.summary.cost.breakdown.cache_savings_usd // 0),
+  before: (.summary.compression.total_tokens_before // 0),
+  claude: (.requests.by_model // {} | with_entries(select(.key|startswith("claude-"))) | to_entries | map(.value) | add // 0)
+}' 2>/dev/null)
+if [ -z "$snap" ] || [ "$snap" = "null" ]; then
+  row FAIL "7 optimizing" "/stats unreadable"
+elif [ -f "$BASELINE" ]; then
+  o=$(cat "$BASELINE")
+  d() { echo "$1" | jq -r ".$2"; }
+  dc=$(( $(d "$snap" claude) - $(d "$o" claude) ))
+  db=$(( $(d "$snap" before) - $(d "$o" before) ))
+  dr=$(( ($(d "$snap" frozen) + $(d "$snap" compressed)) - ($(d "$o" frozen) + $(d "$o" compressed)) ))
+  du=$(echo "$(d "$snap" cache_usd) > $(d "$o" cache_usd)" | bc -l)
+  if [ "$dc" -gt 0 ] && [ "$db" -gt 0 ] && [ "$dr" -ge 1 ] && [ "$du" = "1" ]; then
+    row PASS "7 optimizing" "+$dc claude reqs, +$db tok_before, +$dr compressed/frozen, cache_savings up"
+  else
+    row FAIL "7 optimizing" "+$dc claude reqs, +$db tok_before, +$dr compressed/frozen, cache_usd_grew=$du"
+  fi
+  rm -f "$BASELINE"
+else
+  echo "$snap" > "$BASELINE"
+  row PENDING "7 optimizing" "baseline saved; do a ~1400-line Read (the tool, not cat), then re-run"
+fi
+
+# --- disruptive block -------------------------------------------------------
+if [ "$QUICK" = 1 ]; then
+  row SKIP "9 port fallback" "--quick"
+  row SKIP "6 pause/resume" "--quick"
+  row SKIP "12 sitecustomize imported" "--quick"
+else
+  # --- 9. backend port fallback when 6768 is held ---------------------------
+  quit_app
+  python3 -c "import socket,time; s=socket.socket(); s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1); s.bind(('127.0.0.1',6768)); s.listen(16); time.sleep(180)" &
+  blocker=$!
+  sleep 1
+  open -a Headroom >/dev/null 2>&1
+  # A fallback port boots cold (memory tools, model load), so poll rather than
+  # sleep, and keep --max-time on every curl: one hung curl against a
+  # half-booted intercept strands the whole script.
+  code=$(wait_livez 90)
+  fb=$(backend_port)
+  kill "$blocker" 2>/dev/null
+  wait "$blocker" 2>/dev/null
+  if [ "$code" = "200" ] && [ -n "$fb" ] && [ "$fb" != "6768" ]; then
+    row PASS "9 port fallback" "6768 held, backend took $fb"
+  else
+    row FAIL "9 port fallback" "livez=$code, backend port=${fb:-none} (wanted != 6768)"
+  fi
+  quit_app
+  open -a Headroom >/dev/null 2>&1
+  code=$(wait_livez 90)
+  PORT=$(backend_port); [ -n "$PORT" ] || PORT=6768
+  set_boot_ts
+  [ "$code" = "200" ] && [ "$PORT" = "6768" ] \
+    && row PASS "9 port restored" "back on 6768" \
+    || row FAIL "9 port restored" "livez=$code, port=$PORT"
+
+  # --- 6. pause / resume ----------------------------------------------------
+  before=$(cat "$HOME/.zprofile" "$HOME/.zshrc" 2>/dev/null | grep -c 'headroom:claude_code')
+  AX 'to click menu bar item 1 of menu bar 2' >/dev/null; sleep 1
+  AX 'to click menu item "Pause Headroom" of menu 1 of menu bar item 1 of menu bar 2' >/dev/null
+  sleep 5
+  paused=$(cat "$HOME/.zprofile" "$HOME/.zshrc" 2>/dev/null | grep -c 'headroom:claude_code')
+  AX 'to click menu bar item 1 of menu bar 2' >/dev/null; sleep 1
+  AX 'to click menu item "Resume Headroom" of menu 1 of menu bar item 1 of menu bar 2' >/dev/null
+  # Resume is start_headroom -> resume_runtime -> ensure_headroom_running, and
+  # only then the restore thread, so this waits on a cold Python boot (15-20s
+  # measured). A fixed sleep here scores a healthy build as a FAIL.
+  for _ in $(seq 1 60); do
+    [ "$(cat "$HOME/.zprofile" "$HOME/.zshrc" 2>/dev/null | grep -c 'headroom:claude_code')" = "$before" ] && break
+    sleep 1
+  done
+  resumed=$(cat "$HOME/.zprofile" "$HOME/.zshrc" 2>/dev/null | grep -c 'headroom:claude_code')
+  if [ "$before" -gt 0 ] && [ "$paused" = "0" ] && [ "$resumed" = "$before" ]; then
+    row PASS "6 pause/resume" "$before -> 0 -> $resumed markers"
+  else
+    row FAIL "6 pause/resume" "$before -> $paused -> $resumed markers (wanted N -> 0 -> N)"
+  fi
+  wait_livez 60 >/dev/null
+  PORT=$(backend_port); [ -n "$PORT" ] || PORT=6768
+  set_boot_ts
+fi
+
+# --- 12. the running proxy has the configured flags and patches -------------
+pid=$(backend_pid "$PORT")
+if [ -z "$pid" ]; then
+  row FAIL "12 backend pid" "nothing listening on $PORT"
+else
+  noccr=$(ps -o args= -p "$pid" | tr ' ' '\n' | grep -c -- '--no-ccr')
+  inj=$(ps eww -o command= -p "$pid" | grep -c 'pyinject')
+  guard=$(grep -c '_hd_sc_cacheable' "$HR/pyinject/sitecustomize.py" 2>/dev/null)
+  # 0.9.6 re-enabled CCR, so --no-ccr is opt-in now; a 1 means the kill switch
+  # is set for this session, not that the build is broken.
+  [ "$noccr" = "0" ] && row PASS "12 ccr enabled" "no --no-ccr (default)" \
+    || row FAIL "12 ccr enabled" "--no-ccr present, CCR is OFF this session"
+  [ "$inj" = "1" ] && row PASS "12 pyinject on path" "PYTHONPATH set" \
+    || row FAIL "12 pyinject on path" "pyinject not on the backend's env"
+  [ "${guard:-0}" -gt 0 ] && row PASS "12 cache guard on disk" "$guard hits" \
+    || row FAIL "12 cache guard on disk" "_hd_sc_cacheable absent from sitecustomize.py"
+
+  if [ "$QUICK" = 1 ]; then
+    : # SIGUSR1 already reported as skipped above
+  else
+    # Definitive proof sitecustomize was IMPORTED, not merely present. The dump
+    # lands in the per-boot log, not ~/.headroom/logs/proxy.log. Destructive
+    # when injection did not happen: Python has no handler and the OS default
+    # terminates the proxy. Acceptable on a beta box, cheap to restart.
+    name=$(ls -t "$HR/logs" 2>/dev/null | grep -m1 "headroom-proxy---port-${PORT}-")
+    perboot="$HR/logs/$name"
+    was=$(grep -c 'Thread 0x' "$perboot" 2>/dev/null); was=${was:-0}
+    kill -USR1 "$pid" 2>/dev/null
+    sleep 2
+    now=$(grep -c 'Thread 0x' "$perboot" 2>/dev/null); now=${now:-0}
+    if [ -z "$name" ]; then
+      row FAIL "12 sitecustomize imported" "no per-boot log for port $PORT"
+    elif kill -0 "$pid" 2>/dev/null && [ "$now" -gt "$was" ]; then
+      row PASS "12 sitecustomize imported" "survived SIGUSR1, dumped $((now - was)) thread lines"
+    elif kill -0 "$pid" 2>/dev/null; then
+      row FAIL "12 sitecustomize imported" "survived SIGUSR1 but no thread dump in $(basename "$perboot")"
+    else
+      row FAIL "12 sitecustomize imported" "proxy terminated - sitecustomize was never imported"
+    fi
+  fi
+fi
+
+echo
+n_pass=$(printf '%s\n' "${ROWS[@]}" | grep -c '^PASS|')
+n_fail=$(printf '%s\n' "${ROWS[@]}" | grep -c '^FAIL|')
+n_other=$(( ${#ROWS[@]} - n_pass - n_fail ))
+echo "  $n_pass pass, $n_fail fail, $n_other skipped/manual/pending"
+[ "$FAILED" = "1" ] && echo "  Do not promote. See docs/beta-smoke-test.md for what each check means."
+exit "$FAILED"

--- a/scripts/verify-cache-integrity.py
+++ b/scripts/verify-cache-integrity.py
@@ -1,0 +1,171 @@
+"""Offline checks for the desktop cache-integrity observer; no Sentry/provider calls.
+
+Run with managed Python and --sitecustomize pointing to the candidate injection.
+--broken-lineage disables the repair to verify detection of the original defect.
+"""
+
+import argparse
+import copy
+import contextvars
+import json
+import os
+from pathlib import Path
+import runpy
+import socket
+from unittest.mock import patch
+
+
+def deny_network(*args, **kwargs):
+    raise AssertionError("cache-integrity checks must stay offline")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sitecustomize", type=Path, required=True)
+    parser.add_argument("--broken-lineage", action="store_true")
+    parser.add_argument("--capture", type=Path, help="Optional saved three-request incident capture")
+    args = parser.parse_args()
+    socket.socket.connect = socket.socket.connect_ex = deny_network
+    socket.create_connection = socket.getaddrinfo = deny_network
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    os.environ["HEADROOM_SDK"] = "headroom-desktop-proxy"
+    if args.broken_lineage:
+        os.environ["HEADROOM_TRANSIENT_SYSTEM_LINEAGE"] = "0"
+    runpy.run_path(str(args.sitecustomize))
+
+    from headroom.cache import prefix_tracker as pt
+    from headroom.proxy import cost
+    from headroom.proxy.prometheus_metrics import PrometheusMetrics
+
+    fixture = runpy.run_path(str(Path(__file__).with_name("reproduce-transient-system-cache.py")))
+    previous, forwarded, current, drifted = fixture["synthetic_pair"]()
+    metrics = PrometheusMetrics(stateless=True)
+
+    def stats():
+        return cost.build_prefix_cache_stats(metrics, None)["desktop_integrity"]
+
+    def resolve(store, messages, affinity="same"):
+        return store.resolve_tracker("session", "anthropic", messages, affinity)
+
+    def seeded(floor=4):
+        store = pt.SessionTrackerStore()
+        prior = resolve(store, previous)
+        prior.update_from_response(0, 20_000, copy.deepcopy(forwarded),
+                                   [20_000 // floor] * 4, copy.deepcopy(previous))
+        assert prior.get_frozen_message_count() == floor
+        return store, prior
+
+    def complete(tracker, original=current, output=drifted, reads=100, writes=19_900):
+        tracker.update_from_response(reads, writes, copy.deepcopy(output),
+                                     original_messages=copy.deepcopy(original))
+
+    before = stats()["count"]
+    store, prior = seeded()
+    selected = resolve(store, current)
+    untouched = copy.deepcopy(drifted)
+    complete(selected)
+    assert drifted == untouched, "observer mutated request data"
+    assert selected.get_last_forwarded_messages() == drifted
+    assert stats()["count"] == before + 1
+    assert stats()["kind"] == ("tracker_reset" if args.broken_lineage else "prefix_rewrite")
+    assert stats()["first_changed_message"] == 2
+    assert stats()["stable_messages"] == 3
+    assert "original source" not in json.dumps(stats())
+    print("PASS: confirmed prefix drift detected with numeric-only diagnostics")
+
+    before = stats()["count"]
+    store, prior = seeded()
+    selected = resolve(store, current)
+    repaired = pt.overlay_cached_prefix(copy.deepcopy(drifted), current, previous, forwarded,
+                                        confirmed_frozen_count=4)
+    complete(selected, output=repaired)
+    assert stats()["count"] == before, "stable replay raised an alarm"
+
+    store, prior = seeded(floor=2)
+    complete(resolve(store, current))
+    assert stats()["count"] == before, "beyond-floor compression raised an alarm"
+
+    # The provider's previous RESPONSE is appended to tracker history, but was
+    # not cached input. A rough token floor can overshoot into that last reply.
+    store, prior = seeded()
+    response = {"role": "assistant", "content": "fresh response " * 200}
+    prior.update_from_response(0, 20_000, forwarded + [response], [100] * 5,
+                               previous + [response])
+    incoming = previous + [response, {"role": "user", "content": "continue"}]
+    optimized = copy.deepcopy(forwarded + incoming[4:])
+    optimized[4]["content"] = "compressed response"
+    complete(resolve(store, incoming), original=incoming, output=optimized)
+    assert stats()["count"] == before, "new assistant response treated as previously cached"
+
+    store, prior = seeded()
+    complete(resolve(store, current), reads=20_000, writes=500)
+    store, prior = seeded()
+    complete(resolve(store, current), reads=0, writes=0)
+    assert stats()["count"] == before, "cache hit or missing usage raised an alarm"
+
+    store, prior = seeded()
+    changed = copy.deepcopy(current)
+    changed[0]["content"] = "A different task"
+    complete(resolve(store, changed), original=changed)
+    store, prior = seeded()
+    complete(resolve(store, current, "different-tools"))
+    store, prior = seeded()
+    branch = copy.deepcopy(current)
+    branch[2]["content"][0]["content"] = "changed original tool result"
+    complete(resolve(store, branch), original=branch)
+    assert stats()["count"] == before, "changed history, affinity, or sibling raised an alarm"
+
+    store, prior = seeded()
+    prior.config.cache_ttl_seconds = 1
+    prior._last_activity -= 2
+    complete(resolve(store, current))
+    store, prior = seeded()
+    prior.config.cache_ttl_seconds = 1
+    with patch("time.monotonic", return_value=100):
+        selected = resolve(store, current)
+    with patch("time.monotonic", return_value=102):
+        complete(selected)
+    assert stats()["count"] == before, "expired cache raised an alarm"
+    print("PASS: stable replay, beyond-floor compression, hits, history, affinity, TTL")
+
+    # Two concurrent requests must not borrow each other's evidence.
+    store_a, _ = seeded()
+    store_b, _ = seeded()
+    a, b = contextvars.copy_context(), contextvars.copy_context()
+    tracker_a = a.run(resolve, store_a, current)
+    tracker_b = b.run(resolve, store_b, current)
+    b.run(complete, tracker_b, current, repaired)
+    a.run(complete, tracker_a)
+    assert stats()["count"] == before + 1
+
+    # Observability failure must not stop the tracker from recording a response.
+    store, _ = seeded()
+    selected = resolve(store, current)
+    with patch.object(pt, "_canonicalize_for_prefix_compare", side_effect=RuntimeError("probe")):
+        complete(selected)
+    assert selected.get_last_forwarded_messages() == drifted
+    assert stats()["count"] == before + 1
+    print("PASS: concurrent contexts isolated; observer failure does not affect response state")
+
+    from headroom.proxy import server
+    assert server._build_prefix_cache_stats(metrics, None)["desktop_integrity"] == stats()
+    print("PASS: the server's /stats helper exposes the same diagnostic snapshot")
+
+    if args.capture:
+        old, new = json.loads(args.capture.read_text())[-2:]
+        store = pt.SessionTrackerStore()
+        prior = resolve(store, old["request_messages"])
+        prior.update_from_response(0, 1_000_000, old["compressed_messages"],
+                                   original_messages=old["request_messages"])
+        before = stats()["count"]
+        selected = resolve(store, new["request_messages"])
+        # Actual cache counts for the captured September 7 failure.
+        complete(selected, new["request_messages"], new["compressed_messages"], 7259, 491260)
+        assert stats()["count"] == before + 1
+        assert stats()["first_changed_message"] == 3
+        assert stats()["stable_messages"] == 861
+        print("PASS: captured Fable failure detected at historical message 3")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify-first-appearance.py
+++ b/scripts/verify-first-appearance.py
@@ -14,10 +14,13 @@ wheel:
      two-request sequence are byte-identical to a control subprocess running
      with HEADROOM_MATURATION_FIRST_APPEARANCE=0. The vendor must only
      observe the transform, never change what is forwarded.
-  3. accounting: the newly-matured request accumulates nothing; the replay
-     request accumulates a positive token delta; the record_request wrapper
-     subtracts it from tokens_saved exactly once and drains, so the next
-     request passes through untouched.
+  3. accounting: the newly-matured request accumulates nothing; BOTH replay
+     shapes accumulate a positive token delta -- the pass swapping the raw
+     content out itself, and the marker arriving already in place from the
+     cached-prefix replay (the shape that actually runs in production, and
+     the one the original vendor missed entirely) -- and the record_request
+     wrapper subtracts the total from tokens_saved exactly once and drains,
+     so the next request passes through untouched.
 """
 
 import json
@@ -54,7 +57,7 @@ def build_messages():
     ]
 
 
-def run_transform():
+def run_transform(observe=None):
     import sitecustomize  # noqa: F401  (auto-imported anyway; explicit for clarity)
     from headroom.transforms import read_maturation as rm
 
@@ -69,17 +72,34 @@ def run_transform():
                 pass
     mgr = rm.ReadMaturationManager(cfg, compression_store=None)
     msgs = build_messages()
+
+    def step(payload):
+        out = mgr.apply([dict(m) for m in payload])
+        if observe is not None:
+            observe()
+        return out
+
     # Request 1: the Read has been quiet for 2 assistant turns -> matures.
-    r1 = mgr.apply([dict(m) for m in msgs])
-    # Request 2: the client re-sends the raw conversation -> replay branch.
-    r2 = mgr.apply([dict(m) for m in msgs])
-    return r1, r2
+    r1 = step(msgs)
+    # Request 2: raw conversation again and no cached prefix covering it, so
+    # this pass swaps the content out itself.
+    r2 = step(msgs)
+    # Request 3: the marker is ALREADY in place on the way in, exactly as the
+    # cached-prefix replay leaves it once a Read has matured. This is the
+    # steady state in production and it must still be charged.
+    r3 = step(r1.messages)
+    return r1, r2, r3
 
 
 def main() -> int:
     if os.environ.get("HD_FA_PROBE_MODE") == "control":
-        r1, r2 = run_transform()
-        print(json.dumps({"r1": r1.messages, "r2": r2.messages}, sort_keys=True))
+        r1, r2, r3 = run_transform()
+        print(
+            json.dumps(
+                {"r1": r1.messages, "r2": r2.messages, "r3": r3.messages},
+                sort_keys=True,
+            )
+        )
         return 0
 
     import sitecustomize as sc
@@ -90,21 +110,23 @@ def main() -> int:
 
     from headroom.proxy import prometheus_metrics as pm
 
-    r1, r2 = run_transform()
+    pending = []
+    r1, r2, r3 = run_transform(observe=lambda: pending.append(sc._hd_fa_pending[0]))
     marker_seen = json.dumps(r2.messages)
     if "Retrieve original: hash=" not in marker_seen:
         print("FAIL maturation did not run (no marker in replay output)")
         return 1
 
-    delta = sc._hd_fa_pending[0]
+    delta = sc._hd_fa_deltas.get("tc_1", 0)
     if delta <= 0:
-        print("FAIL replay delta not accumulated")
+        print("FAIL replay delta never learned")
         return 1
-    # Exactly ONE replay's worth: request 1 (newly matured) must have
-    # contributed nothing.
-    if delta != sc._hd_fa_deltas.get("tc_1"):
-        print("FAIL newly-matured request contributed to pending:", delta)
+    # Request 1 newly matured, so it books in full and accrues nothing.
+    # Requests 2 and 3 are the two replay shapes, one debt each.
+    if pending != [0, delta, 2 * delta]:
+        print("FAIL accrual per request:", pending, "delta", delta)
         return 1
+    total = sc._hd_fa_pending[0]
 
     # 2. Traffic neutrality against an unpatched control run.
     env = dict(os.environ)
@@ -120,7 +142,9 @@ def main() -> int:
     if control.returncode != 0:
         print("FAIL control run errored:", control.stderr[-400:])
         return 1
-    ours = json.dumps({"r1": r1.messages, "r2": r2.messages}, sort_keys=True)
+    ours = json.dumps(
+        {"r1": r1.messages, "r2": r2.messages, "r3": r3.messages}, sort_keys=True
+    )
     if ours != control.stdout.strip():
         print("FAIL transformed messages differ from unpatched control")
         return 1
@@ -147,12 +171,12 @@ def main() -> int:
                 model="probe",
                 input_tokens=10,
                 output_tokens=1,
-                tokens_saved=delta + 250,
+                tokens_saved=total + 250,
                 latency_ms=1.0,
             )
         )
         if captured.get("tokens_saved") != 250:
-            print("FAIL subtraction:", captured.get("tokens_saved"), "delta", delta)
+            print("FAIL subtraction:", captured.get("tokens_saved"), "total", total)
             return 1
         if sc._hd_fa_pending[0] != 0:
             print("FAIL pending not drained:", sc._hd_fa_pending[0])
@@ -174,7 +198,7 @@ def main() -> int:
     finally:
         sc._hd_fa_orig_record = real
 
-    print("OK first-appearance accounting: bind, neutrality, subtract-once")
+    print("OK first-appearance accounting: bind, neutrality, both replay shapes, subtract-once")
     return 0
 
 

--- a/scripts/verify-responses-budget.py
+++ b/scripts/verify-responses-budget.py
@@ -1,0 +1,237 @@
+"""Offline regression for the desktop Responses compression budget.
+
+Uses the installed wheel's adapter and executors, with simulated slow inference.
+No model downloads, provider requests, or Sentry events.
+"""
+
+import argparse
+import asyncio
+import copy
+import os
+from pathlib import Path
+import re
+import runpy
+import socket
+import threading
+import time
+from types import MethodType, SimpleNamespace
+
+
+def deny_network(*args, **kwargs):
+    raise AssertionError("budget regression must stay offline")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sitecustomize", type=Path, required=True)
+    parser.add_argument("--disabled", action="store_true")
+    args = parser.parse_args()
+    socket.socket.connect = socket.socket.connect_ex = deny_network
+    socket.create_connection = socket.getaddrinfo = deny_network
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    os.environ["HEADROOM_SDK"] = "headroom-desktop-proxy"
+    os.environ["HEADROOM_RESPONSES_SHARED_BUDGET"] = "0" if args.disabled else "1"
+    os.environ["HEADROOM_COMPRESSION_DEADLINE_MS"] = "120"
+
+    from headroom.proxy.server import ProxyConfig, create_app
+    from headroom.proxy.handlers import openai as oa
+    from headroom.transforms.content_router import (
+        ContentRouter, RouterCompressionResult, CompressionStrategy,
+    )
+
+    calls = []
+    delay = 0.025
+    def shortened(content):
+        # Retain the real batch envelope/tag markers while shortening each unit.
+        return re.sub(r"(item\d+word7)(?: item\d+word\d+)+", r"\1", content)
+
+    # Replace only inference; retain the real adapter, batches, and executor.
+    def inference(self, content, *args, **kwargs):
+        calls.append(content)
+        time.sleep(delay)
+        return RouterCompressionResult(
+            original=content, compressed=shortened(content),
+            strategy_used=CompressionStrategy.KOMPRESS,
+        )
+
+    ContentRouter.compress = inference
+    runpy.run_path(str(args.sitecustomize))
+    if not args.disabled:
+        assert ContentRouter.compress.__name__ == "_hd_cb_router_compress", "shim did not bind"
+    scope = oa.OpenAIHandlerMixin._compress_openai_responses_payload_in_executor.__globals__
+
+    class TokenCounter:
+        def count_text(self, text):
+            return len(text.split())
+
+    def make_proxy():
+        proxy = create_app(ProxyConfig(
+            optimize=False, cache_enabled=False, rate_limit_enabled=False,
+            cost_tracking_enabled=False, log_requests=False,
+            ccr_inject_tool=False, ccr_handle_responses=False,
+            ccr_context_tracking=False, image_optimize=False,
+            compression_max_workers=4,
+        )).state.proxy
+        proxy.openai_pipeline = SimpleNamespace(transforms=[ContentRouter()])
+        proxy.openai_provider = SimpleNamespace(get_token_counter=lambda _: TokenCounter())
+        def compress(self, payload, **kwargs):
+            return self._compress_openai_responses_live_text_units_with_router(
+                payload, model=kwargs["model"], request_id=kwargs["request_id"],
+            )
+        proxy._compress_openai_responses_payload = MethodType(compress, proxy)
+        return proxy
+
+    def payload(count, words=180):
+        return {"model": "gpt-5", "input": [
+            {"type": "function_call_output", "call_id": f"call_{i}",
+             "output": " ".join(f"item{i}word{j}" for j in range(words))}
+            for i in range(count)
+        ]}
+
+    async def run(proxy, source, timeout=0.5):
+        return await proxy._compress_openai_responses_payload_in_executor(
+            copy.deepcopy(source), model="gpt-5", request_id="offline-budget", timeout=timeout,
+        )
+
+    async def checks():
+        nonlocal delay
+        for parallelism, words, count in ((1, 180, 100), (4, 180, 100),
+                                          (1, 25, 1000), (4, 25, 1000)):
+            os.environ["HEADROOM_TOOL_OUTPUT_COMPRESSION_PARALLELISM"] = str(parallelism)
+            proxy = make_proxy()
+            source = payload(count, words)
+            calls.clear()
+            started = time.perf_counter()
+            try:
+                result = await run(proxy, source)
+            except asyncio.TimeoutError:
+                assert args.disabled, "fixed request still timed out"
+                assert proxy._compression_timed_out_in_flight > 0
+                n = len(calls)
+                await asyncio.sleep(0.08)
+                assert len(calls) > n, "control did not reproduce continuing work"
+                print(f"PASS control: parallelism={parallelism}, words={words}, "
+                      "timeout with continuing worker")
+            else:
+                assert not args.disabled, "control unexpectedly completed"
+                elapsed = time.perf_counter() - started
+                changed = sum(a != b for a, b in zip(source["input"], result[0]["input"]))
+                assert 0 < changed < count, (changed, len(calls))
+                assert result[2] > 0, "completed compression was discarded"
+                for original, output in zip(source["input"], result[0]["input"]):
+                    assert output["output"] in (original["output"], shortened(original["output"]))
+                    assert output["call_id"] == original["call_id"]
+                assert proxy._compression_leaked_threads == 0
+                assert proxy._compression_timed_out_in_flight == 0
+                n = len(calls)
+                await asyncio.sleep(0.08)
+                assert len(calls) == n, "work continued after response"
+                assert await proxy._run_compression_in_executor(lambda: 42, timeout=0.2) == 42
+                print(f"PASS fixed: parallelism={parallelism}, words={words}, {elapsed:.3f}s, "
+                      f"{changed}/{count} compressed, {result[2]} estimated tokens saved, no worker debt")
+            finally:
+                proxy._compression_executor.shutdown(wait=True)
+
+        if args.disabled:
+            return
+
+        # Fast requests must remain byte-identical to the unwrapped adapter.
+        delay = 0
+        proxy = make_proxy()
+        source = payload(3)
+        fixed = await run(proxy, source)
+        control_proxy = make_proxy()
+        control = control_proxy._compress_openai_responses_payload(copy.deepcopy(source),
+            model="gpt-5", request_id="offline-control")
+        assert fixed[0] == control[0] and fixed[2] == control[2]
+        print("PASS: fast output and estimated savings identical to control")
+
+        os.environ["HEADROOM_COMPRESSION_DEADLINE_MS"] = "0"
+        original = scope["_hd_cb_responses"]
+        async def unbounded(self, payload, **kwargs):
+            assert scope["_hd_cb_budget"].get() is None
+            return payload
+        scope["_hd_cb_responses"] = unbounded
+        try:
+            assert await run(proxy, source) == source
+        finally:
+            scope["_hd_cb_responses"] = original
+            os.environ["HEADROOM_COMPRESSION_DEADLINE_MS"] = "120"
+        print("PASS: existing zero-deadline opt-out leaves requests unbounded")
+
+        delay = 0.025
+        cancelled_proxy = make_proxy()
+        calls.clear()
+        task = asyncio.create_task(run(cancelled_proxy, payload(100)))
+        for _ in range(100):
+            if calls:
+                break
+            await asyncio.sleep(0.005)
+        assert calls, "cancellation test never entered the worker"
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        await asyncio.sleep(0.15)
+        assert cancelled_proxy._compression_in_flight == 0
+        assert cancelled_proxy._compression_timed_out_in_flight == 0
+        cancelled_proxy._compression_executor.shutdown(wait=True)
+        print("PASS: request cancellation drains remaining work")
+
+        # Context isolation across both executor hops and cancellation signal.
+        async def isolated(cancel):
+            event = threading.Event()
+            budget = (time.perf_counter() + 2, event)
+            token = scope["_hd_cb_budget"].set(budget)
+            try:
+                def nested():
+                    return oa._openai_responses_unit_executor().submit(
+                        lambda: scope["_hd_cb_budget"].get()).result()
+                assert await proxy._run_compression_in_executor(nested, timeout=1) is budget
+                if cancel:
+                    event.set()
+                    assert proxy.openai_pipeline.transforms[0].compress("untouched").compressed == "untouched"
+            finally:
+                scope["_hd_cb_budget"].reset(token)
+        await asyncio.gather(isolated(True), isolated(False))
+        assert scope["_hd_cb_budget"].get() is None
+
+        # Native Kompress receives one shared start time, including nested calls.
+        starts = []
+        class Compressor:
+            _deadline_s = 20
+            def _passthrough(self, text, count):
+                return text
+        def native(self, content, **kwargs):
+            starts.append(kwargs["_deadline_started_at"])
+            return content
+        bounded = scope["_hd_cb_kompress_wrapper"](native)
+        event = threading.Event()
+        deadline = time.perf_counter() + 1
+        token = scope["_hd_cb_budget"].set((deadline, event))
+        try:
+            bounded(Compressor(), "a")
+            bounded(Compressor(), "b", _deadline_started_at=deadline - 30)
+            assert starts == [deadline - 20, deadline - 30]
+            bounded(Compressor(), content="keyword")
+            def native_batch(self, contents, **kwargs):
+                return [bounded(self, text, **kwargs) for text in contents]
+            batch = scope["_hd_cb_kompress_wrapper"](native_batch, batch=True)
+            assert batch(Compressor(), contents=["a", "b"]) == ["a", "b"]
+            assert starts[-2:] == [deadline - 20, deadline - 20]
+            event.set()
+            assert bounded(Compressor(), "unchanged") == "unchanged"
+            assert batch(Compressor(), contents=["a", "b"]) == ["a", "b"]
+            assert len(starts) == 5
+        finally:
+            scope["_hd_cb_budget"].reset(token)
+        print("PASS: executor context isolation, cancellation, native deadline propagation")
+        proxy._compression_executor.shutdown(wait=True)
+        control_proxy._compression_executor.shutdown(wait=True)
+
+    asyncio.run(checks())
+
+
+if __name__ == "__main__":
+    main()

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.11-rc.3"
+version = "0.9.11-rc.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.11-rc.1"
+version = "0.9.11-rc.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.11-rc.4"
+version = "0.9.11-rc.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.11-rc.5"
+version = "0.9.11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.10-rc.3"
+version = "0.9.11-rc.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.11-rc.2"
+version = "0.9.11-rc.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.11-rc.5"
+version = "0.9.11"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.10-rc.3"
+version = "0.9.11-rc.1"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.11-rc.3"
+version = "0.9.11-rc.4"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.11-rc.2"
+version = "0.9.11-rc.3"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.11-rc.1"
+version = "0.9.11-rc.2"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.11-rc.4"
+version = "0.9.11-rc.5"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/src/client_adapters.rs
+++ b/src-tauri/src/client_adapters.rs
@@ -849,6 +849,38 @@ pub(crate) fn newest_mtime_under(root: &Path, cap: usize) -> Option<SystemTime> 
     newest
 }
 
+/// Newest Claude Code transcript, `<projects_root>/<project>/*.jsonl`: the
+/// one artifact only a running session writes. The whole-tree walk this
+/// replaced also counted `<project>/memory/MEMORY.md`, which Headroom's own
+/// learn writer, memory scrubber and end-marker repair touch -- so a launch
+/// that wrote one read as "Claude Code ran", and a machine that had not used
+/// it through the proxy for two days fired the unrouted alert hourly
+/// (RUST-2K: five hosts in the first day of 0.9.10).
+pub(crate) fn newest_claude_transcript_mtime(projects_root: &Path) -> Option<SystemTime> {
+    let mut newest: Option<SystemTime> = None;
+    let mut visited = 0usize;
+    for project in std::fs::read_dir(projects_root).ok()?.flatten() {
+        let Ok(entries) = std::fs::read_dir(project.path()) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            visited += 1;
+            if visited > LOCAL_ACTIVITY_WALK_CAP {
+                return newest;
+            }
+            if !entry.path().extension().is_some_and(|ext| ext == "jsonl") {
+                continue;
+            }
+            if let Ok(modified) = entry.metadata().and_then(|meta| meta.modified()) {
+                if Some(modified) > newest {
+                    newest = Some(modified);
+                }
+            }
+        }
+    }
+    newest
+}
+
 /// When the agent last wrote its own session artifacts on this machine:
 /// evidence it ran, independent of whether Headroom saw any of it.
 pub fn client_local_activity_at(client_id: &str) -> Option<SystemTime> {
@@ -856,20 +888,27 @@ pub fn client_local_activity_at(client_id: &str) -> Option<SystemTime> {
         "codex_cli" => {
             let mut newest =
                 newest_mtime_under(&codex_home().join("sessions"), LOCAL_ACTIVITY_WALK_CAP);
-            // GUI/TUI thread store: state_<N>.sqlite and its -wal/-shm siblings.
+            // GUI/TUI thread store: state_<N>.sqlite and its -wal. Not the -shm
+            // (touched by idle readers, e.g. a backgrounded Codex GUI), and not
+            // anything at or before Headroom's own provider retag: that rewrites
+            // the store on every launch and connect, and read as "Codex ran"
+            // it false-fired the unrouted alert on machines that never ran it.
+            let own_write = last_codex_retag_at().map(|at| at + Duration::from_secs(2));
             for dir in codex_state_dirs() {
                 let Ok(entries) = std::fs::read_dir(&dir) else {
                     continue;
                 };
                 for entry in entries.flatten() {
-                    if !entry
-                        .file_name()
-                        .to_str()
-                        .is_some_and(|name| name.starts_with("state_"))
-                    {
+                    if !entry.file_name().to_str().is_some_and(|name| {
+                        name.starts_with("state_")
+                            && (name.ends_with(".sqlite") || name.ends_with(".sqlite-wal"))
+                    }) {
                         continue;
                     }
                     if let Ok(modified) = entry.metadata().and_then(|meta| meta.modified()) {
+                        if own_write.is_some_and(|until| modified <= until) {
+                            continue;
+                        }
                         if Some(modified) > newest {
                             newest = Some(modified);
                         }
@@ -878,10 +917,9 @@ pub fn client_local_activity_at(client_id: &str) -> Option<SystemTime> {
             }
             newest
         }
-        "claude_code" => newest_mtime_under(
-            &home_dir().join(".claude").join("projects"),
-            LOCAL_ACTIVITY_WALK_CAP,
-        ),
+        "claude_code" => {
+            newest_claude_transcript_mtime(&home_dir().join(".claude").join("projects"))
+        }
         _ => None,
     }
 }
@@ -3363,6 +3401,14 @@ fn discover_codex_state_dbs() -> Vec<PathBuf> {
     out
 }
 
+/// When this process last rewrote the Codex thread store, so
+/// `client_local_activity_at` does not mistake our write for Codex running.
+static LAST_CODEX_RETAG: std::sync::Mutex<Option<SystemTime>> = std::sync::Mutex::new(None);
+
+fn last_codex_retag_at() -> Option<SystemTime> {
+    *LAST_CODEX_RETAG.lock().unwrap()
+}
+
 /// Best-effort retag of Codex thread provider tags so the history menu stays
 /// whole across the Headroom proxy boundary. Never fails the caller: a missing
 /// store, a missing `threads` table, or a DB locked by a running Codex is logged
@@ -3397,6 +3443,7 @@ fn retag_codex_thread_providers(from: &str, to: &str) {
             }
         }
     }
+    *LAST_CODEX_RETAG.lock().unwrap() = Some(SystemTime::now());
     // A `state_*.sqlite`-shaped file with no `threads` table means Codex renamed
     // the table itself (discovery already survives a file rename). Only flag when
     // the store-shaped name is present, so a clean or CLI-only / pre-sqlite
@@ -10951,6 +10998,19 @@ export ANTHROPIC_BASE_URL=http://127.0.0.1:6767
     }
 
     #[test]
+    fn newest_claude_transcript_mtime_ignores_headroom_written_memory_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("-Users-x-repo");
+        fs::create_dir_all(project.join("memory")).unwrap();
+        // Only Headroom's learn output exists: that is not Claude Code activity.
+        fs::write(project.join("memory").join("MEMORY.md"), b"x").unwrap();
+        assert!(super::newest_claude_transcript_mtime(tmp.path()).is_none());
+        fs::write(project.join("session.jsonl"), b"x").unwrap();
+        assert!(super::newest_claude_transcript_mtime(tmp.path()).is_some());
+        assert!(super::newest_claude_transcript_mtime(&tmp.path().join("missing")).is_none());
+    }
+
+    #[test]
     fn client_ran_unrouted_needs_fresh_activity_long_uptime_and_no_requests() {
         let hour = std::time::Duration::from_secs(3600);
         let now = SystemTime::now();
@@ -11599,6 +11659,29 @@ export ANTHROPIC_BASE_URL=http://127.0.0.1:6767
         assert_eq!(provider_count(&db, "openai"), 0);
         // Third-party threads are untouched.
         assert_eq!(provider_count(&db, "anthropic"), 1);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn codex_activity_ignores_headrooms_own_retag_write() {
+        // Every launch retags the thread store; that write must not read as
+        // "Codex ran" or the unrouted alert fires on machines that never ran it.
+        let home = TestHome::new();
+        let db = home.path().join(".codex").join("state_5.sqlite");
+        std::fs::create_dir_all(db.parent().unwrap()).unwrap();
+        seed_codex_threads_db(&db, &[("a", "openai")]);
+
+        retag_codex_threads_to_headroom();
+        assert_eq!(super::client_local_activity_at("codex"), None);
+
+        // Codex itself writing the store afterwards does count.
+        std::fs::File::options()
+            .write(true)
+            .open(&db)
+            .unwrap()
+            .set_modified(SystemTime::now() + std::time::Duration::from_secs(10))
+            .unwrap();
+        assert!(super::client_local_activity_at("codex").is_some());
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3260,6 +3260,14 @@ pub(crate) fn is_endpoint_protection_signal(text: &str) -> bool {
     // OpenMP DLL. The probe only runs after a 0xffffffff exit, and "killed"
     // only comes from the timeout (Windows has no signals), so the phrase is
     // specific. An `(exit N)` verdict is a broken venv, not this.
+    // STATUS_DLL_INIT_FAILED from a python.exe whose next attempt printed the
+    // banner (RUST-DA, Win11 26200, fresh install): not a missing DLL
+    // (0xc0000135) or a bad image (0xc000007b), a DLL's init refused, which on
+    // a venv that runs a moment later is an injected security-product DLL.
+    // The code survives every locale.
+    if lower.contains("0xc0000142") {
+        return true;
+    }
     if lower.contains("import onnxruntime failed (killed)") {
         return true;
     }
@@ -4996,16 +5004,53 @@ async fn detect_unrouted_clients(
             if !client_adapters::client_ran_unrouted(activity, requests, app_started_at, now) {
                 continue;
             }
+            // One report per activity timestamp: the condition holds for the
+            // whole 24h window, so the hourly rescan re-filed the same stale
+            // session every hour (nine events per host per day on RUST-2K).
+            static LAST_REPORTED: OnceLock<
+                Mutex<std::collections::HashMap<&'static str, SystemTime>>,
+            > = OnceLock::new();
+            if activity.is_some_and(|at| {
+                LAST_REPORTED
+                    .get_or_init(Default::default)
+                    .lock()
+                    .unwrap()
+                    .insert(client_id, at)
+                    == Some(at)
+            }) {
+                continue;
+            }
             let enabled = match client_id {
                 "codex" => client_adapters::is_codex_enabled(),
                 _ => client_adapters::is_claude_code_enabled(),
             };
             let reapplied = enabled && client_adapters::apply_client_setup(client_id).is_ok();
             let active_at: chrono::DateTime<chrono::Utc> = activity.unwrap_or(now).into();
-            // warn: the log bridge forwards it to Sentry, the only fleet-wide
-            // trace of an agent silently running outside Headroom.
-            log::warn!(
+            log::info!(
                 "unrouted client {client_id}: active locally at {active_at}, no proxied request since yesterday; enabled={enabled} reapplied={reapplied}"
+            );
+            // The only fleet-wide trace of an agent silently running outside
+            // Headroom. Captured explicitly under a fixed fingerprint: as a
+            // warn through the log bridge it grouped on the caller stack,
+            // which release builds cannot symbolicate, so every build opened
+            // a fresh issue for the one condition (RUST-2K, RUST-D5, RUST-D6).
+            sentry::with_scope(
+                |scope| {
+                    scope.set_tag("flow", "unrouted_client");
+                    scope.set_tag("client", client_id);
+                    scope.set_tag("enabled", enabled);
+                    scope.set_tag("reapplied", reapplied);
+                    scope.set_extra("active_at", active_at.to_rfc3339().into());
+                    scope.set_fingerprint(Some(&["unrouted_client", client_id]));
+                },
+                || {
+                    sentry::capture_message(
+                        &format!(
+                            "unrouted client {client_id}: active locally, no proxied request since yesterday; enabled={enabled} reapplied={reapplied}"
+                        ),
+                        sentry::Level::Warning,
+                    );
+                },
             );
             analytics::track_event(
                 &app,
@@ -12108,6 +12153,20 @@ Some unrelated content.
             "Could not resolve host: pypi.org"
         ));
         assert!(!is_endpoint_protection_signal("ENOSPC: no space left"));
+        // Neighbouring NTSTATUS: a DLL that is missing, not one that refused.
+        assert!(!is_endpoint_protection_signal(
+            "exited with status exit code: 0xc0000135 before opening port 6768"
+        ));
+    }
+
+    #[test]
+    fn is_endpoint_protection_signal_matches_dll_init_failed_exit() {
+        let raw = "python.exe: exited with status exit code: 0xc0000142 before opening port 6768";
+        assert!(is_endpoint_protection_signal(raw));
+        assert_eq!(
+            startup_error_fingerprint_key(Some(raw)),
+            Some("startup_endpoint_protection")
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4177,9 +4177,16 @@ const ACTIVITY_OBSERVER_INTERVAL: std::time::Duration = std::time::Duration::fro
 /// Rescan cadence for the Claude projects cache. This keeps Optimize mostly
 /// warm without doing filesystem-heavy project scans every minute forever.
 const CLAUDE_PROJECTS_WARM_INTERVAL: std::time::Duration = std::time::Duration::from_secs(75);
-/// Matches the frontend's `ACTIVITY_FEED_WINDOW` in App.tsx so the observer
-/// sees the same transformations the UI will display.
-const ACTIVITY_OBSERVER_LIMIT: u32 = 150;
+/// The backend hard-caps `/transformations/feed?limit=` at 100, so asking for
+/// more only made the constant lie (it used to claim it matched a frontend
+/// `ACTIVITY_FEED_WINDOW` that no longer exists). 100 is also above the busiest
+/// 20s window measured on a heavy machine (p50 3 requests, p90 8, p99 35, max
+/// 66), so a tick still sees every request that landed since the last one.
+const ACTIVITY_OBSERVER_LIMIT: u32 = 100;
+/// Pull the feed at least this often even when the intercept counters have not
+/// moved, so a producer the intercept cannot see (anything reaching the backend
+/// on 6768 directly) is still observed within a few minutes.
+const ACTIVITY_OBSERVER_MAX_FEED_GAP: std::time::Duration = std::time::Duration::from_secs(300);
 
 fn spawn_activity_observer(app: AppHandle) {
     std::thread::spawn(move || {
@@ -4211,16 +4218,107 @@ fn spawn_claude_projects_warmer(app: AppHandle) {
     });
 }
 
+/// Whether this tick should pull the transformations feed, given the intercept's
+/// forwarded-request total the last pull saw and how long ago that pull was.
+///
+/// One pull costs far more than what is read off it: measured 2026-09-07,
+/// `limit=100` returns ~44 MB because every event carries `request_messages`
+/// plus a byte-identical `compressed_messages` (~160 KB per event, and the
+/// backend has no parameter to omit them) while the observer and the canary
+/// between them read ~403 bytes of each. The backend serializes all of it on
+/// its event loop, and `/stats` -- which the dashboard polls on its own cadence
+/// -- queues behind it: 45 ms idle against 1.3 s with three pulls in flight, on
+/// an otherwise idle machine. That is the shape behind RUST-86's 15s `/stats`
+/// timeouts (122 hosts), so the observer stops paying it for nothing.
+///
+/// Unchanged counters mean every event in the window has already been observed.
+/// The elapsed arm still forces a pull, so a producer the intercept cannot see
+/// (anything reaching the backend on 6768 directly) is not missed forever.
+fn feed_pull_due(last: Option<(u64, std::time::Duration)>, forwarded: u64) -> bool {
+    match last {
+        Some((seen, since)) => seen != forwarded || since >= ACTIVITY_OBSERVER_MAX_FEED_GAP,
+        // First tick of the process: the window holds requests from before
+        // launch that nothing here has observed yet.
+        None => true,
+    }
+}
+
+fn should_pull_transformations_feed() -> bool {
+    static LAST_PULL: Mutex<Option<(u64, std::time::Instant)>> = Mutex::new(None);
+    let forwarded: u64 = crate::proxy_intercept::intercept_request_counts()
+        .values()
+        .sum();
+    let mut last = LAST_PULL.lock();
+    let due = feed_pull_due(
+        last.map(|(seen, at): (u64, std::time::Instant)| (seen, at.elapsed())),
+        forwarded,
+    );
+    if due {
+        *last = Some((forwarded, std::time::Instant::now()));
+    }
+    due
+}
+
 fn run_activity_observation(app: &AppHandle) {
     let state: tauri::State<'_, AppState> = app.state();
 
     let _ = state.maybe_emit_weekly_recap();
 
-    if let Ok(feed) = fetch_transformations_feed(ACTIVITY_OBSERVER_LIMIT) {
-        let _ = state.observe_activity_from_transformations(&feed.transformations);
-        // Same batch, second reader: flags a client whose requests all stopped
-        // compressing (see savings_canary for why the server cannot see this).
-        savings_canary::observe(&feed.transformations);
+    if should_pull_transformations_feed() {
+        match fetch_transformations_feed(ACTIVITY_OBSERVER_LIMIT) {
+            Ok(feed) => {
+                let _ = state.observe_activity_from_transformations(&feed.transformations);
+                // Same batch, second reader: flags a client whose requests all
+                // stopped compressing (see savings_canary for why the server
+                // cannot see this).
+                savings_canary::observe(&feed.transformations);
+            }
+            // This used to be an `if let Ok`, which is how a permanently
+            // failing fetch stayed invisible: both readers above simply never
+            // ran, on exactly the heaviest machines. Once per process is the
+            // whole signal -- the failure repeats every tick, and a warn per
+            // tick would drown Sentry for one machine's one condition.
+            Err(err) => {
+                static WARNED: std::sync::atomic::AtomicBool =
+                    std::sync::atomic::AtomicBool::new(false);
+                if !WARNED.swap(true, std::sync::atomic::Ordering::AcqRel) {
+                    // Fingerprint on the cause class, with the detail in an
+                    // extra. Baking `err` into the message text is what split
+                    // one canary into RUST-A5 + RUST-A4; a timeout (payload too
+                    // big for the window) and an HTTP status (backend answering
+                    // wrong) are different bugs and need separate lifecycles.
+                    let category = if err.contains("timed out") {
+                        "timeout"
+                    } else if err.starts_with("proxy returned HTTP ") {
+                        "http"
+                    } else {
+                        "other"
+                    };
+                    sentry::with_scope(
+                        |scope| {
+                            scope.set_tag("flow", "transformations_feed_fetch");
+                            scope.set_extra("error", err.clone().into());
+                            scope.set_extra("limit", u64::from(ACTIVITY_OBSERVER_LIMIT).into());
+                            scope.set_fingerprint(Some(&["transformations-feed-fetch", category]));
+                        },
+                        || {
+                            sentry::capture_message(
+                                &format!(
+                                    "transformations feed fetch failed ({category}); activity \
+                                     observation and the zero-savings canary see nothing on this \
+                                     machine"
+                                ),
+                                sentry::Level::Warning,
+                            );
+                        },
+                    );
+                    log::warn!(
+                        "transformations feed fetch failed ({err}); activity observation and the \
+                         zero-savings canary see nothing on this machine"
+                    );
+                }
+            }
+        }
     }
 
     let projects = state.list_claude_code_projects().unwrap_or_default();
@@ -6271,13 +6369,18 @@ fn lifetime_token_milestone_kind(milestone_tokens_saved: u64) -> &'static str {
 /// How many recent days of savings travel with the milestone/heartbeat post.
 const SAVINGS_REPORT_DAYS: usize = 30;
 
-/// The output-reduction fields the savings report should carry. The desktop
-/// requests the shaper, but the wheel's rollout gate can block it by channel
-/// (all stable installs on the 0.37.0 wheel). A blocked shaper produces no
-/// live reduction, so the ledger-recomputed figure would report an "estimated"
-/// percentage for a feature that never ran; label it inactive and withhold the
-/// percent instead. Unknown state (older wheels without the rollout block)
-/// reports as before.
+/// The output-reduction percent + method the savings report should carry. Two
+/// states withhold the percent and say why in the method label instead:
+///
+/// - `inactive`: the desktop requests the shaper, but the wheel's rollout gate
+///   can block it by channel (all stable installs on the 0.37.0 wheel). A
+///   blocked shaper produces no live reduction, so the ledger-recomputed figure
+///   would report an "estimated" percentage for a feature that never ran.
+/// - `low_coverage`: the estimate covers too thin a slice of this machine's
+///   shaped traffic to describe it. The counters that prove it travel
+///   separately (see `savings_report`), so the floor can be tuned on real data.
+///
+/// Unknown rollout state (older wheels without the block) reports as before.
 fn reported_output_reduction(
     reduction: Option<&crate::models::OutputReduction>,
     shaper_active: Option<bool>,
@@ -6285,9 +6388,15 @@ fn reported_output_reduction(
     if shaper_active == Some(false) {
         return (None, Some("inactive".to_string()));
     }
+    let Some(reduction) = reduction else {
+        return (None, None);
+    };
+    if !reduction.publishable {
+        return (None, Some("low_coverage".to_string()));
+    }
     (
-        reduction.map(|o| o.reduction_percent),
-        reduction.map(|o| o.method.clone()),
+        Some(reduction.reduction_percent),
+        Some(reduction.method.clone()),
     )
 }
 
@@ -6318,6 +6427,13 @@ fn savings_report(dashboard: &DashboardState) -> Option<pricing::SavingsReport> 
         cache_savings_usd: breakdown.cache_savings_usd,
         output_reduction_percent,
         output_reduction_method,
+        // Unconditional, unlike the percent: a withheld `low_coverage` figure
+        // is exactly the case the server needs the denominator for.
+        output_reduction_requests: dashboard.output_reduction.as_ref().map(|o| o.requests),
+        output_reduction_coverage_percent: dashboard
+            .output_reduction
+            .as_ref()
+            .and_then(|o| o.coverage_percent),
         reread_tokens: dashboard.reread_tokens,
         reread_compressed_tokens: dashboard.reread_compressed_tokens,
         ccr_retrievals: dashboard.ccr_retrievals,
@@ -6652,12 +6768,22 @@ struct RawTransformationsFeedResponse {
     transformations: Vec<crate::models::TransformationFeedEvent>,
 }
 
+/// 2s was silently fatal on exactly the users whose data matters most. The feed
+/// ships every event's full message bodies (~160 KB each, no way to ask the
+/// backend for less), so `limit=100` measured 44 MB / 0.38s on a heavy machine
+/// here -- and a machine with conversations a few times larger crosses 2s, at
+/// which point the activity observer AND the zero-savings canary get nothing,
+/// every tick, forever. Raising this costs the backend nothing: it serializes
+/// the whole response either way, we were only throwing the result away. Half
+/// the observer's 20s tick, so a slow fetch still cannot let ticks pile up.
+const TRANSFORMATIONS_FEED_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 fn fetch_transformations_feed_from(
     base_url: &str,
     limit: u32,
 ) -> Result<TransformationFeedResponse, String> {
     let client = reqwest::blocking::Client::builder()
-        .timeout(std::time::Duration::from_millis(2000))
+        .timeout(TRANSFORMATIONS_FEED_TIMEOUT)
         .build()
         .map_err(|err| err.to_string())?;
     let url = format!("{base_url}/transformations/feed?limit={limit}");
@@ -8951,9 +9077,9 @@ mod tests {
         compute_tray_window_position, conflicting_openssl_dirs, count_memories_created_today,
         cpu_rate_indicates_burn, debounced_tray_runtime_visual, delete_applied_pattern,
         empty_live_learnings_for_projects, exe_path_resolvable, extract_llm_failure_warnings,
-        fake_override, fetch_transformations_feed_from, first_savings_body, format_token_count,
-        install_pending_update, is_blocked_runtime_dll_signal, is_disk_full_signal,
-        is_endpoint_protection_signal, is_environmental_startup_key,
+        fake_override, feed_pull_due, fetch_transformations_feed_from, first_savings_body,
+        format_token_count, install_pending_update, is_blocked_runtime_dll_signal,
+        is_disk_full_signal, is_endpoint_protection_signal, is_environmental_startup_key,
         is_loopback_socket_denied_signal, is_network_download_signal, is_port_conflict_failure,
         is_prerelease_version, learn_agent_auth_hint, learn_agent_limit_hint,
         learn_failure_agent_limit_line, learn_failure_is_agent_auth,
@@ -10241,6 +10367,26 @@ mod tests {
             err.contains("Sign in to the Codex CLI"),
             "expected codex sign-in hint, got: {err}"
         );
+    }
+
+    /// The feed pull is ~44 MB and the observer reads ~0.25% of it, so an idle
+    /// tick must not pay for it -- but an unseen producer must not be able to
+    /// hide behind unchanged counters forever either (RUST-86).
+    #[test]
+    fn feed_pull_skips_idle_ticks_but_never_stalls_past_the_gap() {
+        use std::time::Duration;
+        // First tick of the process: the window predates us, always pull.
+        assert!(feed_pull_due(None, 0));
+        // Nothing forwarded since the last pull, and well inside the gap.
+        assert!(!feed_pull_due(Some((42, Duration::from_secs(20))), 42));
+        // New traffic; pull immediately rather than waiting out the gap.
+        assert!(feed_pull_due(Some((42, Duration::from_secs(20))), 43));
+        // Counters idle but the gap elapsed: pull anyway, in case something
+        // reached the backend without passing the intercept.
+        assert!(feed_pull_due(
+            Some((42, crate::ACTIVITY_OBSERVER_MAX_FEED_GAP)),
+            42
+        ));
     }
 
     #[test]
@@ -12488,6 +12634,8 @@ mod output_reduction_report_tests {
             ci_low_percent: 20.0,
             ci_high_percent: 36.0,
             requests: 19_644,
+            coverage_percent: Some(63.5),
+            publishable: true,
         }
     }
 
@@ -12503,6 +12651,18 @@ mod output_reduction_report_tests {
         let (pct, method) = reported_output_reduction(Some(&reduction()), Some(true));
         assert_eq!(pct, Some(28.0));
         assert_eq!(method.as_deref(), Some("estimated"));
+    }
+
+    #[test]
+    fn a_thinly_covered_estimate_withholds_the_percent_and_says_why() {
+        let thin = OutputReduction {
+            coverage_percent: Some(3.8),
+            publishable: false,
+            ..reduction()
+        };
+        let (pct, method) = reported_output_reduction(Some(&thin), Some(true));
+        assert_eq!(pct, None);
+        assert_eq!(method.as_deref(), Some("low_coverage"));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,7 @@ mod storage;
 mod tool_manager;
 mod upstream_override;
 mod usage_counters;
+mod wsl_probe;
 
 /// Cross-module lock for tests that repoint $HOME / $CODEX_HOME. Env vars are
 /// process-global, so home-mutating tests in different modules (client_adapters
@@ -532,28 +533,86 @@ fn maybe_fire_unrouted_usage_nudge(app: &AppHandle, state: &AppState, dashboard:
         return;
     }
     // Cached (~90s warmer cadence), so polling this every 5s costs nothing.
-    let Ok(projects) = state.list_claude_code_projects() else {
-        return;
-    };
-    if !claude_sessions_touched_since(&projects, since) {
+    let claude = state
+        .list_claude_code_projects()
+        .map(|projects| claude_sessions_touched_since(&projects, since))
+        .unwrap_or(false);
+    // Shared with the hourly self-heal in `detect_unrouted_clients`: the one
+    // helper that knows Codex's session dir AND its GUI thread store, and how
+    // to ignore Headroom's own writes to it. It walks, so it is re-asked at
+    // most once a minute, not on every 5s poll.
+    let codex = codex_ran_locally_since(since);
+    if !claude && !codex {
         return;
     }
-    static UNROUTED_BEACON_SENT: AtomicBool = AtomicBool::new(false);
-    if !UNROUTED_BEACON_SENT.swap(true, Ordering::AcqRel) {
+    // One beacon per agent: Codex users save at 55-66% against ~90% for
+    // Claude Code on both platforms, with 25-35% never producing traffic, and
+    // server-side data cannot tell "routing failed" from "logged in once,
+    // codes with Cursor". Sessions growing while nothing reaches the proxy is
+    // the only honest instrument for that, so it must be attributable by agent.
+    static CLAUDE_BEACON_SENT: AtomicBool = AtomicBool::new(false);
+    static CODEX_BEACON_SENT: AtomicBool = AtomicBool::new(false);
+    if claude && !CLAUDE_BEACON_SENT.swap(true, Ordering::AcqRel) {
         pricing::report_funnel_step(state, "unrouted_usage_detected");
+    }
+    if codex && !CODEX_BEACON_SENT.swap(true, Ordering::AcqRel) {
+        pricing::report_funnel_step(state, "unrouted_codex_usage_detected");
     }
     if !state.try_mark_unrouted_usage_notified() {
         return;
     }
-    let _ = show_notification_impl(
+    let (title, body) = unrouted_usage_copy(claude, codex);
+    let _ = show_notification_impl(app, title, body, None);
+    analytics::track_event(
         app,
-        "Claude Code isn't going through Headroom",
-        "You've used Claude Code since Headroom started, but none of that traffic came \
-         through, so nothing was optimized. Restart your terminal or editor so it picks \
-         up the new settings.",
-        None,
+        "unrouted_usage_nudge_shown",
+        Some(json!({ "claude": claude, "codex": codex })),
     );
-    analytics::track_event(app, "unrouted_usage_nudge_shown", None);
+}
+
+/// Names the agent whose sessions grew: telling a Codex user to restart
+/// "Claude Code" reads as a notification meant for someone else.
+fn unrouted_usage_copy(claude: bool, codex: bool) -> (&'static str, &'static str) {
+    match (claude, codex) {
+        (true, true) => (
+            "Your coding agents aren't going through Headroom",
+            "You've used Claude Code and Codex since Headroom started, but none of that \
+             traffic came through, so nothing was optimized. Restart your terminal or \
+             editor so they pick up the new settings.",
+        ),
+        (false, true) => (
+            "Codex isn't going through Headroom",
+            "You've used Codex since Headroom started, but none of that traffic came \
+             through, so nothing was optimized. Restart Codex, or the terminal it runs \
+             in, so it picks up the new settings.",
+        ),
+        _ => (
+            "Claude Code isn't going through Headroom",
+            "You've used Claude Code since Headroom started, but none of that traffic came \
+             through, so nothing was optimized. Restart your terminal or editor so it picks \
+             up the new settings.",
+        ),
+    }
+}
+
+/// `client_local_activity_at("codex")` against `since`, memoized for a
+/// minute: the helper walks the sessions tree and the thread store (capped),
+/// which is too much for the 5s dashboard poll that drives the nudge. A
+/// cached `false` delays detection by at most that minute; the beacon and the
+/// notification are one-shot anyway.
+fn codex_ran_locally_since(since: chrono::DateTime<Utc>) -> bool {
+    static LAST: std::sync::Mutex<Option<(std::time::Instant, bool)>> = std::sync::Mutex::new(None);
+    let mut last = LAST.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some((asked_at, answer)) = *last {
+        if asked_at.elapsed() < std::time::Duration::from_secs(60) {
+            return answer;
+        }
+    }
+    let answer = client_adapters::client_local_activity_at("codex")
+        .map(|at| chrono::DateTime::<Utc>::from(at) > since)
+        .unwrap_or(false);
+    *last = Some((std::time::Instant::now(), answer));
+    answer
 }
 
 /// True when any Claude Code project's last session activity is newer than
@@ -5783,6 +5842,7 @@ pub fn run() {
             spawn_proxy_watchdog(app.handle().clone());
             spawn_activity_observer(app.handle().clone());
             spawn_claude_projects_warmer(app.handle().clone());
+            wsl_probe::spawn_probe();
             let state: tauri::State<'_, AppState> = app.state();
             let app_handle = app.handle().clone();
             analytics::set_headroom_ai_version(
@@ -12217,6 +12277,15 @@ Some unrelated content.
             since
         ));
         assert!(!claude_sessions_touched_since(&[], since));
+    }
+
+    #[test]
+    fn unrouted_usage_copy_names_the_agent() {
+        use super::unrouted_usage_copy as copy;
+        assert!(copy(true, false).0.contains("Claude Code"));
+        assert!(copy(false, true).0.contains("Codex"));
+        assert!(!copy(false, true).1.contains("Claude"));
+        assert!(copy(true, true).1.contains("Claude Code and Codex"));
     }
 
     /// An app that exited on its own must be relaunched without any kill at all.

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -428,6 +428,13 @@ fn skip_sentry(target: &str, msg: &str) -> bool {
     {
         return true;
     }
+    // Same split, same reason: the observer captures this one at the emit site
+    // with the cause class as the fingerprint and the raw error as an extra.
+    // The local line keeps the full error text -- which is exactly what would
+    // parameterize the bridged twin into a fresh group per machine.
+    if msg.starts_with("transformations feed fetch failed") {
+        return true;
+    }
     // Routing a missing managed runtime back to setup is the RECOVERY path, and
     // the emit site says so: `ensure_runtime_ready_for_tray` deliberately logs
     // instead of calling `capture_headroom_start_failure`, because capturing a
@@ -731,6 +738,19 @@ mod tests {
     /// One detection, two issues: the fully-scoped capture at the emit site
     /// (RUST-A5) and this bridged log line (RUST-A4). The capture is the Sentry
     /// path; the warn is local only.
+    #[test]
+    fn skips_the_transformations_feed_fetch_log_twin() {
+        assert!(super::skip_sentry(
+            "headroom_desktop_lib",
+            "transformations feed fetch failed (operation timed out); activity observation and the zero-savings canary see nothing on this machine"
+        ));
+        // A different feed problem still reaches Sentry through the bridge.
+        assert!(!super::skip_sentry(
+            "headroom_desktop_lib",
+            "transformations feed returned an unparseable payload"
+        ));
+    }
+
     #[test]
     fn skips_the_zero_savings_canary_log_twin() {
         assert!(skip_sentry(

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -918,9 +918,16 @@ pub enum CodexPlanTier {
     Team,
     Business,
     SelfServeBusinessUsageBased,
+    /// A self-serve Business workspace whose seats sit on the Pro Lite level.
+    /// Seen in the fleet from 2026-06, classified 2026-09-07 after the raw
+    /// claim showed up unmapped.
+    SelfServeBusinessProlite,
     Enterprise,
     EnterpriseCbpUsageBased,
     Edu,
+    /// Second spelling of the ChatGPT Edu claim, minted alongside `edu` and
+    /// first seen 2026-09-06. Same plan, same price parity.
+    Education,
     Unknown,
 }
 
@@ -936,9 +943,11 @@ impl CodexPlanTier {
             "team" => CodexPlanTier::Team,
             "business" => CodexPlanTier::Business,
             "self_serve_business_usage_based" => CodexPlanTier::SelfServeBusinessUsageBased,
+            "self_serve_business_prolite" => CodexPlanTier::SelfServeBusinessProlite,
             "enterprise" => CodexPlanTier::Enterprise,
             "enterprise_cbp_usage_based" => CodexPlanTier::EnterpriseCbpUsageBased,
             "edu" => CodexPlanTier::Edu,
+            "education" => CodexPlanTier::Education,
             _ => CodexPlanTier::Unknown,
         }
     }
@@ -956,9 +965,11 @@ impl CodexPlanTier {
             CodexPlanTier::Team => "team",
             CodexPlanTier::Business => "business",
             CodexPlanTier::SelfServeBusinessUsageBased => "self_serve_business_usage_based",
+            CodexPlanTier::SelfServeBusinessProlite => "self_serve_business_prolite",
             CodexPlanTier::Enterprise => "enterprise",
             CodexPlanTier::EnterpriseCbpUsageBased => "enterprise_cbp_usage_based",
             CodexPlanTier::Edu => "edu",
+            CodexPlanTier::Education => "education",
             CodexPlanTier::Unknown => "unknown",
         }
     }
@@ -980,7 +991,10 @@ impl CodexPlanTier {
 /// - Pro ($100/$200) -> Max x20: individual already paying top dollar.
 /// - Enterprise / enterprise CBP usage-based -> Max x20: $60+/seat at a 150-seat
 ///   minimum, the genuine high-budget tier.
-/// - Edu -> Max x5: institutional but discounted.
+/// - Edu / Education -> Max x5: institutional but discounted. OpenAI mints
+///   both spellings for the same plan.
+/// - Self-serve Business Pro Lite -> Max x5: a Business workspace on Pro Lite
+///   seats, and both halves of that name already price at Max x5.
 /// - Unknown -> Max x20: plan claim couldn't be decoded, so pitch the top plan
 ///   rather than under-recommend.
 /// Free carries no recommendation (already on the no-cost tier).
@@ -991,7 +1005,9 @@ pub fn headroom_tier_for_codex_plan(plan: &CodexPlanTier) -> Option<HeadroomSubs
         }
         CodexPlanTier::ProLite
         | CodexPlanTier::SelfServeBusinessUsageBased
-        | CodexPlanTier::Edu => Some(HeadroomSubscriptionTier::Max5x),
+        | CodexPlanTier::SelfServeBusinessProlite
+        | CodexPlanTier::Edu
+        | CodexPlanTier::Education => Some(HeadroomSubscriptionTier::Max5x),
         CodexPlanTier::Pro
         | CodexPlanTier::Enterprise
         | CodexPlanTier::EnterpriseCbpUsageBased
@@ -1340,6 +1356,11 @@ mod tests {
             (CodexPlanTier::Free, "free"),
             (CodexPlanTier::Plus, "plus"),
             (CodexPlanTier::Enterprise, "enterprise"),
+            (CodexPlanTier::Education, "education"),
+            (
+                CodexPlanTier::SelfServeBusinessProlite,
+                "self_serve_business_prolite",
+            ),
             (CodexPlanTier::Unknown, "unknown"),
         ] {
             assert_eq!(serde_json::to_value(tier).unwrap(), json!(wire));
@@ -1355,6 +1376,20 @@ mod tests {
         // ChatGPT Pro Lite: the claim OpenAI mints for the ~$100/mo mid-tier.
         assert_eq!(CodexPlanTier::from_claim("prolite"), CodexPlanTier::ProLite);
         assert_eq!(CodexPlanTier::ProLite.as_header_str(), "prolite");
+        // Both spellings of ChatGPT Edu, and the Business/Pro Lite composite.
+        assert_eq!(
+            CodexPlanTier::from_claim("education"),
+            CodexPlanTier::Education
+        );
+        assert_eq!(CodexPlanTier::Education.as_header_str(), "education");
+        assert_eq!(
+            CodexPlanTier::from_claim("self_serve_business_prolite"),
+            CodexPlanTier::SelfServeBusinessProlite
+        );
+        assert_eq!(
+            CodexPlanTier::SelfServeBusinessProlite.as_header_str(),
+            "self_serve_business_prolite"
+        );
         assert_eq!(
             CodexPlanTier::from_claim("chatgptpaidplan"),
             CodexPlanTier::Unknown
@@ -1385,7 +1420,9 @@ mod tests {
         for plan in [
             CodexPlanTier::ProLite,
             CodexPlanTier::SelfServeBusinessUsageBased,
+            CodexPlanTier::SelfServeBusinessProlite,
             CodexPlanTier::Edu,
+            CodexPlanTier::Education,
         ] {
             assert_eq!(headroom_tier_for_codex_plan(&plan), Some(Max5x));
         }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -149,6 +149,16 @@ pub struct OutputReduction {
     pub ci_low_percent: f64,
     pub ci_high_percent: f64,
     pub requests: u64,
+    /// `requests` as a share of every shaped request. `None` when the figure
+    /// came from the backend's `/stats` rather than the local ledger recompute,
+    /// which is the only place the denominator is visible.
+    pub coverage_percent: Option<f64>,
+    /// False when that share is too thin for the percentage to describe the
+    /// machine (`output_savings::OutputEstimate::covers_enough`). The tile and
+    /// the server report withhold the percentage; the counters above still
+    /// travel, so the floor can be tuned against fleet data rather than guessed
+    /// at twice. The threshold lives in one place, not in every caller.
+    pub publishable: bool,
 }
 
 /// Auto-learning progress from the backend's `/stats` `traffic_learner` block.

--- a/src-tauri/src/output_savings.rs
+++ b/src-tauri/src/output_savings.rs
@@ -30,12 +30,25 @@ use serde::Deserialize;
 /// once strata with data in both arms account for this share of treatment
 /// volume. Below it the holdout describes a corner of the traffic, not the
 /// traffic.
-const MEASURED_MIN_COVERAGE: f64 = 0.5;
+const MEASURED_MIN_COVERAGE_PCT: f64 = 50.0;
 
 /// ...and only once its 95% band is this tight. At a 3% holdout this takes a
 /// heavy user a couple of months; a lighter one may never reach it, which is
 /// the correct outcome -- they keep the synthetic-control number.
 const MEASURED_MAX_CI_HALF_WIDTH_PCT: f64 = 10.0;
+
+/// The synthetic-control estimate is published only once the strata it can
+/// score account for this share of shaped traffic. Below it the number
+/// describes a corner of the machine and is read as if it described all of it.
+/// A fleet snapshot on 2026-09-07 had 23 of 312 reporting users above 90%
+/// reduction, which no shaper mechanism produces: it lowers verbosity, it does
+/// not delete 19 of every 20 output tokens. Those are thin slices of scoreable
+/// traffic whose baseline strata were seeded on a different request class.
+///
+/// ponytail: provisional value. Coverage only starts travelling to the server
+/// in this same change, so there is no fleet distribution to tune against yet;
+/// revisit once `output_reduction_coverage_pct` has a fortnight of data.
+const ESTIMATED_MIN_COVERAGE_PCT: f64 = 20.0;
 
 /// A baseline stratum speaks for a treatment stratum only with this many
 /// observations behind it. Below it, one long pre-install reply becomes the
@@ -140,6 +153,12 @@ impl Ledger {
             (c.n >= MIN_BASELINE_N).then(|| (c.mean(), c.var(), c.n))
         })
     }
+
+    /// Every shaped request in the ledger, scored or not: the denominator
+    /// both coverage gates measure against.
+    fn shaped(&self) -> u64 {
+        self.treatment.values().map(|acc| acc.n).sum()
+    }
 }
 
 /// One side of the counterfactual, ready for the dashboard.
@@ -153,6 +172,10 @@ pub struct OutputEstimate {
     /// Treatment requests the estimate actually covers -- not every shaped
     /// request, since strata without baseline evidence are excluded.
     pub requests: u64,
+    /// `requests` as a share of every shaped request, so a reader can tell a
+    /// number about all of this machine's traffic from one about a corner of
+    /// it. Travels to the server with the percentage for the same reason.
+    pub coverage_percent: f64,
     pub tokens_saved: u64,
     pub baseline_tokens: u64,
 }
@@ -186,8 +209,21 @@ pub enum LedgerEstimate {
     /// seeded baseline covers only pre-install claude traffic). Resolves
     /// itself once the holdout's control arm feeds a live stratum past
     /// [`MIN_BASELINE_N`].
+    ///
+    /// A merely THIN estimate is not this: it stays [`LedgerEstimate::Scored`]
+    /// and reports [`OutputEstimate::covers_enough`] false, because this
+    /// variant makes the tracker discard every sampled output bucket it holds.
     Unscored,
     Scored(OutputEstimate),
+}
+
+impl OutputEstimate {
+    /// Whether this estimate speaks for the machine or for a corner of it.
+    /// False withholds the PERCENTAGE from the tile and the server report; the
+    /// coverage counters still travel, and the dollar series is untouched.
+    pub fn covers_enough(&self) -> bool {
+        self.coverage_percent >= ESTIMATED_MIN_COVERAGE_PCT
+    }
 }
 
 impl LedgerEstimate {
@@ -260,7 +296,14 @@ fn estimate_from_baseline(ledger: &Ledger) -> Option<OutputEstimate> {
         var += n * acc.var() + (n * n) * (mu_var / m as f64);
     }
 
-    finalize("estimated", saved, baseline_tokens, var, requests)
+    finalize(
+        "estimated",
+        saved,
+        baseline_tokens,
+        var,
+        requests,
+        ledger.shaped(),
+    )
 }
 
 /// A/B measurement: per-stratum control mean minus treatment mean, over strata
@@ -285,11 +328,18 @@ fn estimate_from_holdout(ledger: &Ledger) -> Option<OutputEstimate> {
         var += (n * n) * (c.var() / c.n as f64 + t.var() / t.n as f64);
     }
 
-    finalize("measured", saved, baseline_tokens, var, requests)
+    finalize(
+        "measured",
+        saved,
+        baseline_tokens,
+        var,
+        requests,
+        ledger.shaped(),
+    )
 }
 
 /// The measured estimate, but only once it is worth showing: it must cover
-/// [`MEASURED_MIN_COVERAGE`] of the shaped traffic and carry a band no wider
+/// [`MEASURED_MIN_COVERAGE_PCT`] of the shaped traffic and carry a band no wider
 /// than [`MEASURED_MAX_CI_HALF_WIDTH_PCT`].
 ///
 /// Coverage is measured against the same denominator the synthetic control
@@ -299,12 +349,7 @@ fn measured_if_ready(
     estimated: &Option<OutputEstimate>,
 ) -> Option<OutputEstimate> {
     let measured = estimate_from_holdout(ledger)?;
-    let shaped: u64 = ledger.treatment.values().map(|acc| acc.n).sum();
-    if shaped == 0 {
-        return None;
-    }
-    let covered = measured.requests as f64 / shaped as f64;
-    if covered < MEASURED_MIN_COVERAGE {
+    if measured.coverage_percent < MEASURED_MIN_COVERAGE_PCT {
         return None;
     }
     let half_width = (measured.ci_high_percent - measured.ci_low_percent) / 2.0;
@@ -338,8 +383,9 @@ fn finalize(
     baseline_tokens: f64,
     var: f64,
     requests: u64,
+    shaped: u64,
 ) -> Option<OutputEstimate> {
-    if requests == 0 || baseline_tokens <= 0.0 || !baseline_tokens.is_finite() {
+    if requests == 0 || shaped == 0 || baseline_tokens <= 0.0 || !baseline_tokens.is_finite() {
         return None;
     }
     let pct = saved / baseline_tokens * 100.0;
@@ -353,6 +399,7 @@ fn finalize(
         ci_low_percent: (saved - 1.96 * se) / baseline_tokens * 100.0,
         ci_high_percent: (saved + 1.96 * se) / baseline_tokens * 100.0,
         requests,
+        coverage_percent: requests as f64 / shaped as f64 * 100.0,
         tokens_saved: saved.max(0.0).round() as u64,
         baseline_tokens: baseline_tokens.round() as u64,
     })
@@ -416,6 +463,8 @@ mod tests {
         // baseline stratum. The 2 opus|ask|l|notools (no exact stratum) and
         // the 3 fable requests (no evidence at all) stay out.
         assert_eq!(e.requests, 4);
+        // 4 of the 9 shaped requests are scoreable.
+        assert!((e.coverage_percent - 44.444_444).abs() < 1e-5);
         assert_eq!(e.tokens_saved, 800);
         assert_eq!(e.baseline_tokens, 4000);
         assert!((e.reduction_percent - 20.0).abs() < 1e-9);
@@ -499,6 +548,33 @@ mod tests {
         let e = estimate(&json);
         assert_eq!(e.method, "estimated");
         assert_eq!(e.requests, 5000);
+    }
+
+    #[test]
+    fn an_estimate_covering_a_corner_of_traffic_is_not_publishable() {
+        // The 90-100% fleet tail: a well-fed baseline stratum scores 4 of 104
+        // shaped requests, and the percentage gets read as if it described the
+        // machine. It stays SCORED -- demoting it to Unscored would make the
+        // tracker discard the machine's sampled output buckets -- but it is
+        // not publishable.
+        let json = MIXED.replace(
+            r#""fable|ask|l|tools":  {"n": 3, "sum": 2100, "sumsq": 1490000}"#,
+            r#""fable|ask|l|tools":  {"n": 98, "sum": 68600, "sumsq": 48706000}"#,
+        );
+        let thin = estimate(&json);
+        assert_eq!(thin.requests, 4);
+        assert!((thin.coverage_percent - 3.846_153).abs() < 1e-5);
+        assert!(!thin.covers_enough());
+
+        // Its own control arm restores coverage, and with it the headline.
+        let scored = estimate(&json.replace(
+            r#""control": {}"#,
+            r#""control": {"fable|ask|l|tools": {"n": 10, "sum": 10000, "sumsq": 10200000}}"#,
+        ));
+        // 102 of 104: the 2 opus|ask|l|notools still have no evidence.
+        assert_eq!(scored.requests, 102);
+        assert!((scored.coverage_percent - 98.076_923).abs() < 1e-5);
+        assert!(scored.covers_enough());
     }
 
     #[test]

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -2503,9 +2503,11 @@ fn codex_billing_type(plan: &CodexPlanTier, has_org: bool) -> Option<String> {
         CodexPlanTier::Team
         | CodexPlanTier::Business
         | CodexPlanTier::SelfServeBusinessUsageBased
+        | CodexPlanTier::SelfServeBusinessProlite
         | CodexPlanTier::Enterprise
         | CodexPlanTier::EnterpriseCbpUsageBased
-        | CodexPlanTier::Edu => Some(plan.as_header_str().to_string()),
+        | CodexPlanTier::Edu
+        | CodexPlanTier::Education => Some(plan.as_header_str().to_string()),
         CodexPlanTier::Go | CodexPlanTier::Plus | CodexPlanTier::ProLite | CodexPlanTier::Pro => {
             Some(if has_org {
                 plan.as_header_str().to_string()
@@ -4137,6 +4139,11 @@ mod tests {
         assert_eq!(CodexPlanTier::Business.as_header_str(), "business");
         assert_eq!(CodexPlanTier::Enterprise.as_header_str(), "enterprise");
         assert_eq!(CodexPlanTier::Edu.as_header_str(), "edu");
+        assert_eq!(CodexPlanTier::Education.as_header_str(), "education");
+        assert_eq!(
+            CodexPlanTier::SelfServeBusinessProlite.as_header_str(),
+            "self_serve_business_prolite"
+        );
         assert_eq!(CodexPlanTier::Unknown.as_header_str(), "unknown");
     }
 

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -1619,6 +1619,11 @@ pub struct SavingsReport {
     pub cache_savings_usd: f64,
     pub output_reduction_percent: Option<f64>,
     pub output_reduction_method: Option<String>,
+    /// How much of the machine's shaped traffic that percentage actually
+    /// covers. Without it the server cannot tell a solid 43% from a 97% drawn
+    /// from 3% of requests, and both render identically in the admin.
+    pub output_reduction_requests: Option<u64>,
+    pub output_reduction_coverage_percent: Option<f64>,
     /// Retrieval-churn gauges (see `DashboardState`): how much compressed-away
     /// content came back. The over-compression tripwire behind "context filled
     /// up faster with Headroom" reports.

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -121,6 +121,10 @@ struct IdentityPayload {
     /// captures acceptance. `None` (omitted) when nothing accepted yet.
     #[serde(skip_serializing_if = "Option::is_none")]
     accepted_terms_version: Option<u32>,
+    /// Windows only: what the WSL probe found (`wsl_probe`). Omitted until the
+    /// probe finishes and on every other platform.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    wsl_agents: Option<String>,
 }
 
 /// Reqwest errors caused by the user's environment (offline, captive portal,
@@ -304,6 +308,7 @@ impl IdentityPayload {
             codex_usage_windows: None,
             tier_mismatch_since: None,
             accepted_terms_version: None,
+            wsl_agents: crate::wsl_probe::result(),
         }
     }
 

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -46,6 +46,75 @@ pub fn command(program: impl AsRef<OsStr>) -> Command {
     command
 }
 
+/// Why a spawned child did not produce an `Output`.
+#[derive(Debug)]
+pub enum OutputError {
+    Spawn(std::io::Error),
+    TimedOut,
+}
+
+/// `Command::output()` with a deadline. `std` has no `wait_timeout`, so this
+/// is the same try_wait/kill loop `tool_manager::run_command_with_timeout`
+/// uses, minus the pip-specific error shaping, for probes that must never
+/// hang the caller (a WSL distro that is still booting, a PowerShell that
+/// blocks on a profile). Stdin is closed so a child that reads it cannot wait
+/// on us either. On timeout the child is killed and reaped; whatever it
+/// wrote is discarded, because a partial answer is not an answer.
+pub fn output_with_timeout(
+    mut command: Command,
+    timeout: std::time::Duration,
+) -> Result<std::process::Output, OutputError> {
+    use std::io::Read;
+    use std::process::Stdio;
+
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command.spawn().map_err(OutputError::Spawn)?;
+    let mut stdout = child.stdout.take();
+    let mut stderr = child.stderr.take();
+    // Drain both pipes off-thread: a child that fills one while we wait on
+    // the other deadlocks against the pipe buffer.
+    let stdout_handle = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(pipe) = stdout.as_mut() {
+            let _ = pipe.read_to_end(&mut buf);
+        }
+        buf
+    });
+    let stderr_handle = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(pipe) = stderr.as_mut() {
+            let _ = pipe.read_to_end(&mut buf);
+        }
+        buf
+    });
+
+    let started = std::time::Instant::now();
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if started.elapsed() >= timeout => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(OutputError::TimedOut);
+            }
+            Ok(None) => std::thread::sleep(std::time::Duration::from_millis(25)),
+            Err(err) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(OutputError::Spawn(err));
+            }
+        }
+    };
+    Ok(std::process::Output {
+        status,
+        stdout: stdout_handle.join().unwrap_or_default(),
+        stderr: stderr_handle.join().unwrap_or_default(),
+    })
+}
+
 /// `powershell` by its canonical absolute path when `system_root` has one.
 ///
 /// A bare name resolves through PATH, and a user-edited PATH that lost

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -48,6 +48,7 @@ pub fn command(program: impl AsRef<OsStr>) -> Command {
 
 /// Why a spawned child did not produce an `Output`.
 #[derive(Debug)]
+#[cfg_attr(not(windows), allow(dead_code))]
 pub enum OutputError {
     Spawn(std::io::Error),
     TimedOut,
@@ -60,6 +61,9 @@ pub enum OutputError {
 /// blocks on a profile). Stdin is closed so a child that reads it cannot wait
 /// on us either. On timeout the child is killed and reaped; whatever it
 /// wrote is discarded, because a partial answer is not an answer.
+///
+/// Only the Windows-only WSL probe calls this today, hence the allow.
+#[cfg_attr(not(windows), allow(dead_code))]
 pub fn output_with_timeout(
     mut command: Command,
     timeout: std::time::Duration,

--- a/src-tauri/src/proxy_intercept.rs
+++ b/src-tauri/src/proxy_intercept.rs
@@ -124,9 +124,7 @@ static FIRST_PROMPT_REQUEST_REPORTED: AtomicBool = AtomicBool::new(false);
 /// line (with how long it was down) and collapses the per-request spam.
 static BACKEND_REACHABILITY_STATE: AtomicU8 = AtomicU8::new(0);
 static BACKEND_DOWN_SINCE: Mutex<Option<std::time::Instant>> = Mutex::new(None);
-static BACKEND_DOWN_CODEX_RETRY_503S: AtomicU64 = AtomicU64::new(0);
 static CODEX_INFLIGHT_503_LAST_REPORTED: AtomicU64 = AtomicU64::new(0);
-static CODEX_GLOBAL_BYPASS_503_LAST_REPORTED: AtomicU64 = AtomicU64::new(0);
 static CODEX_STREAM_NO_TERMINAL_LAST_REPORTED: AtomicU64 = AtomicU64::new(0);
 const CODEX_RECONNECT_REPORT_MIN_INTERVAL_SECS: u64 = 60;
 /// Last-reported epoch-seconds per (client, status) for `report_upstream_error`:
@@ -250,16 +248,6 @@ fn note_backend_reachability(reachable: bool, backend_addr: SocketAddr) {
                     "backend {backend_addr} reachable (after {:.0}s unreachable)",
                     downtime.as_secs_f64()
                 );
-                let affected = BACKEND_DOWN_CODEX_RETRY_503S.swap(0, Ordering::AcqRel);
-                // Sub-10s outages are routine restart blips (updates, gate
-                // transitions); only report episodes long enough to be felt.
-                if affected > 0 && downtime.as_secs() >= 10 {
-                    report_codex_reconnect_incident(
-                        "backend_unreachable",
-                        affected,
-                        Some(downtime),
-                    );
-                }
             }
             None => log::info!("backend {backend_addr} reachable"),
         }
@@ -532,6 +520,36 @@ pub type FreshBearerNotifier = mpsc::Sender<()>;
 
 pub const ANTHROPIC_DIRECT_BASE: &str = "https://api.anthropic.com";
 pub const OPENAI_DIRECT_BASE: &str = "https://api.openai.com";
+/// Where a ChatGPT-subscription Codex request really goes. Its OAuth token is
+/// scoped to this backend and rejected by api.openai.com with a misleading
+/// "missing api.responses.write" 401, which is why those requests used to be
+/// answered 503 whenever the Python backend was down instead of forwarded.
+/// Same formula as the backend's `providers/codex/endpoints.py`.
+pub const CHATGPT_CODEX_DIRECT_BASE: &str = "https://chatgpt.com/backend-api/codex";
+
+/// Test seam. Shipped builds have no override and always use the const above;
+/// it exists so the direct-forward path can be exercised against a local mock
+/// instead of the real chatgpt.com, which a test must never call.
+#[cfg(test)]
+static CHATGPT_CODEX_BASE_OVERRIDE: Mutex<Option<String>> = Mutex::new(None);
+
+fn chatgpt_codex_direct_base() -> String {
+    #[cfg(test)]
+    if let Some(base) = CHATGPT_CODEX_BASE_OVERRIDE.lock().clone() {
+        return base;
+    }
+    CHATGPT_CODEX_DIRECT_BASE.to_string()
+}
+
+/// Path on `CHATGPT_CODEX_DIRECT_BASE` for a request Codex sent to our `/v1`
+/// provider base: `/v1/responses` -> `/responses`, query intact. A path with
+/// no `/v1` prefix is passed through unchanged rather than guessed at.
+fn chatgpt_codex_direct_path(path: &str) -> &str {
+    match path.strip_prefix("/v1") {
+        Some(rest) if rest.is_empty() || rest.starts_with('/') || rest.starts_with('?') => rest,
+        _ => path,
+    }
+}
 
 /// What a held intercept port means, given who (if anyone) is listening on it
 /// and how long we have been trying.
@@ -1053,7 +1071,6 @@ async fn handle(
     // Codex plan capture, Codex-only bypass, counters, and response handling.
     let parsed_head = find_header_end(&buf).and_then(|end| parse_request_head(&buf[..end + 4]));
     let is_codex = parsed_head.as_ref().is_some_and(is_codex_request_head);
-    let is_chatgpt_codex = is_codex && request_uses_chatgpt_auth(&buf);
     let is_local_backend_path = parsed_head
         .as_ref()
         .is_some_and(|head| is_local_proxy_path(&head.path));
@@ -1180,12 +1197,11 @@ async fn handle(
     }
 
     // When the pricing gate has bypassed Headroom, the Python proxy on
-    // `backend_addr` is intentionally stopped. Forward direct to Anthropic so
-    // already-running CC sessions stay alive while optimization is off.
-    // ChatGPT-authenticated Codex cannot be sent to api.openai.com: its OAuth
-    // token is scoped for chatgpt.com/backend-api/codex and the Platform API
-    // rejects it with a misleading missing `api.responses.write` 401. Return a
-    // retryable response instead of misrouting the credential.
+    // `backend_addr` is intentionally stopped. Forward direct to the provider
+    // so already-running sessions stay alive while optimization is off. The
+    // forwarder picks the upstream from the credential: Claude Code to
+    // Anthropic, API-key Codex to api.openai.com, ChatGPT-subscription Codex
+    // to chatgpt.com's Codex backend (the only place its OAuth token is valid).
     // OpenCode's transport plugin routes third-party providers (Google, custom
     // gateways) here with the real upstream in `x-headroom-base-url`. The
     // direct forwarder only knows the Anthropic/OpenAI bases, so forwarding
@@ -1195,10 +1211,11 @@ async fn handle(
     let is_plugin_routed = request_has_header(&buf, "x-headroom-base-url");
 
     if bypass.load(Ordering::Acquire) {
-        if is_chatgpt_codex || is_plugin_routed {
-            if is_chatgpt_codex && should_report_throttled(&CODEX_GLOBAL_BYPASS_503_LAST_REPORTED) {
-                report_codex_reconnect_incident("global_bypass", 1, None);
-            }
+        // ChatGPT-authenticated Codex goes through the direct forwarder too
+        // now: it knows chatgpt.com's Codex backend, so the OAuth token lands
+        // where it is valid instead of being answered 503. Only plugin-routed
+        // third-party providers still have no correct direct upstream.
+        if is_plugin_routed {
             write_retryable_service_unavailable(&mut client).await;
         } else {
             forward_direct_to_anthropic(client, buf, &upstream_base).await;
@@ -1263,17 +1280,18 @@ async fn handle(
     let Ok(mut backend) = TcpStream::connect(backend_addr).await else {
         // Backend down or mid-restart (crash, gate transition, post-update
         // cold boot — which deliberately holds the bypass flags off for up to
-        // 10 minutes): fall back per-request to the native provider for Claude
-        // and API-key Codex. ChatGPT-authenticated Codex must retry until the
-        // backend returns because its OAuth token is not valid at the Platform
-        // API used by the direct forwarder.
+        // 10 minutes): fall back per-request to the native provider. That now
+        // includes ChatGPT-authenticated Codex, which the forwarder sends to
+        // chatgpt.com's Codex backend where its OAuth token is valid. It used
+        // to get a 503 here and retry until the backend returned, which on a
+        // first launch (model download, a minute or more) meant the setup
+        // wizard's "send a test message" produced an error in Codex while
+        // Claude Code passed through unnoticed: Codex users reached savings
+        // at 55-66% against ~90% for Claude Code on both platforms.
         // info, not warn: warn would ship to Sentry per request; the watchdog's
         // capture_watchdog_give_up already reports genuine down episodes.
         note_backend_reachability(false, backend_addr);
-        if is_chatgpt_codex {
-            BACKEND_DOWN_CODEX_RETRY_503S.fetch_add(1, Ordering::AcqRel);
-            write_retryable_service_unavailable(&mut client).await;
-        } else if is_plugin_routed {
+        if is_plugin_routed {
             // See the bypass branch above: no correct direct upstream exists
             // for plugin-routed third-party providers.
             write_retryable_service_unavailable(&mut client).await;
@@ -2383,10 +2401,21 @@ async fn forward_direct_to_anthropic(
     // OpenAI's, separate from Headroom's Claude account gate, so don't break
     // Codex when the gate trips — forward Codex requests to OpenAI directly
     // rather than (wrongly) to api.anthropic.com.
-    let effective_base: &str = if is_codex_request_head(&parsed) {
-        OPENAI_DIRECT_BASE
+    // Three upstreams, keyed on what the request carries: a ChatGPT OAuth
+    // token is only valid at chatgpt.com's Codex backend, an API key at
+    // api.openai.com, anything else is Claude Code on `upstream_base`.
+    let chatgpt_codex = is_codex_request_head(&parsed) && request_uses_chatgpt_auth(&header_buf);
+    let effective_base: String = if chatgpt_codex {
+        chatgpt_codex_direct_base()
+    } else if is_codex_request_head(&parsed) {
+        OPENAI_DIRECT_BASE.to_string()
     } else {
-        upstream_base
+        upstream_base.to_string()
+    };
+    let effective_path: &str = if chatgpt_codex {
+        chatgpt_codex_direct_path(&parsed.path)
+    } else {
+        &parsed.path
     };
 
     let header_value = |name: &str| {
@@ -2403,7 +2432,7 @@ async fn forward_direct_to_anthropic(
     // bypass modes meant to keep it alive. Tunnel the upgrade via hyper's
     // connection takeover instead.
     if header_value("upgrade").is_some() {
-        let url = format!("{}{}", effective_base, parsed.path);
+        let url = format!("{}{}", effective_base, effective_path);
         tunnel_upgrade_direct(client, &parsed, leftover_body, &url).await;
         return;
     }
@@ -2477,7 +2506,7 @@ async fn forward_direct_to_anthropic(
         sanitize_stale_tool_references(body, &parsed.path)
     };
 
-    let url = format!("{}{}", effective_base, parsed.path);
+    let url = format!("{}{}", effective_base, effective_path);
     let method = match reqwest::Method::from_bytes(parsed.method.as_bytes()) {
         Ok(m) => m,
         Err(_) => {
@@ -2489,6 +2518,16 @@ async fn forward_direct_to_anthropic(
     };
 
     let mut req = upstream_client().request(method, &url);
+    // Same fallback the backend's `resolve_codex_routing` applies: a Codex
+    // build that omits the account header on some request still carries the
+    // account id in its JWT, and chatgpt.com wants it as a header.
+    if chatgpt_codex && header_value("chatgpt-account-id").is_none() {
+        if let Some(account) = extract_bearer(&header_buf)
+            .and_then(|token| decode_codex_auth_claim(&token, "chatgpt_account_id"))
+        {
+            req = req.header("ChatGPT-Account-ID", account);
+        }
+    }
     for (name, value) in &parsed.headers {
         if is_hop_by_hop_request_header(name) {
             continue;
@@ -3400,6 +3439,33 @@ mod tests {
         assert_eq!(extract_bearer(request).as_deref(), Some("test-token"));
     }
 
+    /// The direct forwarder now sends ChatGPT-subscription Codex to
+    /// chatgpt.com's Codex backend instead of answering 503. The path Codex
+    /// sends is relative to our `/v1` provider base; chatgpt.com's is not.
+    #[test]
+    fn chatgpt_codex_direct_path_drops_our_v1_prefix_and_keeps_the_query() {
+        use super::chatgpt_codex_direct_path as map;
+        assert_eq!(map("/v1/responses"), "/responses");
+        assert_eq!(map("/v1/responses?stream=true"), "/responses?stream=true");
+        assert_eq!(map("/v1/responses/abc/compact"), "/responses/abc/compact");
+        assert_eq!(
+            map("/v1/models?client_version=1"),
+            "/models?client_version=1"
+        );
+        assert_eq!(map("/v1"), "");
+        // Not our prefix: never invent a mapping.
+        assert_eq!(map("/v10/responses"), "/v10/responses");
+        assert_eq!(map("/responses"), "/responses");
+        assert_eq!(
+            format!(
+                "{}{}",
+                super::CHATGPT_CODEX_DIRECT_BASE,
+                map("/v1/responses")
+            ),
+            "https://chatgpt.com/backend-api/codex/responses"
+        );
+    }
+
     #[test]
     fn detects_chatgpt_codex_auth_from_header_or_jwt() {
         assert!(request_uses_chatgpt_auth(
@@ -3835,8 +3901,14 @@ mod tests {
             "codex counter should not move for an Anthropic-path request"
         );
 
-        // ChatGPT-authenticated Codex cannot use the Platform API direct
-        // fallback. It must retry until the auth-aware Python backend returns.
+        // ChatGPT-authenticated Codex forwards to chatgpt.com's Codex backend,
+        // where its OAuth token is valid. It used to be answered 503 and left
+        // to retry until the Python backend returned, which on a first launch
+        // is a minute or more of the setup wizard's test message failing in
+        // Codex while Claude Code passed through direct and looked fine.
+        // Pointed at the local mock: a test must never call the real host.
+        *super::CHATGPT_CODEX_BASE_OVERRIDE.lock() =
+            Some(format!("http://127.0.0.1:{}", upstream_addr.port()));
         let mut codex_client = TcpStream::connect(intercept_addr)
             .await
             .expect("codex connect");
@@ -3847,14 +3919,11 @@ mod tests {
             .await
             .expect("write codex request");
         let response = read_response(codex_client).await;
+        *super::CHATGPT_CODEX_BASE_OVERRIDE.lock() = None;
         let response_str = std::str::from_utf8(&response).unwrap_or("");
         assert!(
-            response_str.starts_with("HTTP/1.1 503"),
-            "expected retryable 503 for ChatGPT Codex, got: {response_str:?}"
-        );
-        assert!(
-            response_str.contains("\r\nRetry-After: 1\r\n"),
-            "ChatGPT Codex 503 should ask the client to retry: {response_str:?}"
+            response_str.starts_with("HTTP/1.1 200"),
+            "expected ChatGPT Codex to forward direct, got: {response_str:?}"
         );
         let counts_after_codex = intercept_request_counts();
         assert_eq!(

--- a/src-tauri/src/proxy_intercept.rs
+++ b/src-tauri/src/proxy_intercept.rs
@@ -813,7 +813,14 @@ pub fn spawn(
                                         // be configured for, so "it will
                                         // clear itself" has stopped being
                                         // true. Nothing to name, but worth
-                                        // knowing about.
+                                        // knowing about. The phrase is what
+                                        // `state::intercept_bind_hint` keys
+                                        // on to say "reboot" instead of "quit
+                                        // whatever holds the port".
+                                        *bind_error.lock() = Some(format!(
+                                            "port {INTERCEPT_PORT} stuck in use with nothing listening ({}s)",
+                                            launched_at.elapsed().as_secs()
+                                        ));
                                         log::warn!(
                                             "[proxy_intercept] port {INTERCEPT_PORT} still in use with nothing listening after {}s; retrying in 15s ({e})",
                                             launched_at.elapsed().as_secs()

--- a/src-tauri/src/savings_canary.rs
+++ b/src-tauri/src/savings_canary.rs
@@ -47,6 +47,14 @@ pub struct Anomaly {
     pub strata: Vec<String>,
     /// Distinct `provider/model` pairs, to point at which client broke.
     pub models: Vec<String>,
+    /// Distinct transform families that ran on the zero-saved requests, with
+    /// per-request parameters trimmed off. This is the discriminator the first
+    /// ten reports lacked: a wire-format regression leaves the router with
+    /// nothing to match (`router:noop` alone next to the output shaper), while
+    /// a compressor that ran and returned nothing shows its real stages. Every
+    /// report so far spanned every provider at once, which no single client's
+    /// wire format can explain -- the transforms say which of the two it was.
+    pub transforms: Vec<String>,
 }
 
 /// Pick out the anomaly, or `None` when the batch looks healthy or is too
@@ -80,11 +88,23 @@ pub fn detect(events: &[TransformationFeedEvent]) -> Option<Anomaly> {
     // machines instead of reshuffling per batch.
     let mut strata = BTreeSet::new();
     let mut models = BTreeSet::new();
+    let mut transforms = BTreeSet::new();
     for event in &zeroed {
         for transform in &event.transforms_applied {
             if let Some(stratum) = transform.strip_prefix("output_shaper:stratum:") {
                 strata.insert(stratum.to_string());
+                continue;
             }
+            // First two segments only: `router:tool_search_deferral:9tools:
+            // 14341tok` carries per-request counts that would make every
+            // machine's set unique and the fleet view unreadable.
+            transforms.insert(
+                transform
+                    .split(':')
+                    .take(2)
+                    .collect::<Vec<&str>>()
+                    .join(":"),
+            );
         }
         let provider = event.provider.as_deref().unwrap_or("?");
         let model = event.model.as_deref().unwrap_or("?");
@@ -96,6 +116,7 @@ pub fn detect(events: &[TransformationFeedEvent]) -> Option<Anomaly> {
         zero: zeroed.len(),
         strata: strata.into_iter().take(5).collect(),
         models: models.into_iter().take(5).collect(),
+        transforms: transforms.into_iter().take(6).collect(),
     })
 }
 
@@ -110,6 +131,7 @@ pub fn observe(events: &[TransformationFeedEvent]) {
 
     let strata = anomaly.strata.join(", ");
     let models = anomaly.models.join(", ");
+    let transforms = anomaly.transforms.join(", ");
     // Fixed fingerprint: every affected machine lands in one issue, so the
     // event count is the blast radius. Counts stay out of it deliberately.
     let fingerprint: [&str; 1] = ["zero_savings_canary"];
@@ -121,13 +143,14 @@ pub fn observe(events: &[TransformationFeedEvent]) {
             scope.set_extra("min_input_tokens", MIN_INPUT_TOKENS.into());
             scope.set_extra("strata", strata.clone().into());
             scope.set_extra("models", models.clone().into());
+            scope.set_extra("transforms", transforms.clone().into());
             scope.set_fingerprint(Some(fingerprint.as_slice()));
         },
         || {
             sentry::capture_message(
                 &format!(
                     "zero_savings_canary: {}/{} large requests compressed to nothing \
-                     (models: {models}; strata: {strata})",
+                     (models: {models}; strata: {strata}; transforms: {transforms})",
                     anomaly.zero, anomaly.sample
                 ),
                 sentry::Level::Warning,
@@ -136,7 +159,7 @@ pub fn observe(events: &[TransformationFeedEvent]) {
     );
     log::warn!(
         "zero-savings canary: {}/{} requests over {MIN_INPUT_TOKENS} tokens saved nothing \
-         (models: {models}; strata: {strata})",
+         (models: {models}; strata: {strata}; transforms: {transforms})",
         anomaly.zero,
         anomaly.sample
     );
@@ -187,6 +210,31 @@ mod tests {
         assert_eq!(anomaly.zero, MIN_SAMPLE);
         assert_eq!(anomaly.strata, vec!["gpt|new_user_ask|m|notools"]);
         assert_eq!(anomaly.models, vec!["openai/gpt-5.6-sol"]);
+        assert_eq!(anomaly.transforms, vec!["output_shaper:verbosity"]);
+    }
+
+    /// The two shapes the first ten reports could not be told apart by: a
+    /// router that matched nothing, versus stages that ran and returned zero.
+    /// Per-request parameters are trimmed so the sets collapse across machines.
+    #[test]
+    fn names_the_transform_families_behind_the_zeroes() {
+        let batch: Vec<_> = (0..MIN_SAMPLE)
+            .map(|_| {
+                event(
+                    40_000,
+                    0,
+                    &[
+                        "router:noop",
+                        "router:tool_search_deferral:9tools:14341tok",
+                        "output_shaper:stratum:gpt|new_user_ask|m|notools",
+                    ],
+                )
+            })
+            .collect();
+        assert_eq!(
+            detect(&batch).expect("anomaly").transforms,
+            vec!["router:noop", "router:tool_search_deferral"]
+        );
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -3231,19 +3231,38 @@ impl AppState {
         // coding and silently saves nothing. That is Sentry RUST-6J into
         // RUST-5C, and the largest Windows cluster we have.
         //
-        // Asking the backend directly closes it. The argv check is what keeps
-        // this safe: adopting a backend from an OLDER app build would silently
-        // run a mismatched wheel and, worse, quietly disable the exact-pin
-        // prefix-floor vendor. A mismatched argv fails this test and falls
-        // through to the existing teardown-and-respawn path unchanged.
-        let backend_serving =
-            crate::tool_manager::probe_backend_readyz_ok(crate::backend_port::get());
+        // Asking the backend directly closes it. The argv check is the gate
+        // against adopting a backend from an OLDER app build, which would
+        // silently run a mismatched wheel and quietly disable the exact-pin
+        // prefix-floor vendor: a mismatched argv falls through to the
+        // teardown-and-respawn path unchanged. Know its limit: argv is read
+        // through `ps`, so on Windows it is unreadable and the check fails
+        // OPEN (see `running_proxy_matches_expected_args`), leaving the
+        // /readyz probe as the only gate there. What bounds that: an orphan
+        // is this machine's own venv, and `stop_headroom`'s sweep reaps it at
+        // the next quit or upgrade (verified on Windows 2026-09-06).
+        let intercept_reachable = is_headroom_proxy_reachable();
+        // Each probe below only runs when it can change the answer: the
+        // backend probe is a request, the argv check shells out.
+        let backend_serving = !intercept_reachable
+            && crate::tool_manager::probe_backend_readyz_ok(crate::backend_port::get());
+        let backend_argv_is_current =
+            backend_serving && crate::tool_manager::running_proxy_matches_expected_args();
         if runtime_already_serving(
-            is_headroom_proxy_reachable(),
+            intercept_reachable,
             backend_serving,
-            // Only consult argv when it can change the answer: it shells out.
-            backend_serving && crate::tool_manager::running_proxy_matches_expected_args(),
+            backend_argv_is_current,
+            *self.runtime_upgrade_in_progress.lock(),
         ) {
+            if !intercept_reachable {
+                // The one line that says this path fired. Verified on Windows
+                // 2026-09-06 by backend pid identity; the field signal is
+                // RUST-6J / RUST-5C going quiet.
+                log::info!(
+                    "ensure_headroom_running: adopting healthy backend on port {} behind an unreachable intercept; not spawning",
+                    crate::backend_port::get()
+                );
+            }
             *self.last_startup_error.lock() = None;
             return Ok(());
         }
@@ -4317,6 +4336,37 @@ struct LaunchProfile {
     unrouted_usage_notified: bool,
 }
 
+/// Parse a launch profile, resetting every top-level field that does not
+/// deserialize and keeping the rest. Returns the profile and, for each field
+/// reset, `name (cause)`. RUST-D7: a hand-edited `upstream_override.mode:
+/// "custom"` threw away the whole profile, launch count and lifetime savings
+/// included, where resetting that one field would have done. Field by field
+/// because `#[serde(default)]` only covers a MISSING field; one that is present
+/// and unreadable fails the container. Not JSON at all is still an error: the
+/// caller backs the file up and starts fresh.
+/// ponytail: top-level fields only, so a bad nested value resets its whole
+/// parent object; split the parent if that ever loses something worth keeping.
+fn parse_launch_profile_salvaging(bytes: &[u8]) -> Result<(LaunchProfile, Vec<String>)> {
+    if let Ok(profile) = serde_json::from_slice::<LaunchProfile>(bytes) {
+        return Ok((profile, Vec::new()));
+    }
+    let mut map: serde_json::Map<String, serde_json::Value> = serde_json::from_slice(bytes)?;
+    let dropped: Vec<String> = map
+        .iter()
+        .filter_map(|(key, value)| {
+            let one = serde_json::Map::from_iter([(key.clone(), value.clone())]);
+            serde_json::from_value::<LaunchProfile>(serde_json::Value::Object(one))
+                .err()
+                .map(|err| format!("{key} ({err})"))
+        })
+        .collect();
+    for entry in &dropped {
+        map.remove(entry.split(' ').next().unwrap_or_default());
+    }
+    let profile = serde_json::from_value::<LaunchProfile>(serde_json::Value::Object(map))?;
+    Ok((profile, dropped))
+}
+
 fn persist_launch_profile(path: &std::path::Path, profile: &LaunchProfile) {
     if let Ok(bytes) = serde_json::to_vec_pretty(profile) {
         let _ = crate::client_adapters::atomic_write(path, &bytes);
@@ -4354,12 +4404,23 @@ impl LaunchProfile {
         // A corrupt or truncated profile (0-byte file from a crash mid-write,
         // RUST-1P) must not crash startup — that's an unrecoverable launch
         // loop until the user manually deletes the file. Degrade to a fresh
-        // profile; the warn still reaches Sentry for visibility.
+        // profile; the warn still reaches Sentry for visibility. A profile
+        // that is valid JSON with one unreadable field keeps every other
+        // field (RUST-D7).
         let previous = if path.exists() {
             std::fs::read(&path)
                 .map_err(anyhow::Error::from)
-                .and_then(|bytes| {
-                    serde_json::from_slice::<LaunchProfile>(&bytes).map_err(anyhow::Error::from)
+                .and_then(|bytes| parse_launch_profile_salvaging(&bytes))
+                .map(|(profile, dropped)| {
+                    if !dropped.is_empty() {
+                        log::warn!(
+                            "launch profile at {} had unreadable field(s) {}; reset those to default and kept the rest (backup: .json.salvaged)",
+                            path.display(),
+                            dropped.join(", ")
+                        );
+                        let _ = std::fs::copy(&path, path.with_extension("json.salvaged"));
+                    }
+                    profile
                 })
                 .unwrap_or_else(|err| {
                     log::warn!(
@@ -7770,20 +7831,46 @@ pub(crate) fn classify_startup_error(raw: &str) -> Option<String> {
 /// `net stop winnat`, which fails on any machine where winnat is not even
 /// running -- confidently wrong advice is worse than none. Name the port, hand
 /// over the command that identifies the holder, and let the user look.
+/// The banner's explanation for a failed 6767 bind. `raw` is whatever the
+/// intercept's bind loop wrote into `AppState::intercept_bind_error`: the OS
+/// error while it is still working out who holds the port, or one of its own
+/// verdict phrases once it knows (`is held by NAME (pid N)`, `still being
+/// released`, `stuck in use`). Two sentences: the fact, then what to do. The
+/// dashboard prefixes the first sentence with "Headroom is not hooked up right
+/// now:" as the headline and shows the rest underneath, so the first sentence
+/// states only the fact and stays short.
 pub(crate) fn intercept_bind_hint(raw: &str) -> String {
     let port = crate::proxy_intercept::INTERCEPT_PORT;
+    if let Some((_, holder)) = raw.split_once(" is held by ") {
+        let holder = holder.trim_end_matches('.').replace("(pid ", "(PID ");
+        return format!(
+            "Port {port} is in use by {holder}. \
+             Quit that program, or end it in Task Manager, and Headroom reconnects on its own."
+        );
+    }
+    if raw.contains("still being released") {
+        return format!(
+            "Port {port} is still being released by the previous Headroom session. \
+             Nothing to do: Headroom reconnects on its own within a few minutes."
+        );
+    }
+    if raw.contains("stuck in use") {
+        return format!(
+            "Port {port} is in use, but no program is listening on it. \
+             Reboot to clear it; if it comes back, check for a reserved port range with: \
+             netsh int ipv4 show excludedportrange protocol=tcp"
+        );
+    }
     if raw.contains("os error 10048") {
         return format!(
-            "Port {port} is already held by another process, so Headroom cannot open it and \
-             clients get \"connection refused\". In PowerShell, \
-             `Get-NetTCPConnection -LocalPort {port}` names the owning process: if it is a \
-             leftover Headroom, quit it and relaunch. If nothing owns the port, check for a \
-             reserved range with `netsh int ipv4 show excludedportrange protocol=tcp`."
+            "Port {port} is in use by another program. \
+             Headroom retries every few seconds; if this doesn't clear, \
+             Get-NetTCPConnection -LocalPort {port} in PowerShell shows what holds the port."
         );
     }
     format!(
-        "Headroom cannot open port {port}, so no client traffic can reach it ({raw}). \
-         Another app is holding the port -- quit it, or reboot to clear stuck listeners."
+        "Headroom can't open port {port} ({raw}). \
+         Quit whatever holds the port, or reboot to clear stuck listeners."
     )
 }
 
@@ -7797,13 +7884,18 @@ fn is_headroom_proxy_reachable() -> bool {
 ///
 /// A reachable intercept is sufficient (the pre-existing rule). A healthy
 /// backend alone is NOT: it must also be running this build's argv, or we would
-/// adopt an older build's proxy and silently run a mismatched wheel.
+/// adopt an older build's proxy and silently run a mismatched wheel. And never
+/// during an upgrade's boot validation: the backend on the port then is the
+/// OLD wheel that `stop_headroom` was meant to remove, and validating against
+/// it would report the upgrade as working while nothing changed; the spawn
+/// path force-reclaims it instead.
 fn runtime_already_serving(
     intercept_reachable: bool,
     backend_serving: bool,
     backend_argv_is_current: bool,
+    upgrade_in_progress: bool,
 ) -> bool {
-    intercept_reachable || (backend_serving && backend_argv_is_current)
+    intercept_reachable || (!upgrade_in_progress && backend_serving && backend_argv_is_current)
 }
 
 fn probe_proxy_readyz(timeout: Duration) -> bool {
@@ -9481,6 +9573,29 @@ mod tests {
         assert!(!hint.contains("net stop winnat"), "{hint}");
     }
 
+    /// The bind loop's own verdicts each get a hint that says what is wrong
+    /// and what to do, never "quit whatever holds the port" for a port that
+    /// nothing is holding.
+    #[test]
+    fn intercept_bind_hint_reads_the_bind_loops_verdicts() {
+        let foreign = intercept_bind_hint("port 6767 is held by python.exe (pid 11236)");
+        assert!(foreign.contains("python.exe (PID 11236)"), "{foreign}");
+        assert!(foreign.contains("Task Manager"), "{foreign}");
+        let draining =
+            intercept_bind_hint("port 6767 is still being released after a restart; reconnecting");
+        assert!(draining.contains("Nothing to do"), "{draining}");
+        assert!(!draining.contains("Quit"), "{draining}");
+        let stuck = intercept_bind_hint("port 6767 stuck in use with nothing listening (301s)");
+        assert!(stuck.contains("excludedportrange"), "{stuck}");
+        assert!(stuck.contains("Reboot"), "{stuck}");
+        // Every variant leads with a sentence that stands alone as the headline.
+        for hint in [&foreign, &draining, &stuck] {
+            let first = hint.split(". ").next().unwrap();
+            assert!(first.starts_with("Port 6767"), "{first}");
+            assert!(first.len() < 110, "headline too long: {first}");
+        }
+    }
+
     #[test]
     fn intercept_bind_hint_falls_back_to_the_raw_cause() {
         let hint = intercept_bind_hint("Address already in use (os error 48)");
@@ -9759,20 +9874,26 @@ mod tests {
         use super::runtime_already_serving as serving;
 
         // The pre-existing rule is untouched: a reachable intercept is enough.
-        assert!(serving(true, false, false));
-        assert!(serving(true, true, true));
+        assert!(serving(true, false, false, false));
+        assert!(serving(true, true, true, false));
 
         // The fix: intercept down, backend healthy and running this build.
-        assert!(serving(false, true, true));
+        assert!(serving(false, true, true, false));
 
         // A healthy backend from an OLDER build must NOT be adopted. Doing so
         // would silently run a mismatched wheel and disable the exact-pin
         // prefix-floor vendor, so this has to fall through to respawn.
-        assert!(!serving(false, true, false));
+        assert!(!serving(false, true, false, false));
 
         // Nothing serving at all still spawns.
-        assert!(!serving(false, false, false));
-        assert!(!serving(false, false, true));
+        assert!(!serving(false, false, false, false));
+        assert!(!serving(false, false, true, false));
+
+        // During an upgrade's boot validation the healthy backend is the OLD
+        // wheel: never adopt it, fall through to the force-reclaim spawn. The
+        // intercept rule is not affected by the flag.
+        assert!(!serving(false, true, true, true));
+        assert!(serving(true, false, false, true));
     }
 
     #[test]
@@ -13209,6 +13330,63 @@ mod tests {
         let (profile, _) = super::LaunchProfile::load_or_create(&base_dir).expect("reload");
         assert_eq!(profile.launch_count, 2);
         let _ = std::fs::remove_dir_all(&base_dir);
+    }
+
+    /// RUST-D7: one hand-edited enum value must reset that field, not the
+    /// profile. The counters next to it survive and the file is backed up.
+    #[test]
+    fn launch_profile_load_or_create_keeps_the_fields_next_to_an_unreadable_one() {
+        let base_dir = std::env::temp_dir().join(format!(
+            "headroom-launch-profile-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        ensure_data_dirs(&base_dir).expect("create temp dirs");
+        let path = crate::storage::config_file(&base_dir, "launch-profile.json");
+        std::fs::write(
+            &path,
+            r#"{"launch_count": 7, "lifetime_requests": 3, "accepted_terms_version": 2,
+                "upstream_override": {"mode": "custom", "base_url": "https://api.example.com"}}"#,
+        )
+        .expect("write profile");
+
+        let (profile, _) = super::LaunchProfile::load_or_create(&base_dir).expect("salvaged");
+        assert_eq!(profile.launch_count, 8);
+        assert_eq!(profile.lifetime_requests, 3);
+        assert_eq!(profile.accepted_terms_version, 2);
+        assert_eq!(
+            profile.upstream_override,
+            super::UpstreamOverride::default()
+        );
+        assert!(path.with_extension("json.salvaged").exists());
+        // The rewritten file parses cleanly on the next launch.
+        let (profile, _) = super::LaunchProfile::load_or_create(&base_dir).expect("reload");
+        assert_eq!(profile.launch_count, 9);
+        let _ = std::fs::remove_dir_all(&base_dir);
+    }
+
+    #[test]
+    fn parse_launch_profile_salvaging_names_only_the_bad_fields() {
+        let (profile, dropped) = super::parse_launch_profile_salvaging(
+            br#"{"launch_count": 4, "upstream_override": {"mode": "custom"}, "setup_wizard_complete": "yes"}"#,
+        )
+        .expect("salvaged");
+        assert_eq!(profile.launch_count, 4);
+        assert!(!profile.setup_wizard_complete);
+        let mut names: Vec<&str> = dropped
+            .iter()
+            .map(|entry| entry.split(' ').next().unwrap())
+            .collect();
+        names.sort();
+        assert_eq!(names, ["setup_wizard_complete", "upstream_override"]);
+        assert!(
+            dropped
+                .iter()
+                .any(|entry| entry.contains("unknown variant `custom`")),
+            "{dropped:?}"
+        );
+        // Not JSON at all is still an error: the caller backs up and starts fresh.
+        assert!(super::parse_launch_profile_salvaging(b"").is_err());
+        assert!(super::parse_launch_profile_salvaging(b"{").is_err());
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -2493,6 +2493,8 @@ impl AppState {
                 ci_low_percent: e.ci_low_percent,
                 ci_high_percent: e.ci_high_percent,
                 requests: e.requests,
+                coverage_percent: Some(e.coverage_percent),
+                publishable: e.covers_enough(),
             })
             .or_else(|| {
                 if !backend_output_fallback_allowed {
@@ -2507,6 +2509,8 @@ impl AppState {
                         ci_low_percent: o.ci_low_percent,
                         ci_high_percent: o.ci_high_percent,
                         requests: o.requests,
+                        coverage_percent: None,
+                        publishable: true,
                     })
             });
 
@@ -8604,14 +8608,39 @@ fn warn_once_if_savings_rate_implausible(
         // legit expensive-model mix, a foreign backend on 6767, and real
         // contamination are indistinguishable from the rate alone (RUST-89,
         // 2026-09-01: $93.70/M on a 0.35.0-pinned install, undecidable).
+        //
+        // The lifetime rate alone still could not separate the two shapes this
+        // canary has churned through four resolve/regress cycles on: one
+        // contaminated day dragging an otherwise-sane series up, versus every
+        // day sitting above the ceiling. The worst bucket says which, and the
+        // configured upstream says whether Anthropic rates were applied to a
+        // third-party endpoint's traffic -- both read off state already in hand.
         let saved_usd: f64 = daily_savings.iter().map(|p| p.estimated_savings_usd).sum();
         let saved_tokens: u64 = daily_savings.iter().map(|p| p.estimated_tokens_saved).sum();
         let wheel = installed_wheel().unwrap_or_else(|| "unknown".into());
+        let bucket_rate =
+            |p: &DailySavingsPoint| p.estimated_savings_usd / p.estimated_tokens_saved as f64 * 1e6;
+        let worst = daily_savings
+            .iter()
+            .filter(|p| p.estimated_tokens_saved > 0)
+            .max_by(|a, b| bucket_rate(a).total_cmp(&bucket_rate(b)))
+            .map(|p| {
+                format!(
+                    "{} at ${:.2}/M (${:.2} / {} tok)",
+                    p.date,
+                    bucket_rate(p),
+                    p.estimated_savings_usd,
+                    p.estimated_tokens_saved
+                )
+            })
+            .unwrap_or_else(|| "none".into());
+        let upstream = crate::upstream_override::get().mode;
         log::warn!(
             "savings rate implausible: buckets imply ${savings_per_m:.2}/M saved (${saved_usd:.2} \
              across {saved_tokens} tokens, wheel {wheel}), above the \
              ${MAX_PLAUSIBLE_INPUT_USD_PER_M:.2}/M ceiling for an input token; upstream savings \
-             semantics likely changed under the pinned wheel"
+             semantics likely changed under the pinned wheel; worst bucket {worst}, upstream \
+             {upstream:?}"
         );
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -6348,6 +6348,111 @@ fn note_stats_fetch_success() {
     }
 }
 
+// A structural failure signal from the proxy, not a savings-rate canary.
+// Deserialize an allowlist so request text or arbitrary extras can never enter
+// Sentry through this endpoint. Empty/old-wheel payloads are simply absent.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum CacheIntegrityKind {
+    TrackerReset,
+    PrefixRewrite,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct CacheIntegrityReport {
+    boot_id: String,
+    count: u64,
+    kind: CacheIntegrityKind,
+    stable_messages: u64,
+    first_changed_message: u64,
+    previously_cached_tokens: u64,
+    cache_read_tokens: u64,
+    cache_write_tokens: u64,
+}
+
+impl CacheIntegrityReport {
+    fn from_stats(body: &str) -> Option<Self> {
+        let stats: Value = serde_json::from_str(body).ok()?;
+        let report: Self =
+            serde_json::from_value(stats.get("prefix_cache")?.get("desktop_integrity")?.clone())
+                .ok()?;
+        (report.boot_id.len() == 32
+            && report.boot_id.bytes().all(|c| c.is_ascii_hexdigit())
+            && report.count > 0
+            && report.first_changed_message < report.stable_messages
+            && report.cache_read_tokens < report.previously_cached_tokens
+            && report.cache_write_tokens > 0)
+            .then_some(report)
+    }
+}
+
+#[derive(Default)]
+struct CacheIntegrityReporter {
+    seen: Option<(String, u64)>,
+    last_reported: Option<Instant>,
+}
+
+impl CacheIntegrityReporter {
+    fn should_report(&mut self, report: &CacheIntegrityReport, now: Instant) -> bool {
+        if self
+            .seen
+            .as_ref()
+            .is_some_and(|(boot, count)| boot == &report.boot_id && *count >= report.count)
+        {
+            return false;
+        }
+        self.seen = Some((report.boot_id.clone(), report.count));
+        // A broken loop should create one grouped issue, not an event per turn.
+        // Proxy restarts do not bypass the desktop's one-hour throttle.
+        if self
+            .last_reported
+            .is_some_and(|at| now.duration_since(at) < Duration::from_secs(3600))
+        {
+            return false;
+        }
+        self.last_reported = Some(now);
+        true
+    }
+}
+
+fn report_cache_integrity(body: &str) {
+    static REPORTER: Mutex<CacheIntegrityReporter> = Mutex::new(CacheIntegrityReporter {
+        seen: None,
+        last_reported: None,
+    });
+    let Some(report) = CacheIntegrityReport::from_stats(body) else {
+        return;
+    };
+    if !REPORTER.lock().should_report(&report, Instant::now()) {
+        return;
+    }
+    let kind = match report.kind {
+        CacheIntegrityKind::TrackerReset => "tracker_reset",
+        CacheIntegrityKind::PrefixRewrite => "prefix_rewrite",
+    };
+    sentry::with_scope(
+        |scope| {
+            scope.set_fingerprint(Some(&["cache-prefix-integrity", kind]));
+            scope.set_tag("cache_integrity_kind", kind);
+            scope.set_tag("provider", "anthropic");
+            scope.set_extra(
+                "cache_integrity",
+                serde_json::to_value(&report).unwrap_or_default(),
+            );
+        },
+        || {
+            sentry::capture_message(
+                "Headroom rewrote an unchanged cached prefix",
+                sentry::Level::Warning,
+            );
+        },
+    );
+    log::info!(
+        "cache-prefix-integrity: {kind}, observation {}",
+        report.count
+    );
+}
+
 fn fetch_headroom_dashboard_stats() -> Option<HeadroomDashboardStats> {
     if !is_headroom_proxy_reachable() {
         return None;
@@ -6401,6 +6506,7 @@ fn fetch_headroom_dashboard_stats() -> Option<HeadroomDashboardStats> {
         };
 
         if let Some(parsed) = parse_headroom_stats_from_json(&body) {
+            report_cache_integrity(&body);
             // Only a SUSTAINED recovery resets the backoff; a lone success
             // between two timeouts must not (see STATS_FETCH_RECOVERY_WINDOW).
             note_stats_fetch_success();
@@ -8753,6 +8859,97 @@ fn bootstrap_failed_state(current: &BootstrapProgress, message: String) -> Boots
 mod tests {
     use std::fs;
     use std::path::PathBuf;
+
+    #[test]
+    fn cache_integrity_report_is_allowlisted_and_throttled() {
+        use super::{CacheIntegrityReport, CacheIntegrityReporter, Duration, Instant};
+        let mut payload = serde_json::json!({"prefix_cache": {"desktop_integrity": {
+            "boot_id": "0123456789abcdef0123456789abcdef", "count": 1,
+            "kind": "tracker_reset", "stable_messages": 861, "first_changed_message": 3,
+            "previously_cached_tokens": 503505, "cache_read_tokens": 7259,
+            "cache_write_tokens": 491260, "unexpected_prompt": "private content"
+        }}});
+        let mut report = CacheIntegrityReport::from_stats(&payload.to_string()).unwrap();
+        assert!(!serde_json::to_string(&report)
+            .unwrap()
+            .contains("private content"));
+        let mut reporter = CacheIntegrityReporter::default();
+        let start = Instant::now();
+        assert!(reporter.should_report(&report, start));
+        assert!(!reporter.should_report(&report, start + Duration::from_secs(3601)));
+        report.count = 2;
+        assert!(!reporter.should_report(&report, start + Duration::from_secs(12)));
+        report.boot_id = "fedcba9876543210fedcba9876543210".into();
+        report.count = 1;
+        assert!(!reporter.should_report(&report, start + Duration::from_secs(24)));
+        report.count = 2;
+        assert!(reporter.should_report(&report, start + Duration::from_secs(3601)));
+
+        assert!(CacheIntegrityReport::from_stats("{}").is_none());
+        assert!(CacheIntegrityReport::from_stats("not json").is_none());
+        for (key, value) in [
+            ("boot_id", serde_json::json!("user-supplied-content")),
+            ("count", serde_json::json!(0)),
+            ("kind", serde_json::json!("arbitrary-message")),
+            ("first_changed_message", serde_json::json!(861)),
+            ("cache_read_tokens", serde_json::json!(503505)),
+            ("cache_write_tokens", serde_json::json!(0)),
+        ] {
+            let previous = payload["prefix_cache"]["desktop_integrity"][key].clone();
+            payload["prefix_cache"]["desktop_integrity"][key] = value;
+            assert!(
+                CacheIntegrityReport::from_stats(&payload.to_string()).is_none(),
+                "{key}"
+            );
+            payload["prefix_cache"]["desktop_integrity"][key] = previous;
+        }
+    }
+
+    #[test]
+    fn cache_integrity_sentry_event_is_grouped_and_contains_no_prompt() {
+        use std::sync::{Arc, Mutex};
+        #[derive(Default)]
+        struct Recorder(Mutex<Vec<sentry::protocol::Event<'static>>>);
+        impl sentry::Transport for Recorder {
+            fn send_envelope(&self, envelope: sentry::Envelope) {
+                if let Some(event) = envelope.event() {
+                    self.0.lock().unwrap().push(event.clone());
+                }
+            }
+        }
+        let recorder = Arc::new(Recorder::default());
+        let client = sentry::Client::from(sentry::ClientOptions {
+            dsn: Some("https://public@sentry.invalid/1".parse().unwrap()),
+            transport: Some(Arc::new(recorder.clone())),
+            ..Default::default()
+        });
+        let hub = Arc::new(sentry::Hub::new(
+            Some(Arc::new(client)),
+            Arc::new(Default::default()),
+        ));
+        let payload = serde_json::json!({"prefix_cache": {"desktop_integrity": {
+            "boot_id": "0123456789abcdef0123456789abcdef", "count": 1,
+            "kind": "tracker_reset", "stable_messages": 861, "first_changed_message": 3,
+            "previously_cached_tokens": 503505, "cache_read_tokens": 7259,
+            "cache_write_tokens": 491260, "unexpected_prompt": "private content"
+        }}})
+        .to_string();
+        sentry::Hub::run(hub, || {
+            super::report_cache_integrity(&payload);
+            super::report_cache_integrity(&payload);
+        });
+        let events = recorder.0.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].fingerprint.as_ref(),
+            ["cache-prefix-integrity", "tracker_reset"]
+        );
+        assert_eq!(events[0].level, sentry::Level::Warning);
+        assert_eq!(events[0].tags["provider"], "anthropic");
+        assert!(!serde_json::to_string(&events[0])
+            .unwrap()
+            .contains("private content"));
+    }
 
     #[test]
     fn strip_extended_length_prefix_handles_windows_and_unix_forms() {

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -9433,7 +9433,48 @@ fn argv_contains_flag(argv: &str, flag: &str) -> bool {
     argv.split_whitespace().any(|tok| tok == flag)
 }
 
+/// argv of `pid`, for the argv gate and the listener diagnostics.
+///
+/// This used to shell `/bin/ps` unconditionally, so on Windows it was always
+/// `None` and `running_proxy_matches_expected_args` failed open: the one
+/// platform where the healthy-backend adoption in `ensure_headroom_running`
+/// matters had no argv gate at all, and every occupant string Sentry saw from
+/// Windows was a bare image name. `Win32_Process.CommandLine` is the argv
+/// there, same shape as `ps -o command=` (quoted exe, then the flags).
+///
+/// One-entry cache keyed on pid: the gate runs on every ensure pass while the
+/// backend is up, and the Windows lookup is a PowerShell spawn. A live process
+/// never changes its argv, so a repeat pid answers from cache. Pid reuse after
+/// the backend exits can only fail in the safe direction: a stale argv reads
+/// as "not this build", which respawns.
 fn ps_command(pid: u32) -> Option<String> {
+    static CACHE: std::sync::Mutex<Option<(u32, String)>> = std::sync::Mutex::new(None);
+    if let Ok(guard) = CACHE.lock() {
+        if let Some((cached_pid, argv)) = guard.as_ref() {
+            if *cached_pid == pid {
+                return Some(argv.clone());
+            }
+        }
+    }
+    let argv = ps_command_uncached(pid)?;
+    if let Ok(mut guard) = CACHE.lock() {
+        *guard = Some((pid, argv.clone()));
+    }
+    Some(argv)
+}
+
+fn ps_command_uncached(pid: u32) -> Option<String> {
+    #[cfg(windows)]
+    let output = crate::proc::command("powershell")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            &format!("(Get-CimInstance Win32_Process -Filter \"ProcessId = {pid}\").CommandLine"),
+        ])
+        .output()
+        .ok()?;
+    #[cfg(not(windows))]
     let output = crate::proc::command("/bin/ps")
         .args(["-p", &pid.to_string(), "-o", "command="])
         .output()
@@ -11590,6 +11631,40 @@ const PIP_OUTPUT_SILENCE_TIMEOUT: Duration = Duration::from_secs(600);
 /// the default window above.
 const PIP_UNPACK_SILENCE_TIMEOUT: Duration = Duration::from_secs(1800);
 
+/// Retry schedule for a failed pip run, indexed by the attempt that just
+/// failed: `Some(backoff)` means try again after it, `None` means that was the
+/// last attempt.
+///
+/// Two tables. The default is the long-standing 3 attempts. A Windows sharing
+/// violation gets more room: on a fresh install it is almost always antivirus
+/// scanning the wheel pip just wrote (torch alone is ~200MB), it clears on its
+/// own in seconds to tens of seconds, and 2s+5s was not enough for it
+/// (RUST-6Z, 3 attempts burned inside 7 seconds). Windows is where bootstrap
+/// dies: 11% of Windows installs never complete it against 4% on macOS, and
+/// pip failures run 7 Windows users to 2.
+const PIP_RETRY_BACKOFFS_SECS: &[u64] = &[2, 5];
+const PIP_SHARING_VIOLATION_BACKOFFS_SECS: &[u64] = &[2, 5, 10, 20, 30];
+
+fn pip_retry_backoff(failed_attempt: u32, failure_text: &str) -> Option<Duration> {
+    let table = if pip_failure_is_sharing_violation(failure_text) {
+        PIP_SHARING_VIOLATION_BACKOFFS_SECS
+    } else {
+        PIP_RETRY_BACKOFFS_SECS
+    };
+    table
+        .get(failed_attempt.checked_sub(1)? as usize)
+        .map(|secs| Duration::from_secs(*secs))
+}
+
+/// ERROR_SHARING_VIOLATION, "the process cannot access the file because it is
+/// being used by another process". Matched on the numeric code only: the
+/// sentence is localized (RUST-6Z arrived in Portuguese) and the code is not.
+/// The bracket after 32 keeps 320-329 out.
+fn pip_failure_is_sharing_violation(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains("winerror 32]") || lower.contains("os error 32)")
+}
+
 /// Widen `limit` for the rest of the run once `line` marks the start of pip's
 /// silent unpack phase. `None` (wait forever) stays `None`.
 fn widen_silence_for_unpack(limit: Option<Duration>, line: &str) -> Option<Duration> {
@@ -11612,11 +11687,10 @@ fn run_pip_install_with_retries_streaming<F>(
 where
     F: FnMut(&str),
 {
-    const MAX_ATTEMPTS: u32 = 3;
-    const BACKOFFS_SECS: &[u64] = &[2, 5];
-    let mut last_err: Option<anyhow::Error> = None;
-    for attempt in 1..=MAX_ATTEMPTS {
-        match run_command_streaming(
+    let mut attempt: u32 = 0;
+    loop {
+        attempt += 1;
+        let err = match run_command_streaming(
             python,
             args,
             cwd,
@@ -11624,68 +11698,49 @@ where
             &mut on_line,
         ) {
             Ok(()) => return Ok(()),
-            Err(err) => {
-                if attempt < MAX_ATTEMPTS {
-                    log::info!(
-                        "pip install attempt {}/{} failed (will retry): {}",
-                        attempt,
-                        MAX_ATTEMPTS,
-                        err
-                    );
-                } else {
-                    let compact = compact_pip_failure(&err);
-                    if crate::is_disk_full_signal(&compact)
-                        || crate::is_disk_full_signal(&format!("{err:#}"))
-                    {
-                        // ENOSPC is environmental and already surfaced + Sentry-
-                        // suppressed by the caller's runtime_upgrade_failed /
-                        // bootstrap_failed guard. Drop this per-attempt warn to
-                        // info so the log->Sentry bridge doesn't recapture it
-                        // (RUST-4C).
-                        log::info!(
-                            "pip install attempt {}/{} failed (final): disk full (ENOSPC)",
-                            attempt,
-                            MAX_ATTEMPTS
-                        );
-                    } else {
-                        // Explicit per-category fingerprint; the bridged warn is
-                        // local-only (skip_sentry rule) so this doesn't double-
-                        // report. See `pip_failure_category`.
-                        let category = pip_failure_category_with_evidence(
-                            &compact,
-                            &pip_failure_evidence(&err, &compact),
-                        );
-                        sentry::with_scope(
-                            |scope| {
-                                scope.set_fingerprint(Some(&["pip-install-failed", category]));
-                            },
-                            || {
-                                sentry::capture_message(
-                                    &format!(
-                                        "pip install failed after {MAX_ATTEMPTS} attempts \
-                                         [{category}]: {compact}"
-                                    ),
-                                    sentry::Level::Warning,
-                                );
-                            },
-                        );
-                        log::warn!(
-                            "pip install attempt {}/{} failed (final): {}",
-                            attempt,
-                            MAX_ATTEMPTS,
-                            compact
-                        );
-                    }
-                }
-                last_err = Some(err);
-                if attempt < MAX_ATTEMPTS {
-                    let idx = (attempt as usize - 1).min(BACKOFFS_SECS.len() - 1);
-                    std::thread::sleep(std::time::Duration::from_secs(BACKOFFS_SECS[idx]));
-                }
-            }
+            Err(err) => err,
+        };
+        let compact = compact_pip_failure(&err);
+        let evidence = pip_failure_evidence(&err, &compact);
+        // The schedule depends on WHAT failed, so classify before deciding
+        // whether this attempt was the last one (see `pip_retry_backoff`).
+        if let Some(backoff) = pip_retry_backoff(attempt, &evidence) {
+            log::info!(
+                "pip install attempt {attempt} failed (will retry in {}s): {err}",
+                backoff.as_secs()
+            );
+            std::thread::sleep(backoff);
+            continue;
         }
+        if crate::is_disk_full_signal(&compact) || crate::is_disk_full_signal(&format!("{err:#}")) {
+            // ENOSPC is environmental and already surfaced + Sentry-
+            // suppressed by the caller's runtime_upgrade_failed /
+            // bootstrap_failed guard. Drop this per-attempt warn to
+            // info so the log->Sentry bridge doesn't recapture it
+            // (RUST-4C).
+            log::info!("pip install attempt {attempt} failed (final): disk full (ENOSPC)");
+        } else {
+            // Explicit per-category fingerprint; the bridged warn is
+            // local-only (skip_sentry rule) so this doesn't double-
+            // report. See `pip_failure_category`.
+            let category = pip_failure_category_with_evidence(&compact, &evidence);
+            sentry::with_scope(
+                |scope| {
+                    scope.set_fingerprint(Some(&["pip-install-failed", category]));
+                },
+                || {
+                    sentry::capture_message(
+                        &format!(
+                            "pip install failed after {attempt} attempts [{category}]: {compact}"
+                        ),
+                        sentry::Level::Warning,
+                    );
+                },
+            );
+            log::warn!("pip install attempt {attempt} failed (final): {compact}");
+        }
+        return Err(err);
     }
-    Err(last_err.expect("at least one attempt was made"))
 }
 
 /// Like `run_command` but streams stdout + stderr line-by-line through
@@ -17739,6 +17794,37 @@ exit 0
         let compact = compact_pip_failure(&pip_failure(&stderr));
         assert!(compact.starts_with("exit=1; stderr tail: "));
         assert!(compact.contains("エラー"));
+    }
+
+    /// A sharing violation is antivirus holding a freshly written wheel; the
+    /// old 2s+5s schedule burned all its attempts before the scan finished
+    /// (RUST-6Z). Everything else keeps the original three attempts.
+    #[test]
+    fn pip_retry_backoff_gives_sharing_violations_more_room() {
+        use super::pip_retry_backoff as backoff;
+        let plain = "exit=1; stderr tail: ERROR: No matching distribution found";
+        assert_eq!(backoff(1, plain), Some(Duration::from_secs(2)));
+        assert_eq!(backoff(2, plain), Some(Duration::from_secs(5)));
+        assert_eq!(backoff(3, plain), None, "third failure is final");
+
+        // Localized stderr: only the code identifies it.
+        let locked = "ERROR: Could not install packages due to an OSError: [WinError 32] \
+                      O arquivo já está sendo usado por outro processo: 'C:\\x\\torch.dll'";
+        assert_eq!(backoff(3, locked), Some(Duration::from_secs(10)));
+        assert_eq!(backoff(5, locked), Some(Duration::from_secs(30)));
+        assert_eq!(backoff(6, locked), None);
+        // Rust-side io error shape.
+        assert!(super::pip_failure_is_sharing_violation(
+            "renaming x: (os error 32)"
+        ));
+        // 320-329 are different errors.
+        assert!(!super::pip_failure_is_sharing_violation(
+            "[WinError 3] path not found"
+        ));
+        assert!(!super::pip_failure_is_sharing_violation(
+            "[WinError 320] whatever"
+        ));
+        assert_eq!(backoff(0, locked), None, "attempt numbering starts at 1");
     }
 
     #[test]

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -1297,6 +1297,55 @@ def finalize_turn(
                 _hd_v_se.finalize_turn = _hd_v_finalize
     except Exception:
         pass
+    # Claude Code can replace a trailing system reminder on every turn. Keep
+    # its unchanged history attached to the cached tracker. This fallback only
+    # affects lineage selection, never wire messages or the #3380 replay body.
+    # Remove when the pinned wheel handles transient system tails itself.
+    try:
+        from importlib import metadata as _hd_ts_meta
+        if (_hd_ts_meta.version("headroom-ai") == "0.37.0" and
+            _hd_os.environ.get("HEADROOM_TRANSIENT_SYSTEM_LINEAGE", "1").strip().lower()
+                not in ("0", "false", "no", "off")):
+            import headroom.cache.prefix_tracker as _hd_ts_pt
+            _hd_ts_resolve = _hd_ts_pt.SessionTrackerStore.resolve_tracker
+            def _hd_ts_resolve_tracker(self, session_id, provider, messages=None,
+                                       cache_affinity=None):
+                if provider != "anthropic" or not messages or not self._default_config.enabled:
+                    return _hd_ts_resolve(self, session_id, provider, messages, cache_affinity)
+                self._maybe_cleanup()
+                snap = _hd_ts_pt._lineage_snapshot(
+                    _hd_ts_pt._canonicalize_for_prefix_compare(messages))
+                family = self._lineages.get(session_id, {})
+                candidates = []
+                for key, chain in family.items():
+                    if self._lineage_affinities.get(key) != cache_affinity:
+                        continue
+                    # Every existing match takes precedence, including ambiguous
+                    # block rewrites: let the wheel apply its own tie policy.
+                    if _hd_ts_pt._classify_history_canonical(snap, chain).kind != "diverged":
+                        return _hd_ts_resolve(self, session_id, provider, messages, cache_affinity)
+                    if (len(chain) > 1 and chain[-1].get("role") == "system"
+                        and any(m.get("role") in ("user", "assistant") for m in chain[:-1])
+                        and len(snap) >= len(chain) and snap[:len(chain) - 1] == chain[:-1]):
+                        candidates.append((len(chain), key))
+                candidates.sort(reverse=True)
+                if candidates and (len(candidates) == 1 or candidates[0][0] > candidates[1][0]):
+                    key = candidates[0][1]
+                    previous = family[key]
+                    trimmed = previous[:-1]
+                    # Synchronous resolver: expose only the proven prefix for
+                    # selection, then let the wheel store the FULL current snap.
+                    family[key] = trimmed
+                    try:
+                        return _hd_ts_resolve(self, session_id, provider, messages, cache_affinity)
+                    finally:
+                        if family.get(key) is trimmed:
+                            family[key] = previous
+                return _hd_ts_resolve(self, session_id, provider, messages, cache_affinity)
+            _hd_ts_pt.SessionTrackerStore.resolve_tracker = _hd_ts_resolve_tracker
+    except Exception:
+        pass
+
     # Prefix-replay guard (upstream issue #3379 / PR #3380; remove once a
     # wheel ships the fix -- see the module docstring for the cache-bust loop
     # this prevents). Restores v0.35.0's policy: that release has no size
@@ -12756,6 +12805,38 @@ mod tests {
         assert!(py.contains("_rewrite_delta"));
         // ...and the kill switch is honored.
         assert!(py.contains("HEADROOM_CONTEXT_GUARD"));
+    }
+
+    #[test]
+    fn transient_system_lineage_behaves_against_the_installed_wheel() {
+        let python =
+            ManagedRuntime::bootstrap_root(&crate::storage::app_data_dir()).managed_python();
+        if !python.exists() {
+            eprintln!("skipping: no managed runtime {}", python.display());
+            return;
+        }
+        let dir = std::env::temp_dir().join(format!("hd-transient-lineage-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp inject dir");
+        std::fs::write(dir.join("sitecustomize.py"), super::SITECUSTOMIZE_PY)
+            .expect("write sitecustomize");
+        let out = crate::proc::command(&python)
+            .arg(
+                std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                    .join("../scripts/reproduce-transient-system-cache.py"),
+            )
+            .arg("--sitecustomize")
+            .arg(dir.join("sitecustomize.py"))
+            .arg("--expect-fixed")
+            .env("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+            .output()
+            .expect("run transient-system lineage probe");
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(
+            out.status.success(),
+            "transient-system lineage regression\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
     }
 
     /// Behavioural check of the vendored #3380 prefix floor, against the REAL

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -1466,6 +1466,107 @@ def finalize_turn(
     except Exception:
         pass
 
+    # Responses compression fans one request out across many router/Kompress
+    # calls. The wheel resets its 20s budget per call, so a timed-out request
+    # keeps doing inference for minutes and quarantines unrelated requests.
+    # Share one cooperative budget across both executor hops. Finished work
+    # survives; unstarted content passes through byte-for-byte. No inference
+    # thread is killed, and the existing cache/replay policy is unchanged.
+    try:
+        from importlib import metadata as _hd_cb_meta
+        if (_hd_cb_meta.version("headroom-ai") == "0.37.0" and
+            _hd_os.environ.get("HEADROOM_RESPONSES_SHARED_BUDGET", "1").strip().lower()
+                not in ("0", "false", "no", "off")):
+            import contextvars as _hd_cb_context
+            import threading as _hd_cb_threading
+            import time as _hd_cb_time
+            from headroom.proxy import server as _hd_cb_server
+            from headroom.proxy.handlers import openai as _hd_cb_oa
+            from headroom.transforms import content_router as _hd_cb_router
+            from headroom.transforms import kompress_compressor as _hd_cb_kc
+            _hd_cb_budget = _hd_cb_context.ContextVar("desktop_responses_budget", default=None)
+            _hd_cb_responses = _hd_cb_oa.OpenAIHandlerMixin._compress_openai_responses_payload_in_executor
+            _hd_cb_executor = _hd_cb_server.HeadroomProxy._run_compression_in_executor
+            _hd_cb_units = _hd_cb_oa._openai_responses_unit_executor
+            _hd_cb_compress = _hd_cb_router.ContentRouter.compress
+            _hd_cb_units_lock = _hd_cb_threading.Lock()
+
+            async def _hd_cb_responses_bounded(self, payload, **kwargs):
+                seconds = _hd_cb_router._compression_deadline_seconds()
+                if seconds <= 0:
+                    return await _hd_cb_responses(self, payload, **kwargs)
+                # Leave time to finish the current non-preemptible inference,
+                # merge results and serialize before the outer timeout fires.
+                timeout = kwargs.get("timeout", _hd_cb_oa.COMPRESSION_TIMEOUT_SECONDS)
+                seconds = min(seconds, max(0.0, timeout * 0.75))
+                cancelled = _hd_cb_threading.Event()
+                token = _hd_cb_budget.set((_hd_cb_time.perf_counter() + seconds, cancelled))
+                try:
+                    return await _hd_cb_responses(self, payload, **kwargs)
+                finally:
+                    cancelled.set()
+                    _hd_cb_budget.reset(token)
+
+            async def _hd_cb_run_executor(self, fn, *, timeout):
+                if _hd_cb_budget.get() is None:
+                    return await _hd_cb_executor(self, fn, timeout=timeout)
+                context = _hd_cb_context.copy_context()
+                return await _hd_cb_executor(self, lambda: context.run(fn), timeout=timeout)
+
+            def _hd_cb_unit_executor():
+                executor = _hd_cb_units()
+                with _hd_cb_units_lock:
+                    if not getattr(executor, "_desktop_budget_context", False):
+                        submit = executor.submit
+                        def submit_with_context(fn, *args, **kwargs):
+                            context = _hd_cb_context.copy_context()
+                            return submit(context.run, fn, *args, **kwargs)
+                        executor.submit = submit_with_context
+                        executor._desktop_budget_context = True
+                return executor
+
+            def _hd_cb_expired(budget):
+                return budget and (budget[1].is_set() or _hd_cb_time.perf_counter() >= budget[0])
+
+            def _hd_cb_router_compress(self, content, *args, **kwargs):
+                if _hd_cb_expired(_hd_cb_budget.get()):
+                    return _hd_cb_router.RouterCompressionResult(
+                        compressed=content, original=content,
+                        strategy_used=_hd_cb_router.CompressionStrategy.PASSTHROUGH,
+                        routing_log=[])
+                return _hd_cb_compress(self, content, *args, **kwargs)
+
+            def _hd_cb_kompress_wrapper(original, batch=False):
+                def bounded(self, *args, **kwargs):
+                    content = args[0] if args else kwargs["contents" if batch else "content"]
+                    budget = _hd_cb_budget.get()
+                    if _hd_cb_expired(budget):
+                        if batch:
+                            return [self._passthrough(text, len(text.split())) for text in content]
+                        return self._passthrough(content, len(content.split()))
+                    if budget is not None:
+                        seconds = getattr(self, "_deadline_s", None)
+                        if seconds is None:
+                            seconds = _hd_cb_kc._request_deadline_seconds()
+                        if seconds > 0:
+                            # Feed the native chunk/acquire deadline, including
+                            # nested compress_batch -> compress calls. Never
+                            # extend an earlier deadline supplied by the caller.
+                            started = budget[0] - seconds
+                            previous = kwargs.get("_deadline_started_at")
+                            kwargs["_deadline_started_at"] = min(started, previous) if previous is not None else started
+                    return original(self, *args, **kwargs)
+                return bounded
+
+            _hd_cb_oa.OpenAIHandlerMixin._compress_openai_responses_payload_in_executor = _hd_cb_responses_bounded
+            _hd_cb_server.HeadroomProxy._run_compression_in_executor = _hd_cb_run_executor
+            _hd_cb_oa._openai_responses_unit_executor = _hd_cb_unit_executor
+            _hd_cb_router.ContentRouter.compress = _hd_cb_router_compress
+            _hd_cb_kc.KompressCompressor.compress = _hd_cb_kompress_wrapper(_hd_cb_kc.KompressCompressor.compress)
+            _hd_cb_kc.KompressCompressor.compress_batch = _hd_cb_kompress_wrapper(_hd_cb_kc.KompressCompressor.compress_batch, batch=True)
+    except Exception:
+        pass
+
     # Prefix-replay guard (upstream issue #3379 / PR #3380; remove once a
     # wheel ships the fix -- see the module docstring for the cache-bust loop
     # this prevents). Restores v0.35.0's policy: that release has no size
@@ -12987,6 +13088,41 @@ mod tests {
             assert!(
                 out.status.success(),
                 "cache-integrity regression (broken={broken})\n{}\n{}",
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn responses_shared_budget_behaves_against_the_installed_wheel() {
+        let python =
+            ManagedRuntime::bootstrap_root(&crate::storage::app_data_dir()).managed_python();
+        if !python.exists() {
+            eprintln!("skipping: no managed runtime {}", python.display());
+            return;
+        }
+        let dir = std::env::temp_dir().join(format!("hd-responses-budget-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp inject dir");
+        std::fs::write(dir.join("sitecustomize.py"), super::SITECUSTOMIZE_PY)
+            .expect("write sitecustomize");
+        for disabled in [false, true] {
+            let mut command = crate::proc::command(&python);
+            command
+                .arg(
+                    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                        .join("../scripts/verify-responses-budget.py"),
+                )
+                .arg("--sitecustomize")
+                .arg(dir.join("sitecustomize.py"));
+            if disabled {
+                command.arg("--disabled");
+            }
+            let out = command.output().expect("run Responses budget probe");
+            assert!(
+                out.status.success(),
+                "Responses budget regression (disabled={disabled})\n{}\n{}",
                 String::from_utf8_lossy(&out.stdout),
                 String::from_utf8_lossy(&out.stderr)
             );

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -1346,6 +1346,126 @@ def finalize_turn(
     except Exception:
         pass
 
+    # Observe confirmed prefix rewrites independently of the replay/lineage
+    # fixes. Only numeric diagnostics cross /stats to the desktop's Sentry SDK.
+    # No provider calls, disk writes, or request mutations in this observer.
+    try:
+        from importlib import metadata as _hd_ci_meta
+        if (_hd_ci_meta.version("headroom-ai") == "0.37.0" and
+            _hd_os.environ.get("HEADROOM_CACHE_INTEGRITY", "1").strip().lower()
+                not in ("0", "false", "no", "off")):
+            import contextvars as _hd_ci_cv
+            import time as _hd_ci_time
+            import uuid as _hd_ci_uuid
+            import sys as _hd_ci_sys
+            from headroom.cache import prefix_tracker as _hd_ci_pt
+            from headroom.proxy import cost as _hd_ci_cost
+            _hd_ci_pending = _hd_ci_cv.ContextVar("desktop_cache_integrity", default=None)
+            _hd_ci_stats = {"boot_id": _hd_ci_uuid.uuid4().hex, "count": 0}
+            _hd_ci_resolve = _hd_ci_pt.SessionTrackerStore.resolve_tracker
+            _hd_ci_update = _hd_ci_pt.PrefixCacheTracker.update_from_response
+            _hd_ci_build_stats = _hd_ci_cost.build_prefix_cache_stats
+
+            def _hd_ci_resolve_tracker(self, session_id, provider, messages=None, cache_affinity=None):
+                _hd_ci_pending.set(None)
+                tracker = _hd_ci_resolve(self, session_id, provider, messages, cache_affinity)
+                try:
+                    if provider != "anthropic" or not messages or not self._default_config.enabled:
+                        return tracker
+                    prior = tracker
+                    if not prior.get_frozen_message_count():
+                        # A lost tracker has no history to check. Recover evidence
+                        # ONLY for the proven disappearing-system-tail shape;
+                        # arbitrary sibling branches must not raise an alarm.
+                        snap = _hd_ci_pt._lineage_snapshot(
+                            _hd_ci_pt._canonicalize_for_prefix_compare(messages))
+                        candidates = []
+                        for key, chain in self._lineages.get(session_id, {}).items():
+                            candidate = self.peek(key)
+                            if (candidate is None or candidate is tracker
+                                or self._lineage_affinities.get(key) != cache_affinity
+                                or not candidate.get_frozen_message_count()):
+                                continue
+                            if (len(chain) > 1 and chain[-1].get("role") == "system"
+                                and any(m.get("role") in ("user", "assistant") for m in chain[:-1])
+                                and len(snap) >= len(chain) and snap[:len(chain)-1] == chain[:-1]):
+                                candidates.append((len(chain), key, candidate))
+                        candidates.sort(key=lambda x: x[0], reverse=True)
+                        if not candidates or (len(candidates) > 1 and candidates[0][0] == candidates[1][0]):
+                            return tracker
+                        prior = candidates[0][2]
+                    idle = (prior._idle_seconds_at_fetch if prior is tracker
+                            else prior.seconds_since_activity())
+                    ttl = prior.resolved_cache_ttl_seconds()
+                    if idle >= ttl or not prior.get_frozen_message_count():
+                        return tracker
+                    original = prior._last_original_messages
+                    frozen = prior.get_frozen_message_count()
+                    # The handler appends the assistant RESPONSE to tracker
+                    # history. Those bytes were never in the previous request;
+                    # an estimated floor can overshoot into this fresh message.
+                    if original and original[-1].get("role") == "assistant":
+                        frozen = min(frozen, len(original) - 1)
+                    # Tracker updates replace these lists instead of mutating
+                    # them. Hold references for this request, not another copy
+                    # of a potentially million-token conversation.
+                    _hd_ci_pending.set((tracker, original,
+                        prior._last_forwarded_messages, frozen,
+                        prior._cached_token_count, _hd_ci_time.monotonic() + ttl - idle,
+                        prior is not tracker))
+                except Exception:
+                    pass
+                return tracker
+
+            def _hd_ci_update_tracker(self, cache_read_tokens, cache_write_tokens, messages,
+                                      message_token_counts=None, original_messages=None):
+                evidence = _hd_ci_pending.get()
+                _hd_ci_pending.set(None)
+                try:
+                    if (evidence is not None and evidence[0] is self
+                        and original_messages and cache_write_tokens > 0
+                        and cache_read_tokens < evidence[4]
+                        and _hd_ci_time.monotonic() < evidence[5]):
+                        _, old_original, old_forwarded, frozen, expected, _, reset = evidence
+                        stable = 0
+                        first_changed = None
+                        canon = _hd_ci_pt._canonicalize_for_prefix_compare
+                        for i in range(min(frozen, len(old_original), len(old_forwarded),
+                                           len(original_messages), len(messages))):
+                            if canon([old_original[i]]) != canon([original_messages[i]]):
+                                break
+                            stable += 1
+                            if first_changed is None and canon([old_forwarded[i]]) != canon([messages[i]]):
+                                first_changed = i
+                        if first_changed is not None:
+                            _hd_ci_stats.update(count=_hd_ci_stats["count"] + 1,
+                                kind="tracker_reset" if reset else "prefix_rewrite",
+                                stable_messages=stable, first_changed_message=first_changed,
+                                previously_cached_tokens=expected,
+                                cache_read_tokens=cache_read_tokens,
+                                cache_write_tokens=cache_write_tokens)
+                except Exception:
+                    pass
+                return _hd_ci_update(self, cache_read_tokens, cache_write_tokens, messages,
+                                     message_token_counts, original_messages)
+
+            def _hd_ci_prefix_stats(*args, **kwargs):
+                result = _hd_ci_build_stats(*args, **kwargs)
+                result["desktop_integrity"] = dict(_hd_ci_stats)
+                return result
+
+            _hd_ci_pt.SessionTrackerStore.resolve_tracker = _hd_ci_resolve_tracker
+            _hd_ci_pt.PrefixCacheTracker.update_from_response = _hd_ci_update_tracker
+            _hd_ci_cost.build_prefix_cache_stats = _hd_ci_prefix_stats
+            # Usually server imports cost after sitecustomize; cover an already
+            # loaded server too without importing it just for instrumentation.
+            _hd_ci_server = _hd_ci_sys.modules.get("headroom.proxy.server")
+            if _hd_ci_server is not None:
+                _hd_ci_server.build_prefix_cache_stats = _hd_ci_prefix_stats
+                _hd_ci_server._build_prefix_cache_stats = _hd_ci_prefix_stats
+    except Exception:
+        pass
+
     # Prefix-replay guard (upstream issue #3379 / PR #3380; remove once a
     # wheel ships the fix -- see the module docstring for the cache-bust loop
     # this prevents). Restores v0.35.0's policy: that release has no size
@@ -12837,6 +12957,41 @@ mod tests {
             String::from_utf8_lossy(&out.stdout),
             String::from_utf8_lossy(&out.stderr)
         );
+    }
+
+    #[test]
+    fn cache_integrity_observer_behaves_against_the_installed_wheel() {
+        let python =
+            ManagedRuntime::bootstrap_root(&crate::storage::app_data_dir()).managed_python();
+        if !python.exists() {
+            eprintln!("skipping: no managed runtime {}", python.display());
+            return;
+        }
+        let dir = std::env::temp_dir().join(format!("hd-cache-integrity-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp inject dir");
+        std::fs::write(dir.join("sitecustomize.py"), super::SITECUSTOMIZE_PY)
+            .expect("write sitecustomize");
+        for broken in [false, true] {
+            let mut command = crate::proc::command(&python);
+            command
+                .arg(
+                    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                        .join("../scripts/verify-cache-integrity.py"),
+                )
+                .arg("--sitecustomize")
+                .arg(dir.join("sitecustomize.py"));
+            if broken {
+                command.arg("--broken-lineage");
+            }
+            let out = command.output().expect("run cache-integrity probe");
+            assert!(
+                out.status.success(),
+                "cache-integrity regression (broken={broken})\n{}\n{}",
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// Behavioural check of the vendored #3380 prefix floor, against the REAL

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -1518,6 +1518,25 @@ def finalize_turn(
 # first-appearance counting coherently. Newly-matured and fresh-tail savings
 # are untouched; matured content books exactly once, on the turn it matures.
 #
+# TWO paths re-remove an already-booked Read, and the second is the one that
+# actually runs in production (verified 2026-09-07 by driving a 5-turn session
+# through the real Anthropic handler and reading x-headroom-tokens-saved:
+# [0, 0, 11863, 11863, 11863], turns 3 and 4 re-booking with
+# transforms=router:noop):
+#   * _handle_read swaps the raw content out itself - only when the cached
+#     prefix did not already cover the Read;
+#   * the marker is ALREADY in _handle_read's input, put there by the
+#     cached-prefix replay before maturation ran. _handle_read returns None
+#     and the ORIGINAL vendor accrued nothing here, which is why watching its
+#     replay branch alone left this whole section inert from the turn after
+#     maturation onward.
+# The second path is detected on the apply() seam instead of _handle_read's,
+# because a matured Read eventually falls inside frozen_message_count and
+# apply() skips those messages without ever calling _handle_read for them -
+# the scan below reads the request's full message list, frozen region
+# included. A marker in that input is always Headroom's own re-removal: the
+# client's transcript holds what IT sent (raw), never what we forwarded.
+#
 # Bridge: a lock-guarded module-global pending counter, drained (clamped at
 # the request's own tokens_saved) by the next record_request. Deliberately
 # NOT task/context-scoped: the transform may run on a different task or
@@ -1574,30 +1593,87 @@ if _hd_fa_flag.strip().lower() not in ("", "0", "false", "no", "off"):
                     return max(1, len(text) // 4)
 
             _hd_fa_orig_handle = _hd_fa_rm.ReadMaturationManager._handle_read
+            _hd_fa_orig_apply = _hd_fa_rm.ReadMaturationManager.apply
             _hd_fa_orig_record = _hd_fa_pm.PrometheusMetrics.record_request
+
+            def _hd_fa_delta(tc_id, content, marker):
+                delta = _hd_fa_deltas.get(tc_id)
+                if delta is None:
+                    if len(_hd_fa_deltas) >= 4096:
+                        _hd_fa_deltas.clear()
+                    delta = max(0, _hd_fa_count(content) - _hd_fa_count(marker))
+                    _hd_fa_deltas[tc_id] = delta
+                return delta
+
+            def _hd_fa_tool_results(messages):
+                # (tool_call_id, content) for every string tool result, in both
+                # the Anthropic block and OpenAI role="tool" shapes.
+                for msg in messages or ():
+                    if not isinstance(msg, dict):
+                        continue
+                    content = msg.get("content")
+                    if msg.get("role") == "tool":
+                        if isinstance(content, str):
+                            yield str(msg.get("tool_call_id", "")), content
+                        continue
+                    if isinstance(content, list):
+                        for block in content:
+                            if (
+                                isinstance(block, dict)
+                                and block.get("type") == "tool_result"
+                                and isinstance(block.get("content"), str)
+                            ):
+                                yield str(block.get("tool_use_id", "")), block["content"]
+
+            def _hd_fa_accrue(delta):
+                if delta > 0:
+                    with _hd_fa_lock:
+                        _hd_fa_pending[0] += delta
 
             def _hd_fa_handle(self, tc_id, content, activity, result):
                 matured_before = self._matured.get(tc_id)
                 out = _hd_fa_orig_handle(self, tc_id, content, activity, result)
                 try:
-                    # Replay branch only: matured on an EARLIER request and
-                    # replaced again now. Newly-matured stays fully booked.
-                    if matured_before is not None and out[0] is not None:
-                        delta = _hd_fa_deltas.get(tc_id)
-                        if delta is None:
-                            if len(_hd_fa_deltas) >= 4096:
-                                _hd_fa_deltas.clear()
-                            delta = max(
-                                0,
-                                _hd_fa_count(content)
-                                - _hd_fa_count(matured_before.marker),
-                            )
-                            _hd_fa_deltas[tc_id] = delta
-                        if delta > 0:
-                            with _hd_fa_lock:
-                                _hd_fa_pending[0] += delta
+                    if matured_before is None:
+                        # This request matured the Read, so it books the
+                        # removal in full. Learn the token delta here: it is
+                        # the last time the raw content is in hand, and the
+                        # apply() scan below only ever sees the marker.
+                        matured = self._matured.get(tc_id)
+                        if matured is not None and out[0] is not None:
+                            _hd_fa_delta(tc_id, content, matured.marker)
+                    elif out[0] is not None:
+                        # Matured earlier and swapped out by THIS pass (the
+                        # cached prefix did not cover it): already booked.
+                        _hd_fa_accrue(
+                            _hd_fa_delta(tc_id, content, matured_before.marker)
+                        )
                 except Exception:
                     # Accounting-only: never let bookkeeping break a request.
+                    pass
+                return out
+
+            def _hd_fa_apply(self, messages, *args, **kwargs):
+                # Markers already present on the way IN were put there by the
+                # cached-prefix replay, so their removal was booked on an
+                # earlier request. Snapshot _matured first: a Read maturing on
+                # THIS request must not be charged for its own first
+                # appearance. Reads the full list, frozen region included.
+                known = dict(self._matured) if self._matured else None
+                out = _hd_fa_orig_apply(self, messages, *args, **kwargs)
+                try:
+                    if known:
+                        debt = 0
+                        for tc_id, content in _hd_fa_tool_results(messages):
+                            matured = known.get(tc_id)
+                            if matured is not None and content == matured.marker:
+                                # 0 when the delta was never learned in this
+                                # process (proxy restart, cache cleared): the
+                                # books then stay as upstream writes them
+                                # rather than guessing a share.
+                                debt += _hd_fa_deltas.get(tc_id, 0)
+                        _hd_fa_accrue(debt)
+                except Exception:
                     pass
                 return out
 
@@ -1620,6 +1696,7 @@ if _hd_fa_flag.strip().lower() not in ("", "0", "false", "no", "off"):
                 return await _hd_fa_orig_record(self, *args, **kwargs)
 
             _hd_fa_rm.ReadMaturationManager._handle_read = _hd_fa_handle
+            _hd_fa_rm.ReadMaturationManager.apply = _hd_fa_apply
             _hd_fa_pm.PrometheusMetrics.record_request = _hd_fa_record
     except Exception:
         # Accounting-only vendor: any binding failure leaves the books

--- a/src-tauri/src/wsl_probe.rs
+++ b/src-tauri/src/wsl_probe.rs
@@ -1,0 +1,172 @@
+//! Windows-only: is there a coding agent living inside WSL on this machine?
+//!
+//! Why this exists. 36% of Windows installs have no detectable agent and
+//! save at 15%, against 13% of macOS installs. A Claude Code or Codex that
+//! runs inside a WSL distro reads a Linux home; every Windows-side write the
+//! setup makes (`%USERPROFILE%\.claude\settings.json`, `.codex\config.toml`)
+//! is invisible to it, and Windows-side detection sees nothing in return. If
+//! that is what the agent-less bucket is, it is fixable; if not, no code fixes
+//! it. Nobody knows which, so this measures it: one probe per app run, its
+//! verdict rides along on the identity payload as `wslAgents`.
+//!
+//! Verdicts: `absent` (no wsl.exe, or no user distro), `no_agent`, a comma
+//! list of `claude` / `codex` whose home directory exists in the distro,
+//! `timeout` (a distro that would not boot inside the budget), `error`.
+//!
+//! Deliberately a measurement, not a router: it never writes into the distro.
+
+use std::sync::OnceLock;
+
+static RESULT: OnceLock<String> = OnceLock::new();
+
+/// The verdict, once the background probe has one. `None` until then and on
+/// every non-Windows platform, so the payload field is simply omitted.
+pub fn result() -> Option<String> {
+    RESULT.get().cloned()
+}
+
+/// Kick off the probe on a background thread. Booting a distro can take
+/// seconds, and this runs at app start next to the other warmers.
+pub fn spawn_probe() {
+    #[cfg(windows)]
+    std::thread::spawn(|| {
+        let verdict = probe();
+        log::info!("wsl probe: {verdict}");
+        let _ = RESULT.set(verdict);
+    });
+}
+
+/// Sub-verdict from the check script's stdout: one line per agent home that
+/// exists in the distro.
+fn classify_check_output(stdout: &str) -> String {
+    let mut found: Vec<&str> = Vec::new();
+    for line in stdout.lines().map(str::trim) {
+        match line {
+            ".claude" => found.push("claude"),
+            ".codex" => found.push("codex"),
+            _ => {}
+        }
+    }
+    if found.is_empty() {
+        "no_agent".to_string()
+    } else {
+        found.join(",")
+    }
+}
+
+/// User distros from `wsl --list --quiet`. Docker Desktop registers two
+/// distros of its own that no human codes in; with only those present the
+/// machine has no WSL to speak of, and probing docker-desktop's busybox
+/// would report a confident `no_agent` for the wrong reason.
+fn user_distros(list_stdout: &str) -> Vec<String> {
+    list_stdout
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with("docker-desktop"))
+        .map(str::to_string)
+        .collect()
+}
+
+/// `wsl.exe` itself prints UTF-16LE (with a BOM), while anything the distro's
+/// shell prints comes back UTF-8. Sniff the NUL pattern rather than trusting
+/// either: the two are mixed across the two calls this module makes.
+fn decode_wsl_output(bytes: &[u8]) -> String {
+    let looks_utf16 =
+        bytes.len() >= 2 && (bytes.starts_with(&[0xFF, 0xFE]) || (bytes[1] == 0 && bytes[0] != 0));
+    if looks_utf16 {
+        let units: Vec<u16> = bytes
+            .chunks_exact(2)
+            .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+            .collect();
+        String::from_utf16_lossy(&units)
+            .trim_start_matches('\u{feff}')
+            .to_string()
+    } else {
+        String::from_utf8_lossy(bytes).into_owned()
+    }
+}
+
+#[cfg(windows)]
+fn probe() -> String {
+    use crate::proc::{command, output_with_timeout, OutputError};
+    use std::time::Duration;
+
+    let listed = match output_with_timeout(
+        {
+            let mut c = command("wsl.exe");
+            c.args(["--list", "--quiet"]);
+            c
+        },
+        Duration::from_secs(15),
+    ) {
+        Ok(out) if out.status.success() => decode_wsl_output(&out.stdout),
+        // No wsl.exe, WSL feature off, or "no installed distributions"
+        // (which wsl reports as a failure): all "absent" for our purposes.
+        Ok(_) | Err(OutputError::Spawn(_)) => return "absent".to_string(),
+        Err(OutputError::TimedOut) => return "timeout".to_string(),
+    };
+    let Some(distro) = user_distros(&listed).into_iter().next() else {
+        return "absent".to_string();
+    };
+    // `-e` runs the command without the distro's login shell, so a slow or
+    // broken profile cannot eat the budget. No double quotes inside the
+    // script: they would have to survive both the Windows argv quoting and
+    // wsl's own re-parse.
+    const CHECK: &str = "for d in .claude .codex; do [ -e $HOME/$d ] && echo $d; done; exit 0";
+    match output_with_timeout(
+        {
+            let mut c = command("wsl.exe");
+            c.args(["-d", &distro, "-e", "sh", "-c", CHECK]);
+            c
+        },
+        Duration::from_secs(30),
+    ) {
+        Ok(out) if out.status.success() => classify_check_output(&decode_wsl_output(&out.stdout)),
+        Ok(_) | Err(OutputError::Spawn(_)) => "error".to_string(),
+        Err(OutputError::TimedOut) => "timeout".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify_check_output, decode_wsl_output, user_distros};
+
+    #[test]
+    fn check_output_names_the_agents_it_finds() {
+        assert_eq!(classify_check_output(""), "no_agent");
+        assert_eq!(classify_check_output(".claude\n"), "claude");
+        assert_eq!(classify_check_output(".claude\n.codex\n"), "claude,codex");
+        assert_eq!(classify_check_output("  .codex  \n"), "codex");
+        // Anything else the shell might print is not an agent.
+        assert_eq!(
+            classify_check_output("bash: warning: setlocale\n"),
+            "no_agent"
+        );
+    }
+
+    /// wsl.exe prints UTF-16LE with a BOM; the distro's sh prints UTF-8. Both
+    /// pass through the same decoder.
+    #[test]
+    fn decodes_utf16_from_wsl_and_utf8_from_the_distro() {
+        let mut utf16 = vec![0xFF, 0xFE];
+        for unit in "Ubuntu\r\n".encode_utf16() {
+            utf16.extend_from_slice(&unit.to_le_bytes());
+        }
+        assert_eq!(decode_wsl_output(&utf16), "Ubuntu\r\n");
+        // Without BOM, the NUL-after-first-byte pattern still identifies it.
+        assert_eq!(decode_wsl_output(&utf16[2..]), "Ubuntu\r\n");
+        assert_eq!(decode_wsl_output(b".claude\n"), ".claude\n");
+        assert_eq!(decode_wsl_output(b""), "");
+    }
+
+    /// Docker Desktop's distros do not count as "the user has WSL".
+    #[test]
+    fn docker_desktop_distros_do_not_count() {
+        assert!(user_distros("docker-desktop\r\ndocker-desktop-data\r\n").is_empty());
+        assert_eq!(
+            user_distros("Ubuntu-22.04\r\ndocker-desktop\r\n"),
+            vec!["Ubuntu-22.04".to_string()]
+        );
+        assert!(user_distros("").is_empty());
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.10-rc.3",
+  "version": "0.9.11-rc.1",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.11-rc.3",
+  "version": "0.9.11-rc.4",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.11-rc.4",
+  "version": "0.9.11-rc.5",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.11-rc.5",
+  "version": "0.9.11",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.11-rc.2",
+  "version": "0.9.11-rc.3",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.11-rc.1",
+  "version": "0.9.11-rc.2",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6192,6 +6192,21 @@ export default function App() {
     runtimeIssues.push("Kompress disabled");
   }
 
+  // A startup hint is prose: "what is wrong. What to do." The headline
+  // carries its first sentence and the rest renders underneath it. Short
+  // issue fragments ("proxy unreachable") have no sentence break and stay
+  // inline, joined as before.
+  const splitIssue = (issue: string): { lead: string; detail: string } => {
+    const cut = issue.search(/[.!?] (?=[A-Z])/);
+    return cut === -1
+      ? { lead: issue, detail: "" }
+      : { lead: issue.slice(0, cut + 1), detail: issue.slice(cut + 2) };
+  };
+  const endSentence = (text: string): string => (/[.!?]$/.test(text) ? text : `${text}.`);
+  const primaryIssue = runtimeIssues.length > 0 ? splitIssue(runtimeIssues[0]) : null;
+  const runtimeIssueDetail = primaryIssue?.detail ?? "";
+  const issueSummary = primaryIssue?.detail ? primaryIssue.lead : runtimeIssues.join(", ");
+
   const runtimeHealthy = Boolean(
     runtimeStatus &&
       runtimeStatus.running &&
@@ -6304,27 +6319,20 @@ export default function App() {
       tone: disconnected ? "disconnected" : "degraded",
       title: disconnected
         ? runtimeIssues.length > 0
-          ? `Headroom is not hooked up right now: ${runtimeIssues.join(", ")}.`
+          ? endSentence(`Headroom is not hooked up right now: ${issueSummary}`)
           : "Headroom is not hooked up right now."
         : runtimeIssues.length > 0
-          ? `Headroom needs attention: ${runtimeIssues.join(", ")}.`
+          ? endSentence(`Headroom needs attention: ${issueSummary}`)
           : "Headroom is running, but something needs attention."
     } as const;
   })();
 
   const calloutTitle =
-    calloutBanner.title.length <= 110
+    calloutBanner.title.length <= 110 || !primaryIssue
       ? calloutBanner.title
-      : (() => {
-          const primaryIssue = runtimeIssues[0];
-          if (!primaryIssue) {
-            return calloutBanner.title;
-          }
-          if (calloutBanner.tone === "disconnected") {
-            return `Headroom is not hooked up right now: ${primaryIssue}.`;
-          }
-          return `Headroom needs attention: ${primaryIssue}.`;
-        })();
+      : endSentence(
+          `${calloutBanner.tone === "disconnected" ? "Headroom is not hooked up right now" : "Headroom needs attention"}: ${primaryIssue.lead}`
+        );
   const tierMismatch = pricingStatus?.tierMismatch ?? null;
   // Products the clamp actually limits (per-product scope). Falls back to the
   // recommendation source for payloads cached by builds without the flags.
@@ -6795,6 +6803,9 @@ export default function App() {
               <span className={`callout-banner__dot callout-banner__dot--${calloutBanner.tone}`} aria-hidden="true" />
               <div className="callout-banner__body">
                 <h1>{calloutTitle}</h1>
+                {runtimeIssueDetail && (calloutBanner.tone === "disconnected" || calloutBanner.tone === "degraded") ? (
+                  <p className="callout-banner__subtitle">{runtimeIssueDetail}</p>
+                ) : null}
                 {platformPreviewNotice ? (
                   <p className="callout-banner__subtitle">
                     {platformPreviewNotice} Please report any issues to{" "}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2480,7 +2480,7 @@ export default function App() {
                 : startupError
                 ? { text: `Headroom could not finish starting: ${startupError}`, tone: "error" }
                 : {
-                    text: "Finishing setup - first launch downloads models and can take a minute.",
+                    text: "Finishing setup - first launch downloads models and can take a minute. Wait for this message to clear before sending your test message, or the test will not register.",
                     tone: "info"
                   }
             );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6954,7 +6954,14 @@ export default function App() {
                 resetSignal={chartResetSignal}
                 chartMode={chartMode}
                 setChartMode={setChartMode}
-                outputReduction={dashboard.outputReduction}
+                // Withheld when the estimate covers too thin a slice of this
+                // machine's traffic to be its headline. The per-window chip is
+                // a different lineage (sampled buckets) and stands either way.
+                outputReduction={
+                  dashboard.outputReduction?.publishable === false
+                    ? null
+                    : dashboard.outputReduction
+                }
               />
             ) : (
               <div className="savings-chart__skeleton" role="status">

--- a/src/lib/launcherHelpers.test.ts
+++ b/src/lib/launcherHelpers.test.ts
@@ -283,7 +283,10 @@ describe("launcher helpers", () => {
       // ChatGPT Pro Lite is ~$100/mo, the Claude Max x5 price point.
       expect(recommendedHeadroomTier(null, "prolite")).toBe("max5x");
       expect(recommendedHeadroomTier(null, "self_serve_business_usage_based")).toBe("max5x");
+      expect(recommendedHeadroomTier(null, "self_serve_business_prolite")).toBe("max5x");
       expect(recommendedHeadroomTier(null, "edu")).toBe("max5x");
+      // OpenAI mints both spellings of the ChatGPT Edu claim.
+      expect(recommendedHeadroomTier(null, "education")).toBe("max5x");
       expect(recommendedHeadroomTier(null, "pro")).toBe("max20x");
       expect(recommendedHeadroomTier(null, "enterprise")).toBe("max20x");
       expect(recommendedHeadroomTier(null, "enterprise_cbp_usage_based")).toBe("max20x");

--- a/src/lib/launcherHelpers.test.ts
+++ b/src/lib/launcherHelpers.test.ts
@@ -36,6 +36,7 @@ describe("install-wizard funnel steps", () => {
       "bootstrap_failed",
       "post_install_shown",
       "unrouted_usage_detected",
+      "unrouted_codex_usage_detected",
       "first_optimized_request",
       "first_prompt_request",
       "first_savings_recorded"

--- a/src/lib/launcherHelpers.ts
+++ b/src/lib/launcherHelpers.ts
@@ -40,6 +40,7 @@ export const INSTALL_WIZARD_STEPS = [
   "bootstrap_failed",
   "post_install_shown",
   "unrouted_usage_detected",
+  "unrouted_codex_usage_detected",
   "first_optimized_request",
   "first_prompt_request",
   "first_savings_recorded"

--- a/src/lib/launcherHelpers.ts
+++ b/src/lib/launcherHelpers.ts
@@ -98,7 +98,9 @@ export function recommendedHeadroomTier(
       ? "pro"
     : codexTier === "prolite" ||
         codexTier === "self_serve_business_usage_based" ||
-        codexTier === "edu"
+        codexTier === "self_serve_business_prolite" ||
+        codexTier === "edu" ||
+        codexTier === "education"
       ? "max5x"
     : codexTier === "pro" ||
         codexTier === "enterprise" ||

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -111,6 +111,12 @@ export interface OutputReduction {
   ciLowPercent: number;
   ciHighPercent: number;
   requests: number;
+  // `requests` as a share of every shaped request, and whether that share is
+  // thick enough for the percentage to describe the machine rather than a
+  // corner of it. Rust owns the threshold (output_savings.rs); the UI only
+  // obeys the verdict. Optional: older payloads predate both.
+  coveragePercent?: number | null;
+  publishable?: boolean;
 }
 
 // Lifetime savings decomposition behind the headline card. cacheSavingsUsd is

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -558,9 +558,11 @@ export type CodexPlanTier =
   | "team"
   | "business"
   | "self_serve_business_usage_based"
+  | "self_serve_business_prolite"
   | "enterprise"
   | "enterprise_cbp_usage_based"
   | "edu"
+  | "education"
   | "unknown";
 
 // Mirrors `LaunchFlags` in lib.rs; served cached-or-default, never blocking.


### PR DESCRIPTION
Stable 0.9.11 from staging 6b702fa (0.9.11-rc.5). Download-only: the release commit carries `[publish: download-only]`, so v0.9.11 stays a prerelease, `releases/latest` keeps 0.9.10, and no existing install is offered it. New downloads reach it via `HEADROOM_DOWNLOAD_TAG=v0.9.11` on the headroom-web Railway `web` service.

Promote later without a rebuild once the compression-path changes (rc.3/rc.4 cache vendors, maturation vendor fix) have had their staging soak and `savings:did` run: `gh release edit v0.9.11 --prerelease=false --latest`, then delete the download tag and redeploy `web`.

Supersedes closed PR #93 (the main-plus-one-commit hotfix cut).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
