### PR TITLE
0.9.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.15-rc.10",
+  "version": "0.9.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.15-rc.10",
+      "version": "0.9.15",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.14",
+  "version": "0.9.15-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.14",
+      "version": "0.9.15-rc.1",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.15-rc.6",
+  "version": "0.9.15-rc.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.15-rc.6",
+      "version": "0.9.15-rc.7",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.15-rc.9",
+  "version": "0.9.15-rc.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.15-rc.9",
+      "version": "0.9.15-rc.10",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.15-rc.7",
+  "version": "0.9.15-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.15-rc.7",
+      "version": "0.9.15-rc.8",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.15-rc.5",
+  "version": "0.9.15-rc.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.15-rc.5",
+      "version": "0.9.15-rc.6",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.15-rc.2",
+  "version": "0.9.15-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.15-rc.2",
+      "version": "0.9.15-rc.3",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.15-rc.1",
+  "version": "0.9.15-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.15-rc.1",
+      "version": "0.9.15-rc.2",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.15-rc.3",
+  "version": "0.9.15-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.15-rc.3",
+      "version": "0.9.15-rc.4",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.15-rc.4",
+  "version": "0.9.15-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.15-rc.4",
+      "version": "0.9.15-rc.5",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.15-rc.8",
+  "version": "0.9.15-rc.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom-desktop",
-      "version": "0.9.15-rc.8",
+      "version": "0.9.15-rc.9",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.47.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.15-rc.5",
+  "version": "0.9.15-rc.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.15-rc.9",
+  "version": "0.9.15-rc.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.15-rc.7",
+  "version": "0.9.15-rc.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.15-rc.6",
+  "version": "0.9.15-rc.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.15-rc.1",
+  "version": "0.9.15-rc.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.15-rc.2",
+  "version": "0.9.15-rc.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.14",
+  "version": "0.9.15-rc.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.15-rc.3",
+  "version": "0.9.15-rc.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.15-rc.4",
+  "version": "0.9.15-rc.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.15-rc.8",
+  "version": "0.9.15-rc.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-desktop",
-  "version": "0.9.15-rc.10",
+  "version": "0.9.15",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.15-rc.2"
+version = "0.9.15-rc.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.15-rc.9"
+version = "0.9.15-rc.10"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.15-rc.8"
+version = "0.9.15-rc.9"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.15-rc.5"
+version = "0.9.15-rc.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.15-rc.6"
+version = "0.9.15-rc.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.15-rc.10"
+version = "0.9.15"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.15-rc.1"
+version = "0.9.15-rc.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.15-rc.7"
+version = "0.9.15-rc.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.14"
+version = "0.9.15-rc.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "headroom-desktop"
-version = "0.9.15-rc.3"
+version = "0.9.15-rc.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.15-rc.4"
+version = "0.9.15-rc.5"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.15-rc.10"
+version = "0.9.15"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.15-rc.1"
+version = "0.9.15-rc.2"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.15-rc.8"
+version = "0.9.15-rc.9"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.15-rc.9"
+version = "0.9.15-rc.10"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.15-rc.3"
+version = "0.9.15-rc.4"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.15-rc.2"
+version = "0.9.15-rc.3"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.14"
+version = "0.9.15-rc.1"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.15-rc.7"
+version = "0.9.15-rc.8"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.15-rc.6"
+version = "0.9.15-rc.7"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headroom-desktop"
-version = "0.9.15-rc.5"
+version = "0.9.15-rc.6"
 description = "Headroom v1 local-first LLM optimization tray app"
 authors = ["Codex"]
 license = "MIT"

--- a/src-tauri/src/analytics.rs
+++ b/src-tauri/src/analytics.rs
@@ -329,6 +329,7 @@ fn build_http_client(config: &AnalyticsConfig) -> Client {
     headers.insert("App-Key", app_key_header);
     headers.insert("Content-Type", HeaderValue::from_static("application/json"));
 
+    // proxy-ok: analytics ingest is a public endpoint; a corporate proxy must be honored
     Client::builder()
         .timeout(Duration::from_secs(HTTP_REQUEST_TIMEOUT_SECS))
         .default_headers(headers)

--- a/src-tauri/src/client_adapters.rs
+++ b/src-tauri/src/client_adapters.rs
@@ -3501,7 +3501,8 @@ fn retag_codex_thread_providers(from: &str, to: &str) {
 /// The environmental causes stay dropped (a DB the user's disk corrupted is
 /// not ours to fix, RUST-95/96), but a real one anywhere in the pass still
 /// reports: a lock outliving `busy_timeout` is how we would learn that
-/// assumption went stale.
+/// assumption went stale. Capped at one event per class per session by
+/// `claim_retag_skip_report_slot`.
 fn codex_retag_skip_class(reasons: &[String]) -> Option<&'static str> {
     reasons.iter().find_map(|reason| {
         let lower = reason.to_ascii_lowercase();
@@ -3515,10 +3516,31 @@ fn codex_retag_skip_class(reasons: &[String]) -> Option<&'static str> {
     })
 }
 
+/// Skip classes already reported this session, so the event stays a HOST
+/// count. A retag pass runs on every app launch and every quit, and
+/// `busy_timeout` is 750ms -- which a Codex actively writing its own store
+/// blows past routinely. Without this the one condition files a Warning per
+/// launch, forever, on every user who keeps Codex open. Same shape as
+/// `claim_transient_report_slot` in pricing.rs.
+static RETAG_SKIP_REPORTED: std::sync::Mutex<std::collections::BTreeSet<&'static str>> =
+    std::sync::Mutex::new(std::collections::BTreeSet::new());
+
+fn claim_retag_skip_report_slot(class: &'static str) -> bool {
+    let mut seen = RETAG_SKIP_REPORTED.lock().unwrap_or_else(|e| {
+        // A poisoned lock must not silence reporting outright.
+        RETAG_SKIP_REPORTED.clear_poison();
+        e.into_inner()
+    });
+    seen.insert(class)
+}
+
 fn report_codex_retag_skips(reasons: &[String]) {
     let Some(class) = codex_retag_skip_class(reasons) else {
         return;
     };
+    if !claim_retag_skip_report_slot(class) {
+        return;
+    }
     let sample: Vec<String> = {
         let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
         for reason in reasons {
@@ -6859,14 +6881,15 @@ pub(crate) fn claude_desktop_installed() -> bool {
     let mut candidates = vec![
         PathBuf::from("/Applications/Claude.app"),
         home.join("Applications").join("Claude.app"),
-        home.join("Library")
-            .join("Application Support")
-            .join("Claude"),
     ];
-    for (var, sub) in [("LOCALAPPDATA", "AnthropicClaude"), ("APPDATA", "Claude")] {
-        if let Some(base) = std::env::var_os(var) {
-            candidates.push(PathBuf::from(base).join(sub));
-        }
+    // The Squirrel install root, which uninstall removes. Deliberately NOT the
+    // Electron userData dirs (`~/Library/Application Support/Claude`,
+    // `%APPDATA%\Claude`): those outlive an uninstall, so they would tell a
+    // former user we cannot work with an app they already deleted. Missing an
+    // install in a non-standard location is the safe direction -- the copy is
+    // an extra explanation and its absence leaves the correct generic text.
+    if let Some(base) = std::env::var_os("LOCALAPPDATA") {
+        candidates.push(PathBuf::from(base).join("AnthropicClaude"));
     }
     candidates.iter().any(|path| path.exists())
 }
@@ -7329,6 +7352,21 @@ mod tests {
             Some("locked")
         );
         assert_eq!(codex_retag_skip_class(&[]), None);
+    }
+
+    /// A retag pass runs on every launch AND every quit, and a Codex that is
+    /// open holds its own store past `busy_timeout` routinely -- so without a
+    /// per-session cap the one condition files a Warning per launch forever.
+    /// The event has to stay a HOST count.
+    #[test]
+    fn a_retag_skip_class_reports_once_per_session() {
+        use super::claim_retag_skip_report_slot;
+        // Slug is deliberately not one of the real classes: the static is
+        // process-global, so a real one would couple this to run order.
+        assert!(claim_retag_skip_report_slot("test-only-class"));
+        assert!(!claim_retag_skip_report_slot("test-only-class"));
+        // A different class is still worth one event of its own.
+        assert!(claim_retag_skip_report_slot("test-only-other"));
     }
 
     use std::collections::{BTreeMap, BTreeSet};

--- a/src-tauri/src/client_adapters.rs
+++ b/src-tauri/src/client_adapters.rs
@@ -3434,6 +3434,7 @@ fn last_codex_retag_at() -> Option<SystemTime> {
 fn retag_codex_thread_providers(from: &str, to: &str) {
     let mut found_thread_store = false;
     let mut unreadable = 0usize;
+    let mut skip_reasons: Vec<String> = Vec::new();
     for path in discover_codex_state_dbs() {
         match retag_one_codex_db(&path, from, to) {
             // No `threads` table: unrelated sqlite store (logs/goals/memories).
@@ -3457,9 +3458,11 @@ fn retag_codex_thread_providers(from: &str, to: &str) {
                     "codex retag {from}->{to} skipped for {}: {e}",
                     path.display()
                 );
+                skip_reasons.push(e.to_string());
             }
         }
     }
+    report_codex_retag_skips(&skip_reasons);
     *LAST_CODEX_RETAG.lock().unwrap() = Some(SystemTime::now());
     // A `state_*.sqlite`-shaped file with no `threads` table means Codex renamed
     // the table itself (discovery already survives a file rename). Only flag when
@@ -3486,6 +3489,60 @@ fn retag_codex_thread_providers(from: &str, to: &str) {
             );
         }
     }
+}
+
+/// One Sentry event per retag PASS, not one per file.
+///
+/// The per-file warn names the DB, so the log bridge grouped it by filename: a
+/// running Codex holding three of its own sqlite files opened three issues in
+/// the same second for one condition (RUST-EK, RUST-EM, RUST-EN). The bridged
+/// twin is dropped in logging.rs and the reasons ride along as an extra.
+///
+/// The environmental causes stay dropped (a DB the user's disk corrupted is
+/// not ours to fix, RUST-95/96), but a real one anywhere in the pass still
+/// reports: a lock outliving `busy_timeout` is how we would learn that
+/// assumption went stale.
+fn codex_retag_skip_class(reasons: &[String]) -> Option<&'static str> {
+    reasons.iter().find_map(|reason| {
+        let lower = reason.to_ascii_lowercase();
+        if lower.contains("malformed") || lower.contains("disk i/o error") {
+            None
+        } else if lower.contains("is locked") {
+            Some("locked")
+        } else {
+            Some("other")
+        }
+    })
+}
+
+fn report_codex_retag_skips(reasons: &[String]) {
+    let Some(class) = codex_retag_skip_class(reasons) else {
+        return;
+    };
+    let sample: Vec<String> = {
+        let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        for reason in reasons {
+            seen.insert(reason.chars().take(160).collect());
+        }
+        seen.into_iter().take(5).collect()
+    };
+    sentry::with_scope(
+        |scope| {
+            scope.set_tag("flow", "codex_retag");
+            scope.set_extra("skipped_files", (reasons.len() as u64).into());
+            scope.set_extra("reasons", sample.join(" | ").into());
+            scope.set_fingerprint(Some(&["codex_retag_skipped", class]));
+        },
+        || {
+            sentry::capture_message(
+                &format!(
+                    "codex retag skipped {} database(s) ({class})",
+                    reasons.len()
+                ),
+                sentry::Level::Warning,
+            );
+        },
+    );
 }
 
 fn retag_one_codex_db(path: &Path, from: &str, to: &str) -> rusqlite::Result<Option<usize>> {
@@ -7230,6 +7287,28 @@ fn windows_path_extensions() -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn codex_retag_skip_class_reports_only_what_a_release_can_fix() {
+        use super::codex_retag_skip_class;
+        // A disk the user's Codex corrupted is not ours (RUST-95/96).
+        assert_eq!(
+            codex_retag_skip_class(&["database disk image is malformed".into()]),
+            None
+        );
+        assert_eq!(codex_retag_skip_class(&["disk I/O error".into()]), None);
+        // A lock outliving busy_timeout is: one class for the whole pass,
+        // however many of Codex's own DBs it happened to hold (RUST-EK/EM/EN).
+        assert_eq!(
+            codex_retag_skip_class(&[
+                "database disk image is malformed".into(),
+                "database is locked".into(),
+                "database is locked".into(),
+            ]),
+            Some("locked")
+        );
+        assert_eq!(codex_retag_skip_class(&[]), None);
+    }
+
     use std::collections::{BTreeMap, BTreeSet};
     use std::fs;
     use std::path::{Path, PathBuf};

--- a/src-tauri/src/client_adapters.rs
+++ b/src-tauri/src/client_adapters.rs
@@ -5997,6 +5997,7 @@ fn is_headroom_proxy_reachable() -> bool {
 
 fn probe_headroom_proxy() -> bool {
     let client = match reqwest::blocking::Client::builder()
+        .no_proxy()
         .timeout(Duration::from_millis(500))
         .build()
     {
@@ -6847,6 +6848,27 @@ fn grok_home() -> PathBuf {
         .filter(|v| !v.is_empty())
         .map(PathBuf::from)
         .unwrap_or_else(|| home_dir().join(".grok"))
+}
+
+/// Claude Desktop is not a supported client: its bundled Claude Code pins
+/// provider routing to the host, so nothing Headroom configures reaches it.
+/// A machine that has only it installed still deserves to hear that in words
+/// rather than a generic "no coding tool found". Presence only, no version.
+pub(crate) fn claude_desktop_installed() -> bool {
+    let home = home_dir();
+    let mut candidates = vec![
+        PathBuf::from("/Applications/Claude.app"),
+        home.join("Applications").join("Claude.app"),
+        home.join("Library")
+            .join("Application Support")
+            .join("Claude"),
+    ];
+    for (var, sub) in [("LOCALAPPDATA", "AnthropicClaude"), ("APPDATA", "Claude")] {
+        if let Some(base) = std::env::var_os(var) {
+            candidates.push(PathBuf::from(base).join(sub));
+        }
+    }
+    candidates.iter().any(|path| path.exists())
 }
 
 fn detect_claude_code_client(configured: bool) -> ClientStatus {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2648,6 +2648,7 @@ pub(crate) fn build_watchdog_give_up_report(
 fn probe_backend_readyz_with_body(timeout: std::time::Duration) -> (String, Option<String>) {
     let port = crate::backend_port::get();
     let client = match reqwest::blocking::Client::builder()
+        .no_proxy()
         .timeout(timeout)
         .build()
     {
@@ -3553,6 +3554,7 @@ fn stats_client() -> Option<&'static reqwest::blocking::Client> {
     CLIENT
         .get_or_init(|| {
             reqwest::blocking::Client::builder()
+                .no_proxy()
                 .timeout(std::time::Duration::from_millis(500))
                 .build()
                 .ok()
@@ -4920,6 +4922,7 @@ async fn submit_contact_request(
     let target = validate_contact_request_url(&url)
         .ok_or_else(|| "Could not reach the contact form.".to_string())?;
 
+    // proxy-ok: contact form posts to extraheadroom.com, not loopback
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
         .build()
@@ -6938,6 +6941,7 @@ fn fetch_transformations_feed_from(
     limit: u32,
 ) -> Result<TransformationFeedResponse, String> {
     let client = reqwest::blocking::Client::builder()
+        .no_proxy()
         .timeout(TRANSFORMATIONS_FEED_TIMEOUT)
         .build()
         .map_err(|err| err.to_string())?;
@@ -11497,6 +11501,80 @@ Some unrelated content.
         assert_eq!(auto_resume_backoff(2), Duration::from_secs(120));
         assert_eq!(auto_resume_backoff(3), Duration::from_secs(300));
         assert_eq!(auto_resume_backoff(50), Duration::from_secs(300));
+    }
+
+    /// Every reqwest client must decide, explicitly, whether it honors the
+    /// user's system proxy. reqwest 0.12 delegates proxy discovery to
+    /// hyper-util, which has no loopback exemption anywhere:
+    ///
+    /// - Windows reads HKCU `Internet Settings\ProxyServer` and applies it to
+    ///   http AND https, taking its bypass list only from `ProxyOverride`.
+    ///   WinINET's `<local>` token is copied through as a literal string that
+    ///   can never match `127.0.0.1`, so even a correctly configured corporate
+    ///   proxy fails to exempt loopback.
+    /// - macOS reads `HTTPProxy`/`HTTPSProxy` and ignores `ExceptionsList` and
+    ///   `ExcludeSimpleHostnames` entirely, so the user's own bypass list is
+    ///   not consulted at all.
+    ///
+    /// A user with any system proxy enabled therefore has our /readyz, /livez,
+    /// /stats and feed polls sent to that proxy, and a healthy backend reads as
+    /// unreachable. That is the same class as the v2rayN `socks4://` crashes
+    /// (RUST-9F/9T/AT/AS/AY/B3/B5), which only ever got fixed for the backend
+    /// child's env, not for our own HTTP calls.
+    ///
+    /// So: a client that talks to loopback calls `.no_proxy()`. A client that
+    /// talks to the internet must keep honoring the proxy (corporate networks
+    /// need it) and says so with a `// proxy-ok:` comment above the builder.
+    /// Adding a client without either is the regression this guards.
+    #[test]
+    fn every_reqwest_client_decides_about_the_system_proxy() {
+        // Split so this needle does not match its own source line.
+        let needle = concat!("Client::", "builder()");
+        let sources = [
+            ("analytics.rs", include_str!("analytics.rs")),
+            ("client_adapters.rs", include_str!("client_adapters.rs")),
+            ("lib.rs", include_str!("lib.rs")),
+            ("pricing.rs", include_str!("pricing.rs")),
+            ("proxy_intercept.rs", include_str!("proxy_intercept.rs")),
+            ("state.rs", include_str!("state.rs")),
+            ("tool_manager.rs", include_str!("tool_manager.rs")),
+        ];
+
+        let mut undecided = Vec::new();
+        let mut decided = 0usize;
+        for (name, source) in sources {
+            let lines: Vec<&str> = source.lines().collect();
+            for (i, line) in lines.iter().enumerate() {
+                if !line.contains(needle) {
+                    continue;
+                }
+                // The builder chain runs to its `.build()`; 40 lines is well
+                // clear of the longest one (the asset downloader, at 5).
+                let end = (i..lines.len().min(i + 40))
+                    .find(|&j| lines[j].contains(".build()"))
+                    .unwrap_or(i);
+                let chain = lines[i..=end].join("\n");
+                let marked = i > 0 && lines[i - 1].contains("proxy-ok:");
+                if chain.contains(".no_proxy()") || marked {
+                    decided += 1;
+                } else {
+                    undecided.push(format!("{name}:{}", i + 1));
+                }
+            }
+        }
+
+        assert!(
+            undecided.is_empty(),
+            "reqwest client(s) with no system-proxy decision: {undecided:?}. \
+             Add .no_proxy() if it talks to 127.0.0.1, or a `// proxy-ok: <why>` \
+             comment above the builder if it must honor the user's proxy."
+        );
+        // Tripwire against the scan silently matching nothing (a rename of the
+        // builder API, or the include_str! paths drifting).
+        assert!(
+            decided >= 15,
+            "expected to find the known reqwest clients, found only {decided}"
+        );
     }
 
     /// Ordering guard for the give-up path. `capture_watchdog_give_up`

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3636,6 +3636,11 @@ fn get_client_local_activity_ages(
 /// (the callout just stays quiet); false positives are not, so matching is
 /// strict on the executable/script basename.
 #[tauri::command]
+fn claude_desktop_installed() -> bool {
+    client_adapters::claude_desktop_installed()
+}
+
+#[tauri::command]
 fn get_running_agent_process_counts() -> std::collections::HashMap<String, usize> {
     #[cfg(windows)]
     {
@@ -6356,6 +6361,7 @@ pub fn run() {
             get_intercept_request_counts_by_agent,
             get_running_agent_process_counts,
             get_client_local_activity_ages,
+            claude_desktop_installed,
             get_gated_bypass_bytes,
             install_claude_code_cli,
             get_launch_flags,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4320,7 +4320,17 @@ fn run_activity_observation(app: &AppHandle) {
     // machine where nothing is wrong (RUST-DD regressed on 0.9.12 with the
     // grace in place). The canary is for a backend that is UP and still
     // failing; only count the streak while the app expects it to be up.
-    if state.runtime_is_paused() || state.runtime_is_auto_paused() || state.runtime_is_starting() {
+    // Same reasoning for a front door that never opened: when the intercept
+    // cannot bind 6767 (RUST-EQ, Windows refusing the socket outright), every
+    // fetch is refused for as long as that lasts -- and the bind loop already
+    // reports it, with the OS code and the occupant. The canary would only add
+    // a second, blinder issue for the same machine (RUST-DT).
+    let intercept_bind_failed = state.intercept_bind_error.lock().is_some();
+    if state.runtime_is_paused()
+        || state.runtime_is_auto_paused()
+        || state.runtime_is_starting()
+        || intercept_bind_failed
+    {
         *FEED_FAILING_SINCE.lock() = None;
     } else if should_pull_transformations_feed() {
         match fetch_transformations_feed(ACTIVITY_OBSERVER_LIMIT) {
@@ -7073,10 +7083,18 @@ fn learn_failure_agent_limit_line(text: &str) -> Option<&str> {
         // match the two words the whole family shares. Still specific enough
         // not to hit a project's own source line echoed back.
         "spend limit",
+        // RUST-EP: `You've hit your weekly limit \u{b7} resets 2am
+        // (Europe/Berlin)` -- a fourth wording in three months.
+        "weekly limit",
     ];
     text.lines().map(str::trim).find(|line| {
         let lower = line.to_ascii_lowercase();
         NEEDLES.iter().any(|needle| lower.contains(needle))
+            // Every wording so far is second-person ("You've hit your <window>
+            // limit"), so match that shape too rather than waiting for the
+            // fifth variant to file another Error. Still anchored: a project's
+            // own source line echoed back says "limit", never "hit your".
+            || (lower.contains("hit your") && lower.contains("limit"))
     })
 }
 
@@ -7113,6 +7131,39 @@ fn learn_agent_limit_hint(agent: LearnAgent, limit_line: &str) -> String {
 fn learn_failure_is_agent_model_rejected(text: &str) -> bool {
     let lowered = text.to_ascii_lowercase();
     lowered.contains("unrecognized_model") || lowered.contains("does not support this model")
+}
+
+/// True when a `headroom learn` failure was the agent CLI exhausting its own
+/// API retries: `{"type":"system","subtype":"api_retry","attempt":8,
+/// "max_retries":10,"retry_delay_ms":38510,"error_status":null,"error":
+/// "unknown",...}` repeated until it gave up (RUST-EW). The CLI never reached
+/// its backend, so the outcome is the user's network or an upstream outage --
+/// the same user-environment class as the auth and limit lines above.
+///
+/// `error_status` must be null, and that is load-bearing: a retry storm around
+/// a REAL status -- a 400 for a prompt we built too long (RUST-BK) -- is ours
+/// and has to keep reporting. Suppressing this class also un-fragments it: the
+/// retry event carries `retry_delay_ms`, `attempt` and a session UUID, and the
+/// failure signature is built from that line, so every storm opened a brand
+/// new issue.
+fn learn_failure_is_agent_api_unreachable(text: &str) -> bool {
+    text.lines().any(|line| {
+        line.contains("\"subtype\":\"api_retry\"") && line.contains("\"error_status\":null")
+    })
+}
+
+/// The user-facing remedy for [`learn_failure_is_agent_api_unreachable`].
+fn learn_agent_api_unreachable_hint(agent: LearnAgent) -> String {
+    let cli = match agent {
+        LearnAgent::Claude => "Claude Code",
+        LearnAgent::Codex => "Codex",
+        LearnAgent::Opencode => "opencode",
+        LearnAgent::Grok => "Grok",
+    };
+    format!(
+        "{cli} could not reach its API -- it retried and gave up -- so headroom learn could not \
+         run its analysis. Check this machine's connection, then start the scan again."
+    )
 }
 
 /// The text a learn failure is fingerprinted on.
@@ -7478,7 +7529,11 @@ fn execute_headroom_learn_run(
                     let agent_not_signed_in = learn_failure_is_agent_auth(&stderr);
                     let agent_limit_line =
                         learn_failure_agent_limit_line(&stderr).map(str::to_string);
-                    if !agent_not_signed_in && agent_limit_line.is_none() {
+                    // RUST-EW, third cause in the same class: the CLI never
+                    // reached its own API.
+                    let agent_api_unreachable = learn_failure_is_agent_api_unreachable(&stderr);
+                    if !agent_not_signed_in && agent_limit_line.is_none() && !agent_api_unreachable
+                    {
                         sentry::with_scope(
                             |scope| {
                                 scope.set_tag("flow", "headroom_learn");
@@ -7665,6 +7720,7 @@ fn execute_headroom_learn_run(
                 let agent_not_signed_in = learn_failure_is_agent_auth(&stderr);
                 let agent_limit_line = learn_failure_agent_limit_line(&stderr).map(str::to_string);
                 let agent_model_rejected = learn_failure_is_agent_model_rejected(&stderr);
+                let agent_api_unreachable = learn_failure_is_agent_api_unreachable(&stderr);
                 // RUST-3F: this used to read `signature.contains(...)`, which is
                 // exactly the mistake the paragraph above warns about. Click
                 // prints its usage banner FIRST and the diagnosis LAST:
@@ -7682,7 +7738,8 @@ fn execute_headroom_learn_run(
                 let user_env_condition = path_unreadable
                     || agent_not_signed_in
                     || agent_limit_line.is_some()
-                    || agent_model_rejected;
+                    || agent_model_rejected
+                    || agent_api_unreachable;
                 if !user_env_condition {
                     sentry::with_scope(
                         |scope| {
@@ -7725,6 +7782,8 @@ fn execute_headroom_learn_run(
                     learn_agent_auth_hint(agent)
                 } else if let Some(line) = &agent_limit_line {
                     learn_agent_limit_hint(agent, line)
+                } else if agent_api_unreachable {
+                    learn_agent_api_unreachable_hint(agent)
                 } else {
                     format!(
                         "headroom learn exited with {}.\n{}",
@@ -9272,7 +9331,8 @@ mod tests {
         is_blocked_runtime_dll_signal, is_disk_full_signal, is_endpoint_protection_signal,
         is_environmental_startup_key, is_loopback_socket_denied_signal, is_network_download_signal,
         is_port_conflict_failure, is_prerelease_version, learn_agent_auth_hint,
-        learn_agent_limit_hint, learn_failure_agent_limit_line, learn_failure_is_agent_auth,
+        learn_agent_limit_hint, learn_failure_agent_limit_line,
+        learn_failure_is_agent_api_unreachable, learn_failure_is_agent_auth,
         learn_failure_is_agent_model_rejected, learn_failure_signature_source, learn_step_label,
         lifetime_token_milestone_kind, noop_app_update_progress_emitter,
         normalize_learn_failure_signature, onboarding_recovery_copy, parse_live_learnings,
@@ -12022,6 +12082,37 @@ Some unrelated content.
         ] {
             assert!(
                 learn_failure_agent_limit_line(stderr).is_none(),
+                "for: {stderr}"
+            );
+        }
+    }
+
+    #[test]
+    fn learn_failure_agent_limit_line_matches_the_weekly_window() {
+        // RUST-EP verbatim: a fourth wording, matched by none of the needles.
+        let weekly = "You've hit your weekly limit \u{b7} resets 2am (Europe/Berlin)";
+        assert_eq!(learn_failure_agent_limit_line(weekly), Some(weekly));
+        // The shape rule, not the needle: any future window wording.
+        assert!(learn_failure_agent_limit_line("You've hit your Opus limit for today").is_some());
+    }
+
+    #[test]
+    fn learn_failure_is_agent_api_unreachable_only_on_a_statusless_retry_storm() {
+        // RUST-EW verbatim: claude-cli retried its API ten times, never got a
+        // status back, and gave up. Nothing on our side changes that.
+        let storm = "LLM analysis failed: `claude -p --output-format stream-json --verbose` failed (exit 1):\n{\"type\":\"system\",\"subtype\":\"api_retry\",\"attempt\":8,\"max_retries\":10,\"retry_delay_ms\":38510,\"error_status\":null,\"error\":\"unknown\",\"session_id\":\"083b154e\"}\n";
+        assert!(learn_failure_is_agent_api_unreachable(storm));
+        // A retry storm around a REAL status is OURS (RUST-BK: a prompt we
+        // built too long) and must keep reporting.
+        let ours = "{\"type\":\"system\",\"subtype\":\"api_retry\",\"attempt\":1,\"max_retries\":10,\"error_status\":400,\"error\":\"prompt is too long\"}";
+        assert!(!learn_failure_is_agent_api_unreachable(ours));
+        for stderr in [
+            "LLM analysis failed: `claude -p` did not respond within 120s.",
+            "API Error: 400 status code (no body)",
+            "",
+        ] {
+            assert!(
+                !learn_failure_is_agent_api_unreachable(stderr),
                 "for: {stderr}"
             );
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5105,11 +5105,6 @@ async fn apply_client_setup(
     }
 }
 
-#[tauri::command]
-async fn verify_client_setup(client_id: String) -> Result<ClientSetupVerification, String> {
-    client_adapters::verify_client_setup(&client_id).map_err(|err| err.to_string())
-}
-
 /// Watchdog-driven silent self-heal (see `client_adapters::repair_client_setups`).
 /// Skipped while the runtime is paused or bypassed: the pricing gate and the
 /// watchdog give-up path tear client configs down on purpose, and repairing
@@ -6397,7 +6392,6 @@ pub fn run() {
             get_transformations_feed,
             start_headroom_learn,
             apply_client_setup,
-            verify_client_setup,
             repair_client_setups,
             detect_unrouted_clients,
             detect_oss_remnants,
@@ -7170,10 +7164,23 @@ fn learn_failure_is_agent_model_rejected(text: &str) -> bool {
 /// retry event carries `retry_delay_ms`, `attempt` and a session UUID, and the
 /// failure signature is built from that line, so every storm opened a brand
 /// new issue.
+///
+/// Every retry line has to be statusless, not just one of them: a run that
+/// blipped statuslessly and THEN failed on a real 400 carries both shapes, and
+/// an `any()` over the null one would suppress the report we most need. One
+/// retry around a real status anywhere disqualifies the whole run.
 fn learn_failure_is_agent_api_unreachable(text: &str) -> bool {
-    text.lines().any(|line| {
-        line.contains("\"subtype\":\"api_retry\"") && line.contains("\"error_status\":null")
-    })
+    let mut statusless = false;
+    for line in text
+        .lines()
+        .filter(|line| line.contains("\"subtype\":\"api_retry\""))
+    {
+        if !line.contains("\"error_status\":null") {
+            return false;
+        }
+        statusless = true;
+    }
+    statusless
 }
 
 /// The user-facing remedy for [`learn_failure_is_agent_api_unreachable`].
@@ -12204,6 +12211,11 @@ Some unrelated content.
         // built too long) and must keep reporting.
         let ours = "{\"type\":\"system\",\"subtype\":\"api_retry\",\"attempt\":1,\"max_retries\":10,\"error_status\":400,\"error\":\"prompt is too long\"}";
         assert!(!learn_failure_is_agent_api_unreachable(ours));
+        // Mixed: a statusless blip, then the real 400. The run is still OURS,
+        // so the null line must not buy it a suppression.
+        assert!(!learn_failure_is_agent_api_unreachable(&format!(
+            "{storm}{ours}\n"
+        )));
         for stderr in [
             "LLM analysis failed: `claude -p` did not respond within 120s.",
             "API Error: 400 status code (no body)",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -535,6 +535,12 @@ fn maybe_fire_unrouted_usage_nudge(app: &AppHandle, state: &AppState, dashboard:
     if dashboard.lifetime_requests > 0 || !state.setup_wizard_complete() {
         return;
     }
+    // Sessions growing while nothing reaches the proxy proves a leak, not its
+    // cause. With 6767 unbound the cause is ours, and "restart your terminal"
+    // is advice that cannot work -- same reasoning as the hourly detector.
+    if state.intercept_bind_failed() {
+        return;
+    }
     // Cached (~90s warmer cadence), so polling this every 5s costs nothing.
     let claude = state
         .list_claude_code_projects()
@@ -4325,7 +4331,7 @@ fn run_activity_observation(app: &AppHandle) {
     // fetch is refused for as long as that lasts -- and the bind loop already
     // reports it, with the OS code and the occupant. The canary would only add
     // a second, blinder issue for the same machine (RUST-DT).
-    let intercept_bind_failed = state.intercept_bind_error.lock().is_some();
+    let intercept_bind_failed = state.intercept_bind_failed();
     if state.runtime_is_paused()
         || state.runtime_is_auto_paused()
         || state.runtime_is_starting()
@@ -5155,7 +5161,15 @@ async fn detect_unrouted_clients(
         use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
         let state: State<'_, AppState> = app.state();
         // Paused or bypassed: the agent going direct is the intended state.
+        // A failed intercept bind is the same fact from the other end: when
+        // 6767 never opened (RUST-EQ, Windows refusing the socket outright),
+        // no client CAN reach us, so "active locally, no proxied request" is
+        // OUR outage, not a clobbered client config. Reporting it here blames
+        // the client, re-applies a setup that was never wrong, and shows the
+        // user a "ran without Headroom" affordance pointing at their terminal.
+        // The bind loop already reports the real cause, with the OS code.
         if state.runtime_is_paused()
+            || state.intercept_bind_failed()
             || state
                 .proxy_bypass
                 .load(std::sync::atomic::Ordering::Acquire)

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -342,7 +342,7 @@ fn skip_sentry(target: &str, msg: &str) -> bool {
     // assumption went stale.
     if target.starts_with("headroom_desktop_lib::client_adapters")
         && msg.starts_with("codex retag")
-        && (msg.contains("database disk image is malformed") || msg.contains("disk I/O error"))
+        && msg.contains(" skipped for ")
     {
         return true;
     }
@@ -356,6 +356,18 @@ fn skip_sentry(target: &str, msg: &str) -> bool {
     if target.starts_with("headroom_desktop_lib::proxy_intercept")
         && msg.starts_with("[proxy_intercept] dropped ")
         && msg.contains("stale tool_search reference")
+    {
+        return true;
+    }
+    // The learn-block repair reaches Sentry via the fingerprinted capture at
+    // the emit site, which carries the path, the file mtime and the size as
+    // extras. This line bakes all three into the text, so one host's three
+    // repos landed as RUST-ER + RUST-ES + RUST-ET in the same second -- and a
+    // per-project group cannot answer the only question the warn exists for,
+    // which is how many HOSTS see it. Same split as the sibling lines here.
+    if target.starts_with("headroom_desktop_lib::tool_manager")
+        && msg.starts_with("learn block in ")
+        && msg.contains("end marker restored")
     {
         return true;
     }
@@ -921,15 +933,24 @@ mod tests {
     }
 
     #[test]
-    fn skips_codex_retag_malformed_db() {
+    fn skips_codex_retag_per_file_skip_lines() {
         assert!(skip_sentry(
             "headroom_desktop_lib::client_adapters",
             "codex retag openai->headroom skipped for ~/.codex/logs_2.sqlite: database disk image is malformed"
         ));
-        // Other retag skip causes (locked DB, schema drift) stay in Sentry.
-        assert!(!skip_sentry(
+        // A locked DB is still REPORTED -- by the per-pass capture in
+        // client_adapters, which groups every file in one pass under one
+        // fingerprint. This line names the file, so leaving it bridged filed
+        // one issue per sqlite file a running Codex happened to hold
+        // (RUST-EK/EM/EN, three in one second on one host).
+        assert!(skip_sentry(
             "headroom_desktop_lib::client_adapters",
             "codex retag openai->headroom skipped for ~/.codex/state_5.sqlite: database is locked"
+        ));
+        // The schema-drift signal is not a per-file skip line and stays.
+        assert!(!skip_sentry(
+            "headroom_desktop_lib::client_adapters",
+            "codex retag openai->headroom: a state_*.sqlite is present but has no `threads` table"
         ));
     }
 

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -3708,6 +3708,7 @@ fn fetch_remote_account(
 }
 
 fn http_client() -> Result<Client, String> {
+    // proxy-ok: extraheadroom.com account/pricing API, not loopback
     Client::builder()
         .timeout(std::time::Duration::from_secs(8))
         .build()

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -184,6 +184,30 @@ fn transport_kind_slug(err: &reqwest::Error) -> &'static str {
     }
 }
 
+/// Flatten a transport error's source chain into one line.
+///
+/// `transport_failure` deliberately reduces the cause to three stable phrases
+/// so the message groups, which means the actual reason - DNS, refused, or a
+/// corporate MITM proxy presenting an untrusted root - never leaves the
+/// machine. `is_connect()` covers all three, so RUST-BE could not be told
+/// apart from a captive portal. Carried as an extra, never a tag or
+/// fingerprint component, so grouping is unaffected. Bounded because a chain
+/// is attacker-agnostic but not length-bounded.
+fn transport_cause_chain(err: &reqwest::Error) -> String {
+    let mut parts = vec![err.to_string()];
+    let mut source = std::error::Error::source(err);
+    while let Some(cause) = source {
+        if parts.len() >= 6 {
+            break;
+        }
+        parts.push(cause.to_string());
+        source = cause.source();
+    }
+    let mut chain = parts.join(" <- ");
+    chain.truncate(400);
+    chain
+}
+
 /// (action, kind) pairs that have already reported a TRANSIENT transport
 /// failure this session, so the repeats can be dropped.
 static TRANSIENT_TRANSPORT_REPORTED: std::sync::Mutex<
@@ -235,6 +259,7 @@ fn capture_transport_failure(action_slug: &'static str, msg: &str, err: &reqwest
         |scope| {
             scope.set_fingerprint(Some(&["transport-failure", action_slug, kind]));
             scope.set_tag("transport.kind", kind);
+            scope.set_extra("cause_chain", transport_cause_chain(err).into());
         },
         || sentry::capture_message(msg, transport_level(err)),
     );
@@ -6376,6 +6401,12 @@ mod tests {
             .send()
             .expect_err("port 1 refuses");
         assert_eq!(super::transport_kind_slug(&connect), "connect");
+        // RUST-BE: the user-facing message is the same phrase for a refused
+        // port, a DNS failure and a TLS-intercepting proxy, so the chain is
+        // the only thing that tells them apart in Sentry.
+        let chain = super::transport_cause_chain(&connect);
+        assert!(chain.len() > connect.to_string().len(), "chain: {chain}");
+        assert!(chain.len() <= 400, "chain must stay bounded: {chain}");
     }
 
     #[test]

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -203,9 +203,16 @@ fn transport_cause_chain(err: &reqwest::Error) -> String {
         parts.push(cause.to_string());
         source = cause.source();
     }
-    let mut chain = parts.join(" <- ");
-    chain.truncate(400);
-    chain
+    // A cause can be a filesystem one (a client cert, a CA bundle path), and
+    // this is the one place a raw OS string leaves the machine unbridged --
+    // the log bridge's scrub does not apply to an explicit extra.
+    // Bounded by CHARS, not bytes: `String::truncate` panics when the byte
+    // index is not a char boundary, and a localized Windows OS error message
+    // is exactly the multibyte text that would land one mid-character.
+    crate::logging::scrub_home(&parts.join(" <- "))
+        .chars()
+        .take(400)
+        .collect()
 }
 
 /// (action, kind) pairs that have already reported a TRANSIENT transport
@@ -6407,7 +6414,10 @@ mod tests {
         // the only thing that tells them apart in Sentry.
         let chain = super::transport_cause_chain(&connect);
         assert!(chain.len() > connect.to_string().len(), "chain: {chain}");
-        assert!(chain.len() <= 400, "chain must stay bounded: {chain}");
+        assert!(
+            chain.chars().count() <= 400,
+            "chain must stay bounded: {chain}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/proxy_intercept.rs
+++ b/src-tauri/src/proxy_intercept.rs
@@ -753,18 +753,24 @@ pub fn spawn(
                             // it held) — benign, just wait for it to go away.
                             // Otherwise the port is foreign; escalate once.
                             if probe_existing_intercept().await {
-                                // A Headroom IS serving 6767, so the port is
-                                // not the problem: clear whatever an earlier
-                                // iteration recorded. `bind_error` is otherwise
-                                // only cleared by a successful bind, and this
-                                // arm never binds -- so a stale "port is in
-                                // use; identifying what holds it" would stick
-                                // for the process lifetime and, through
-                                // `AppState::intercept_bind_failed`, mute the
-                                // unrouted detector, the usage nudge and the
-                                // transformations-feed canary on a machine
-                                // whose traffic is flowing fine.
-                                *bind_error.lock() = None;
+                                // Name the real cause. `bind_error` is only
+                                // ever cleared by a successful bind and this
+                                // arm never binds, so whatever an earlier
+                                // iteration wrote sticks for the process
+                                // lifetime -- and that was "in use;
+                                // identifying what holds it", which renders as
+                                // "Headroom is checking what holds it" and
+                                // then never resolves, because the diagnosis
+                                // it promises only runs in the arm below.
+                                //
+                                // Deliberately overwritten, NOT cleared: this
+                                // instance is a spectator, so its view of
+                                // traffic is not authoritative and the
+                                // detectors keyed on `intercept_bind_failed`
+                                // must stay stood down.
+                                *bind_error.lock() = Some(format!(
+                                    "port {INTERCEPT_PORT} is served by another Headroom instance"
+                                ));
                                 // Clients still reach A Headroom, so this is
                                 // benign for traffic -- but nothing in this
                                 // loop ever clears it, and a second instance

--- a/src-tauri/src/proxy_intercept.rs
+++ b/src-tauri/src/proxy_intercept.rs
@@ -2379,6 +2379,7 @@ fn fetch_codex_usage_snapshot(
     account_id: &str,
     user_agent: &str,
 ) -> Option<CodexRateLimitSnapshot> {
+    // proxy-ok: api.openai.com auth probe, not loopback
     let client = reqwest::blocking::Client::builder()
         .timeout(CODEX_USAGE_POLL_TIMEOUT)
         .build()

--- a/src-tauri/src/proxy_intercept.rs
+++ b/src-tauri/src/proxy_intercept.rs
@@ -765,9 +765,33 @@ pub fn spawn(
                                 if launched_at.elapsed() >= RELAUNCH_GRACE
                                     && reported_errors.insert("existing_proxy".to_string())
                                 {
-                                    log::warn!(
-                                        "[proxy_intercept] port {INTERCEPT_PORT} still served by another Headroom proxy {}s after launch; this instance is not the one clients reach",
-                                        launched_at.elapsed().as_secs()
+                                    let held_secs = launched_at.elapsed().as_secs();
+                                    log::info!(
+                                        "[proxy_intercept] port {INTERCEPT_PORT} still served by another Headroom proxy {held_secs}s after launch; this instance is not the one clients reach"
+                                    );
+                                    // The elapsed seconds are an EXTRA, and the
+                                    // fingerprint is fixed: interpolated into
+                                    // the message they open one issue per
+                                    // second-count (RUST-EH arrived as "93s"),
+                                    // and this target does not match the
+                                    // `[proxy_intercept] ... retrying` skip
+                                    // rule either. Same split the two sibling
+                                    // reclaim reports use.
+                                    sentry::with_scope(
+                                        |scope| {
+                                            scope.set_tag("flow", "intercept_second_instance");
+                                            scope.set_extra("held_secs", held_secs.into());
+                                            scope.set_extra("port", INTERCEPT_PORT.into());
+                                            scope.set_fingerprint(Some(&[
+                                                "intercept_second_instance",
+                                            ]));
+                                        },
+                                        || {
+                                            sentry::capture_message(
+                                                "[proxy_intercept] port still served by another Headroom proxy past the relaunch grace; this instance is not the one clients reach",
+                                                sentry::Level::Warning,
+                                            );
+                                        },
                                     );
                                 } else {
                                     log::info!(

--- a/src-tauri/src/proxy_intercept.rs
+++ b/src-tauri/src/proxy_intercept.rs
@@ -753,6 +753,18 @@ pub fn spawn(
                             // it held) — benign, just wait for it to go away.
                             // Otherwise the port is foreign; escalate once.
                             if probe_existing_intercept().await {
+                                // A Headroom IS serving 6767, so the port is
+                                // not the problem: clear whatever an earlier
+                                // iteration recorded. `bind_error` is otherwise
+                                // only cleared by a successful bind, and this
+                                // arm never binds -- so a stale "port is in
+                                // use; identifying what holds it" would stick
+                                // for the process lifetime and, through
+                                // `AppState::intercept_bind_failed`, mute the
+                                // unrouted detector, the usage nudge and the
+                                // transformations-feed canary on a machine
+                                // whose traffic is flowing fine.
+                                *bind_error.lock() = None;
                                 // Clients still reach A Headroom, so this is
                                 // benign for traffic -- but nothing in this
                                 // loop ever clears it, and a second instance

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -3444,6 +3444,16 @@ impl AppState {
         *self.runtime_paused.lock()
     }
 
+    /// True while the intercept's bind loop is still failing, i.e. 6767 is not
+    /// ours right now. Every client is hard-configured to that port, so this
+    /// means nothing CAN route through Headroom whatever the clients' configs
+    /// say -- which is why the unrouted-client detector and the transformations
+    /// feed canary both stand down on it instead of filing a second, blinder
+    /// issue for the same machine (RUST-EQ, RUST-DT).
+    pub fn intercept_bind_failed(&self) -> bool {
+        self.intercept_bind_error.lock().is_some()
+    }
+
     pub fn set_runtime_auto_paused(&self, auto_paused: bool) {
         self.runtime_auto_paused
             .store(auto_paused, std::sync::atomic::Ordering::Release);

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -4059,7 +4059,7 @@ pub(crate) fn current_platform_support_tier() -> &'static str {
 
 pub(crate) fn support_tier_for_platform(os: &str) -> &'static str {
     match os {
-        "linux" | "windows" => "experimental",
+        "linux" => "experimental",
         _ => "stable",
     }
 }
@@ -14569,9 +14569,9 @@ mod tests {
     }
 
     #[test]
-    fn support_tier_for_platform_marks_windows_experimental() {
+    fn support_tier_for_platform_marks_linux_experimental() {
         assert_eq!(support_tier_for_platform("linux"), "experimental");
-        assert_eq!(support_tier_for_platform("windows"), "experimental");
+        assert_eq!(support_tier_for_platform("windows"), "stable");
         assert_eq!(support_tier_for_platform("macos"), "stable");
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1626,6 +1626,7 @@ impl AppState {
         // large Claude request (tokenization, ONNX inference, etc). The
         // previous 1.5s timeout false-fired during those bursts.
         let client = match reqwest::blocking::Client::builder()
+            .no_proxy()
             .timeout(Duration::from_secs(5))
             .build()
         {
@@ -6538,6 +6539,7 @@ fn fetch_headroom_dashboard_stats() -> Option<HeadroomDashboardStats> {
     // fetch that still times out means the backend is genuinely starved.
     const STATS_FETCH_TIMEOUT_SECS: u64 = 15;
     let client = reqwest::blocking::Client::builder()
+        .no_proxy()
         .timeout(Duration::from_secs(STATS_FETCH_TIMEOUT_SECS))
         .build()
         .ok()?;
@@ -6597,6 +6599,7 @@ fn fetch_headroom_savings_history() -> Option<HeadroomSavingsHistoryResponse> {
     }
 
     let client = reqwest::blocking::Client::builder()
+        .no_proxy()
         .timeout(Duration::from_millis(500))
         .build()
         .ok()?;
@@ -8130,6 +8133,7 @@ fn runtime_already_serving(
 
 fn probe_proxy_readyz(timeout: Duration) -> bool {
     let client = match reqwest::blocking::Client::builder()
+        .no_proxy()
         .timeout(timeout)
         .build()
     {

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -8029,6 +8029,17 @@ pub(crate) fn intercept_bind_hint(raw: &str) -> String {
              Quit that program, or end it in Task Manager, and Headroom reconnects on its own."
         );
     }
+    // Two app instances (`restart_app`'s `open -n` relauncher bypasses
+    // single-instance). Traffic is fine -- the OTHER window is optimizing it --
+    // so this must not read as an outage, and the remedy is about the window,
+    // not the port.
+    if raw.contains("served by another Headroom instance") {
+        return format!(
+            "Another Headroom window already has port {port}, so this one is a spectator. \
+             Your traffic is still being optimized by that window. \
+             Quit this window; if you can't tell them apart, quit Headroom entirely and reopen it once."
+        );
+    }
     if raw.contains("still being released") {
         return format!(
             "Port {port} is still being released by the previous Headroom session. \
@@ -9953,6 +9964,18 @@ mod tests {
     /// rather than blaming the Python runtime -- which in that state is running
     /// fine on a port of its own. The hint must hand over the command that
     /// identifies the holder instead of asserting which one it is.
+    #[test]
+    fn intercept_bind_hint_for_a_second_instance_does_not_read_as_an_outage() {
+        // The string the existing-proxy arm writes, verbatim.
+        let hint = intercept_bind_hint("port 6767 is served by another Headroom instance");
+        assert!(hint.contains("6767"), "{hint}");
+        assert!(hint.contains("still being optimized"), "{hint}");
+        // Must not inherit the mid-diagnosis or foreign-holder remedies: no
+        // program is squatting the port and nothing is being identified.
+        assert!(!hint.contains("checking what holds it"), "{hint}");
+        assert!(!hint.contains("Task Manager"), "{hint}");
+    }
+
     #[test]
     fn intercept_bind_hint_names_the_port_and_how_to_find_the_holder() {
         let hint = intercept_bind_hint(

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -8357,11 +8357,21 @@ impl ToolManager {
     /// first or the "update" reinstalls the same commit. Plain `install`/`add`
     /// on an installed plugin is a no-op, which is why Update cannot just be
     /// the install path replayed.
-    fn install_plugin_into(&self, plugin: &'static PluginAddon, host: PluginHost) -> Result<()> {
-        let cli = host.cli().context("CLI not found on PATH")?;
+    ///
+    /// `cli` is resolved by the CALLER and passed in. Re-resolving it here ran
+    /// a second `detect_*_cli` probe milliseconds after the caller's, and that
+    /// one shells out (PATH lookup, then a login shell with a 2s cap): when it
+    /// came back empty the install reported "CLI not found on PATH" for a CLI
+    /// we had just found and filed it as a partial-install failure (RUST-EV).
+    fn install_plugin_into(
+        &self,
+        plugin: &'static PluginAddon,
+        host: PluginHost,
+        cli: &Path,
+    ) -> Result<()> {
         if host.plugin_present(plugin) {
-            let _ = self.run_plugin_cmd(plugin, &cli, host, &host.marketplace_update_args(plugin));
-            self.run_plugin_cmd(plugin, &cli, host, &host.update_args(plugin))?;
+            let _ = self.run_plugin_cmd(plugin, cli, host, &host.marketplace_update_args(plugin));
+            self.run_plugin_cmd(plugin, cli, host, &host.update_args(plugin))?;
         } else {
             // Re-adding an already-known marketplace is a benign error, so its
             // failure is not fatal on its own -- but it must not be discarded
@@ -8371,7 +8381,7 @@ impl ToolManager {
             // names a consequence and hides every cause (Sentry RUST-6K). Carry
             // the add error and attach it if the install then fails.
             let mut marketplace_err = self
-                .run_plugin_cmd(plugin, &cli, host, &host.marketplace_add_args(plugin))
+                .run_plugin_cmd(plugin, cli, host, &host.marketplace_add_args(plugin))
                 .err();
             // "marketplace 'x' is already added from a different source": the
             // host has our marketplace recorded under another spelling of the
@@ -8388,12 +8398,12 @@ impl ToolManager {
                     host.label()
                 );
                 let _ =
-                    self.run_plugin_cmd(plugin, &cli, host, &host.marketplace_remove_args(plugin));
+                    self.run_plugin_cmd(plugin, cli, host, &host.marketplace_remove_args(plugin));
                 marketplace_err = self
-                    .run_plugin_cmd(plugin, &cli, host, &host.marketplace_add_args(plugin))
+                    .run_plugin_cmd(plugin, cli, host, &host.marketplace_add_args(plugin))
                     .err();
             }
-            self.run_plugin_cmd(plugin, &cli, host, &host.install_args(plugin))
+            self.run_plugin_cmd(plugin, cli, host, &host.install_args(plugin))
                 .map_err(|err| match marketplace_err {
                     Some(add_err) => {
                         err.context(format!("marketplace add failed first: {add_err:#}"))
@@ -8414,9 +8424,9 @@ impl ToolManager {
     /// is a version skew the user can only fix by updating Codex.
     pub fn install_plugin(&self, id: &str) -> Result<bool> {
         let plugin = plugin_addon(id).with_context(|| format!("unknown plugin addon: {id}"))?;
-        let hosts: Vec<PluginHost> = PluginHost::ALL
+        let hosts: Vec<(PluginHost, PathBuf)> = PluginHost::ALL
             .into_iter()
-            .filter(|host| host.cli().is_some())
+            .filter_map(|host| host.cli().map(|cli| (host, cli)))
             .collect();
         if hosts.is_empty() {
             bail!(
@@ -8426,8 +8436,8 @@ impl ToolManager {
         let mut errors: Vec<String> = Vec::new();
         let mut installed_any = false;
         let mut codex_outdated = false;
-        for host in hosts {
-            match self.install_plugin_into(plugin, host) {
+        for (host, cli) in hosts {
+            match self.install_plugin_into(plugin, host, &cli) {
                 Ok(()) => installed_any = true,
                 Err(err) if matches!(host, PluginHost::Codex) && is_outdated_codex(&err) => {
                     codex_outdated = true;
@@ -8485,7 +8495,7 @@ impl ToolManager {
             // Codex has no enable/disable verb, so enabling re-installs and
             // disabling removes. Skip disabling a host that isn't present.
             let result = if enabled {
-                self.install_plugin_into(plugin, host)
+                self.install_plugin_into(plugin, host, &cli)
             } else if host.plugin_present(plugin) {
                 self.run_plugin_cmd(plugin, &cli, host, &host.disable_args(plugin))
             } else {
@@ -11138,6 +11148,31 @@ pub fn repair_headroom_learn_block_file(path: &Path) -> bool {
         .unwrap_or_default();
     match crate::client_adapters::atomic_write(path, repaired.as_bytes()) {
         Ok(()) => {
+            // The path, the mtime and the size are EXTRAS. Interpolated into
+            // the message they grouped per project -- RUST-ER, RUST-ES and
+            // RUST-ET are one host's three repos in the same second -- which
+            // destroys the one thing this warn exists for: a fleet count that
+            // tells a code bug (many hosts) from a hand edit (one host). The
+            // bridged twin is dropped in logging.rs; the local line keeps the
+            // path, which is what a support thread needs.
+            sentry::with_scope(
+                |scope| {
+                    scope.set_tag("flow", "learn_block_repair");
+                    scope.set_extra(
+                        "path",
+                        crate::logging::scrub_home(&path.display().to_string()).into(),
+                    );
+                    scope.set_extra("file_mtime", modified.clone().into());
+                    scope.set_extra("bytes", (content.len() as u64).into());
+                    scope.set_fingerprint(Some(&["learn_block_end_marker_restored"]));
+                },
+                || {
+                    sentry::capture_message(
+                        "learn block had no end marker; end marker restored",
+                        sentry::Level::Warning,
+                    );
+                },
+            );
             log::warn!(
                 "learn block in {} had no end marker (file mtime {modified}, {} bytes); end marker restored",
                 path.display(),

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -8709,6 +8709,7 @@ const SERENA_DASHBOARD_PORT_SCAN: u16 = 4;
 /// output_tokens}}}`; empty stats yield Some(0), no/invalid responder None.
 fn fetch_serena_output_tokens(base_url: &str) -> Option<u64> {
     let client = reqwest::blocking::Client::builder()
+        .no_proxy()
         .timeout(Duration::from_millis(300))
         .build()
         .ok()?;
@@ -9599,6 +9600,7 @@ fn find_listener_command(port: u16) -> String {
 /// in time and a healthy one answers in milliseconds.
 pub(crate) fn probe_backend_readyz_ok(port: u16) -> bool {
     let Ok(client) = reqwest::blocking::Client::builder()
+        .no_proxy()
         .timeout(Duration::from_millis(800))
         .build()
     else {
@@ -10925,6 +10927,7 @@ where
         }
     }
 
+    // proxy-ok: downloads wheels/assets from the public internet
     let client = reqwest::blocking::Client::builder()
         .user_agent(concat!("headroom-desktop/", env!("CARGO_PKG_VERSION")))
         .connect_timeout(Duration::from_secs(30))

--- a/src-tauri/src/tool_manager.rs
+++ b/src-tauri/src/tool_manager.rs
@@ -9181,10 +9181,32 @@ enum PortState {
 /// rather than three loose copies of the same literal.
 const UNKNOWN_OCCUPANT: &str = "unknown process";
 
+/// Occupant string for a port Windows refuses outright (WSAEACCES). Not
+/// `UNKNOWN_OCCUPANT`: no process holds the port, so `settle_unowned_port`
+/// must not wait 3s for a socket that is not draining, and the report must not
+/// claim a holder the user could go and quit.
+const DENIED_OCCUPANT: &str = "Windows itself (WinError 10013)";
+
+/// A bind refused for lack of permission rather than because something is
+/// there: a reserved/excluded port range (Hyper-V, WSL2, Docker) or security
+/// software filtering loopback. Windows-only in practice -- the signal keys on
+/// the 10013 code, so a Unix EACCES (os error 13) does not match.
+fn bind_denied_by_os(err: &std::io::Error) -> bool {
+    crate::is_loopback_socket_denied_signal(&err.to_string())
+}
+
 fn diagnose_proxy_port(port: u16) -> PortState {
     // If we can bind the port, nothing is there.
-    if TcpListener::bind(("127.0.0.1", port)).is_ok() {
-        return PortState::Free;
+    match TcpListener::bind(("127.0.0.1", port)) {
+        Ok(_) => return PortState::Free,
+        // Held and denied are different failures with the same errno slot:
+        // this one has no occupant to probe, name, or wait out, and calling it
+        // "held by unknown process" sent RUST-ED's reporter after a squatter
+        // that does not exist. Fall back to another port either way.
+        Err(err) if bind_denied_by_os(&err) => {
+            return PortState::ForeignOccupant(DENIED_OCCUPANT.into());
+        }
+        Err(_) => {}
     }
 
     // Port is held. Probe it: headroom's proxy speaks HTTP and, for an
@@ -14457,6 +14479,25 @@ mod tests {
         );
         assert!(matches!(state, PortState::Free));
         assert_eq!(calls.get(), 3);
+    }
+
+    /// RUST-ED: 6768 refused with WSAEACCES was reported as "held by unknown
+    /// process", which names a squatter the user cannot find and makes
+    /// `settle_unowned_port` wait out a socket that is not draining.
+    #[test]
+    fn a_denied_bind_is_not_reported_as_an_unknown_holder() {
+        use super::{bind_denied_by_os, DENIED_OCCUPANT, UNKNOWN_OCCUPANT};
+        use std::io::Error;
+
+        assert!(bind_denied_by_os(&Error::from_raw_os_error(10013)));
+        // In use (Windows and Unix) is a real holder, not a denial.
+        assert!(!bind_denied_by_os(&Error::from_raw_os_error(10048)));
+        assert!(!bind_denied_by_os(&Error::from_raw_os_error(48)));
+        // Unix EACCES is a privileged port, nothing to do with WSAEACCES.
+        assert!(!bind_denied_by_os(&Error::from_raw_os_error(13)));
+        // The settle loop keys on this exact shape.
+        assert_ne!(DENIED_OCCUPANT, UNKNOWN_OCCUPANT);
+        assert!(DENIED_OCCUPANT.contains("10013"));
     }
 
     /// The boot-validation failure path reports the occupant, not just a

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.15-rc.6",
+  "version": "0.9.15-rc.7",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.15-rc.10",
+  "version": "0.9.15",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.15-rc.3",
+  "version": "0.9.15-rc.4",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.15-rc.1",
+  "version": "0.9.15-rc.2",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.15-rc.4",
+  "version": "0.9.15-rc.5",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.15-rc.5",
+  "version": "0.9.15-rc.6",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.15-rc.8",
+  "version": "0.9.15-rc.9",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.14",
+  "version": "0.9.15-rc.1",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.15-rc.7",
+  "version": "0.9.15-rc.8",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.15-rc.9",
+  "version": "0.9.15-rc.10",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Headroom",
-  "version": "0.9.15-rc.2",
+  "version": "0.9.15-rc.3",
   "identifier": "com.extraheadroom.headroom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5943,35 +5943,39 @@ export default function App() {
             <br />
             in the background
           </h1>
+          {/* Rows exist only when the user just came through client setup
+              (fresh entries from an upgrade start empty). Shown whether or
+              not savings already exist: a re-run after a first prompt still
+              has tools holding pre-setup settings. */}
+          {proxyVerificationRows.length > 0 ? (
+            <div className="connector-list">
+              {proxyVerificationRows.map((row) => (
+                <article className="connector-item" key={row.clientId}>
+                  <div>
+                    <h3>
+                      <span className="client-logo" aria-hidden="true">
+                        {renderConnectorLogo(row.clientId)}
+                      </span>
+                      {row.name}
+                    </h3>
+                    <div className="proxy-verify-item__message">
+                      <span>
+                        {proxyVerificationRowMessage(
+                          row,
+                          runningAgentCounts[row.clientId] ?? 0
+                        )}
+                      </span>
+                      {row.state === "verified" ? (
+                        <span className="proxy-verified-pill">verified</span>
+                      ) : null}
+                      </div>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            ) : null}
           {awaitingFirstSavings ? (
             <>
-              {proxyVerificationRows.length > 0 ? (
-                <div className="connector-list">
-                  {proxyVerificationRows.map((row) => (
-                    <article className="connector-item" key={row.clientId}>
-                      <div>
-                        <h3>
-                          <span className="client-logo" aria-hidden="true">
-                            {renderConnectorLogo(row.clientId)}
-                          </span>
-                          {row.name}
-                        </h3>
-                        <div className="proxy-verify-item__message">
-                          <span>
-                            {proxyVerificationRowMessage(
-                              row,
-                              runningAgentCounts[row.clientId] ?? 0
-                            )}
-                          </span>
-                          {row.state === "verified" ? (
-                            <span className="proxy-verified-pill">verified</span>
-                          ) : null}
-                        </div>
-                      </div>
-                    </article>
-                  ))}
-                </div>
-              ) : null}
               <FirstSavingsChecklist
                 onReopenSetup={() => setLauncherStage("client_setup")}
               />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4887,18 +4887,6 @@ export default function App() {
 
   const headroomTool = dashboard.tools.find((tool) => tool.id === "headroom");
   const headroomVersion = headroomTool?.version ?? "Unknown";
-  const lifetimeTotalTokensSent = dashboard.dailySavings.reduce(
-    (sum, point) => sum + point.totalTokensSent,
-    0
-  );
-  const lifetimeTotalTokensBeforeOptimization =
-    lifetimeTotalTokensSent + dashboard.lifetimeEstimatedTokensSaved;
-  const headroomLifetimeSavingsPct =
-    lifetimeTotalTokensBeforeOptimization > 0
-      ? (dashboard.lifetimeEstimatedTokensSaved /
-          lifetimeTotalTokensBeforeOptimization) *
-        100
-      : null;
   // Paired context for the savings headline. The headline rate dilutes as the
   // client's prompt caching improves, because cache reads sit in its
   // denominator while compression deliberately never touches the cached
@@ -4911,11 +4899,18 @@ export default function App() {
   // feeds it the lifetime breakdown as a single synthetic bucket;
   // cacheReadTokens is used only as an existence signal for coverage, never
   // ratioed against our own token counts.
+  //
+  // The numerator is compression ALONE, not lifetimeEstimatedSavingsUsd. That
+  // three-layer total also carries output shaping and tool-schema deferral,
+  // neither of which removes input, so pairing it with an input-cost
+  // denominator made all-time read above the two rows beside it (measured
+  // 2026-09-10: 17.0% against 11.6% this month, 2.2pp of the gap being the
+  // extra layers rather than better compression). Same layer as the windowed
+  // rows now, so the three are comparable.
   const cachePairAllTime = allTimeCacheHitPair(
     dashboard.savingsBreakdown,
-    dashboard.lifetimeEstimatedSavingsUsd
+    dashboard.savingsBreakdown?.compressionSavingsUsd ?? 0
   );
-  const compressionOfRestPct = cachePairAllTime?.compressedPct ?? null;
   // Same pair for the shorter windows, from the buckets that carry cache
   // coverage (backend history checkpoints; local-tracker buckets and days
   // aged out of retention are excluded from both rates). The all-time row
@@ -8127,13 +8122,6 @@ export default function App() {
                   <div className="runtime-status__meta">
                     <span className="runtime-status__section-title">
                       Headroom CLI ({headroomVersion})
-                      {(compressionOfRestPct ?? headroomLifetimeSavingsPct) !== null ? (
-                        <span className="runtime-status__section-context">
-                          {" "}
-                          ({percent1((compressionOfRestPct ?? headroomLifetimeSavingsPct)!)}% of
-                          billable input removed all-time)
-                        </span>
-                      ) : null}
                     </span>
                   </div>
                   <div className="runtime-status__grid runtime-status__grid--4">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -153,10 +153,9 @@ import {
 } from "./lib/dashboardHelpers";
 import {
   buildInitialProxyVerificationRows,
-  formatConnectorNameList,
   markIdleProxyVerificationRows,
   proxyVerificationRowMessage,
-  setupCheckSuccessMessage,
+  summarizeSetupCheck,
   testableProxyVerificationRows,
   type ProxyVerificationRowState,
   getClaudeConnector,
@@ -1661,20 +1660,12 @@ export default function App() {
     []
   );
   const [runningAgentCounts, setRunningAgentCounts] = useState<Record<string, number>>({});
-  // Result of the on-demand config check, or null when it has not been run.
-  const [setupCheck, setSetupCheck] = useState<
-    { busy: true } | { busy: false; ok: boolean; lines: string[] } | null
-  >(null);
+  // Result of the verify screen's background config check, null until the
+  // first one completes.
+  const [setupCheck, setSetupCheck] = useState<{ ok: boolean; lines: string[] } | null>(null);
   const [proxyVerificationHint, setProxyVerificationHint] = useState<
     { text: string; tone: "info" | "error" } | null
   >(null);
-  // Leaving the verify step unverified takes two clicks: the first arms the
-  // warning, the second leaves. 86% of installs used to click straight past
-  // this screen (median 26s, 45% under 15s) and the ones that did went on to
-  // send a first prompt 59% of the time vs 76% for the ones that waited -- the
-  // single biggest activation leak in onboarding, and invisible in support
-  // reports because nothing errors.
-  const [proxyVerifySkipArmed, setProxyVerifySkipArmed] = useState(false);
   const proxyVerificationRequestAnchorRef = useRef<Record<string, number> | null>(null);
   const [runtimeStatus, setRuntimeStatus] = useState<RuntimeStatus | null>(null);
   // Fresh install (no runtime on disk yet). Drives the onboarding email-harvest
@@ -2541,6 +2532,44 @@ export default function App() {
     };
   }, [windowLabel, launcherStage, interceptOnlyVerify]);
 
+  // The verify screen's config check runs by itself: reads config off disk
+  // plus proxy reachability, the same check `repair_client_setups` trusts
+  // hourly. A pass turns Finish into the primary action; the user never had
+  // to click "Check my setup" to learn that nothing is broken.
+  const proxyVerificationClientIds = proxyVerificationRows
+    .map((row) => row.clientId)
+    .join(",");
+  useEffect(() => {
+    if (
+      windowLabel !== "launcher" ||
+      launcherStage !== "proxy_verify" ||
+      proxyVerificationClientIds === ""
+    ) {
+      return;
+    }
+    let active = true;
+    const check = () => {
+      // Dormant tools are shown but not tested, same as the rows themselves.
+      const testable = testableProxyVerificationRows(proxyVerificationRows);
+      const targets = testable.length > 0 ? testable : proxyVerificationRows;
+      void Promise.all(
+        targets.map((row) =>
+          invoke<ClientSetupVerification>("verify_client_setup", { clientId: row.clientId })
+            .then((verification) => ({ name: row.name, verification }))
+            .catch(() => ({ name: row.name, verification: null }))
+        )
+      ).then((results) => {
+        if (active) setSetupCheck(summarizeSetupCheck(results));
+      });
+    };
+    check();
+    const interval = window.setInterval(check, 3000);
+    return () => {
+      active = false;
+      window.clearInterval(interval);
+    };
+  }, [windowLabel, launcherStage, proxyVerificationClientIds]);
+
   // Live agent processes for the verify screen's restart callout: sessions
   // started before setup keep their pre-Headroom environment, and naming them
   // turns "restart each tool" from generic advice into a concrete instruction.
@@ -2636,16 +2665,6 @@ export default function App() {
       reportFunnelStep("proxy_verified");
     }
   }, [windowLabel, launcherStage, proxyVerificationRows]);
-
-  // A connector checking in invalidates the armed skip warning: it was written
-  // against the old unverified set and reads as "we still see nothing" even
-  // after the user did exactly what it asked. Re-arm on the next Skip click.
-  const proxyVerifiedCount = proxyVerificationRows.filter(
-    (row) => row.state === "verified"
-  ).length;
-  useEffect(() => {
-    if (proxyVerifiedCount > 0) setProxyVerifySkipArmed(false);
-  }, [proxyVerifiedCount]);
 
   useEffect(() => {
     if (!showInstallProgress) {
@@ -4792,7 +4811,7 @@ export default function App() {
 
     setLauncherStage("proxy_verify");
     setProxyVerificationHint(null);
-    setProxyVerifySkipArmed(false);
+    setSetupCheck(null);
     setProxyVerificationRows(buildInitialProxyVerificationRows(fresh));
     // Reset to null so the polling effect re-anchors on its first reachable
     // /stats reading. Setting it here would risk anchoring on a stale value
@@ -5816,57 +5835,12 @@ export default function App() {
     // A dormant tool is displayed but not tested: it can never turn green, and
     // counting it withholds the success button from a healthy install forever.
     const testableRows = testableProxyVerificationRows(proxyVerificationRows);
-    const allIdle = hasEnabledApps && testableRows.length === 0;
     const allVerified = testableRows.length > 0 && testableRows.every((row) => row.state === "verified");
     const anyVerified = proxyVerificationRows.some((row) => row.state === "verified");
-    // Answers "is it broken, or am I just waiting?" without the user having to
-    // guess. Reads config off disk plus proxy reachability -- the same check
-    // `repair_client_setups` already trusts hourly -- so a pass is real
-    // evidence that the only thing left to do is restart the tool.
-    const runSetupCheck = async () => {
-      setSetupCheck({ busy: true });
-      const targets = testableRows.length > 0 ? testableRows : proxyVerificationRows;
-      const results = await Promise.all(
-        targets.map((row) =>
-          invoke<ClientSetupVerification>("verify_client_setup", { clientId: row.clientId })
-            .then((verification) => ({ row, verification }))
-            .catch(() => ({ row, verification: null }))
-        )
-      );
-      const unreadable = results.filter((result) => result.verification === null);
-      const failures = results.flatMap(({ row, verification }) =>
-        verification && !verification.verified
-          ? verification.failures.map((failure) => `${row.name}: ${failure}`)
-          : []
-      );
-      if (unreadable.length > 0) {
-        setSetupCheck({
-          busy: false,
-          ok: false,
-          lines: [
-            `Could not read the setup for ${formatConnectorNameList(
-              unreadable.map(({ row }) => row.name)
-            )}.`
-          ]
-        });
-      } else if (failures.length > 0) {
-        setSetupCheck({ busy: false, ok: false, lines: failures });
-      } else if (!results.some(({ verification }) => verification?.proxyReachable)) {
-        setSetupCheck({
-          busy: false,
-          ok: false,
-          lines: [
-            "Your tools are pointed at Headroom, but the proxy is not answering on 127.0.0.1:6767 yet. Give it a few seconds and check again."
-          ]
-        });
-      } else {
-        setSetupCheck({
-          busy: false,
-          ok: true,
-          lines: [setupCheckSuccessMessage(proxyVerificationRows)]
-        });
-      }
-    };
+    // Finish is the happy path once the config check has passed or a tool has
+    // already come through. Until then leaving is allowed but must not look
+    // like the happy path: it is the road to "Headroom didn't work" emails.
+    const canFinish = anyVerified || setupCheck?.ok === true;
     const finishSetup = () => {
       void invoke("complete_setup_wizard");
       setLauncherStage("post_install");
@@ -5881,19 +5855,10 @@ export default function App() {
         version={appSemver}
       >
         <div className="post-install__lead">
-          <h1>Test your setup</h1>
+          <h1>Restart your tools</h1>
           <p>
-            Restart each tool below, then send it any message to test its connection with Headroom. 
-            "Say hi" is enough. If restarting doesn't work, contact{" "}
-            <button
-              className="install-progress__notice-link"
-              onClick={() =>
-                void invoke("open_external_link", { url: "mailto:support@extraheadroom.com" })}
-              type="button"
-            >
-              support@extraheadroom.com
-            </button>{" "}
-            for help.
+            Tools that were already open still use their old settings, so each one needs a
+            restart. Any message afterwards, even "hi", confirms the connection.
           </p>
           {hasEnabledApps ? (
             <div className="connector-list">
@@ -5923,21 +5888,22 @@ export default function App() {
               No tools are enabled yet. Go back to the previous step to enable one.
             </p>
           )}
-          {hasEnabledApps ? (
-            <p className="launcher-restart-hint">
+          {setupCheck?.ok ? (
+            <p className="launcher-restart-hint">Headroom is set up and running.</p>
+          ) : setupCheck && !proxyVerificationHint ? (
+            // The startup hint below already explains an unreachable proxy on
+            // first launch, so the check only speaks when the hint does not.
+            <p className="install-progress__error">
+              {setupCheck.lines.join(" ")} If this does not clear, contact{" "}
               <button
-                className="secondary-button"
-                disabled={setupCheck?.busy === true}
-                onClick={() => void runSetupCheck()}
+                className="install-progress__notice-link"
+                onClick={() =>
+                  void invoke("open_external_link", { url: "mailto:support@extraheadroom.com" })}
                 type="button"
               >
-                {setupCheck?.busy ? "Checking..." : "Check my setup"}
+                support@extraheadroom.com
               </button>
-            </p>
-          ) : null}
-          {setupCheck && !setupCheck.busy ? (
-            <p className={setupCheck.ok ? "launcher-restart-hint" : "install-progress__error"}>
-              {setupCheck.lines.join(" ")}
+              .
             </p>
           ) : null}
           {proxyVerificationHint ? (
@@ -5951,43 +5917,6 @@ export default function App() {
               {proxyVerificationHint.text}
             </p>
           ) : null}
-          {!allVerified && proxyVerifySkipArmed ? (
-            <p className="install-progress__notice">
-              {allIdle
-                ? "None of your connected tools have been used on this machine recently, so there is nothing to test right now. Headroom is set up and starts saving the moment you use one."
-                : hasEnabledApps
-                  ? // The row for each tool and the setup-check result both
-                    // already say what is pending and what to do about it, so
-                    // this one only has to answer "is skipping safe?".
-                    "You can continue either way: Headroom starts saving as soon as it sees traffic."
-                  : "Headroom has nothing to optimize until a coding agent is connected. Install Claude Code or Codex, then connect it here or later from within the app."}
-              <br />
-              <br />
-              <strong>Note:</strong> Headroom does not work with the Claude Desktop app due to
-              design decisions by Anthropic. You need to use Claude Code{" "}
-              <button
-                className="install-progress__notice-link"
-                onClick={() =>
-                  void invoke("open_external_link", {
-                    url: "https://code.claude.com/docs/en/quickstart#step-1-install-claude-code"
-                  })}
-                type="button"
-              >
-                in the CLI
-              </button>{" "}
-              or{" "}
-              <button
-                className="install-progress__notice-link"
-                onClick={() =>
-                  void invoke("open_external_link", {
-                    url: "https://code.claude.com/docs/en/overview#vs-code"
-                  })}
-                type="button"
-              >
-                in VS Code
-              </button>
-            </p>
-          ) : null}
         </div>
         <div className="post-install__actions">
           <button
@@ -5999,40 +5928,19 @@ export default function App() {
           >
             Back
           </button>
-          {allVerified ? (
+          {canFinish ? (
             <button
-              className="primary-button primary-button--large primary-button--success"
+              className={`primary-button primary-button--large${
+                allVerified ? " primary-button--success" : ""
+              }`}
               onClick={finishSetup}
               type="button"
             >
-              Continue
-            </button>
-          ) : anyVerified ? (
-            // At least one connector is proven working, so continuing is a
-            // legitimate path - no skip-arming friction needed.
-            <button
-              className="primary-button primary-button--large"
-              onClick={finishSetup}
-              type="button"
-            >
-              Continue
+              Finish
             </button>
           ) : (
-            // Deliberately not a primary button: leaving without a single
-            // verified connector is the path that ends in "Headroom didn't
-            // work", so it should not look like the happy path.
-            <button
-              className="secondary-button"
-              onClick={() => {
-                if (proxyVerifySkipArmed) {
-                  finishSetup();
-                  return;
-                }
-                setProxyVerifySkipArmed(true);
-              }}
-              type="button"
-            >
-              {proxyVerifySkipArmed ? "Skip anyway" : "Skip for now"}
+            <button className="secondary-button" onClick={finishSetup} type="button">
+              Skip for now
             </button>
           )}
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -155,8 +155,6 @@ import {
   buildInitialProxyVerificationRows,
   markIdleProxyVerificationRows,
   proxyVerificationRowMessage,
-  summarizeSetupCheck,
-  testableProxyVerificationRows,
   type ProxyVerificationRowState,
   getClaudeConnector,
   getContactRequestValidationError,
@@ -208,7 +206,6 @@ import type {
   ClientConnectorStatus,
   UnroutedClient,
   ClientSetupResult,
-  ClientSetupVerification,
   DailySavingsPoint,
   DashboardState,
   DebugOverrides,
@@ -497,7 +494,6 @@ function reportFunnelStep(step: InstallWizardStep): void {
 // screen is captured by `signup_gate_shown`, not a launcher stage.
 const LAUNCHER_STAGE_STEP: Partial<Record<LauncherStage, InstallWizardStep>> = {
   client_setup: "client_setup_shown",
-  proxy_verify: "proxy_verify_started",
   post_install: "post_install_shown"
 };
 
@@ -533,8 +529,8 @@ function FirstSavingsChecklist({ onReopenSetup }: { onReopenSetup: () => void })
   return (
     <div className="post-install__checklist">
       <p>
-        Use a connected coding agent as normal and your savings appear here. No
-        project in mind? Paste this into your agent to see it work.
+        Tools that were already open still use their old settings, so restart them.
+        Then paste this into one and your first savings appear here.
       </p>
       <div className="post-install__starter">
         <code>{STARTER_PROMPT}</code>
@@ -1660,9 +1656,6 @@ export default function App() {
     []
   );
   const [runningAgentCounts, setRunningAgentCounts] = useState<Record<string, number>>({});
-  // Result of the verify screen's background config check, null until the
-  // first one completes.
-  const [setupCheck, setSetupCheck] = useState<{ ok: boolean; lines: string[] } | null>(null);
   const [proxyVerificationHint, setProxyVerificationHint] = useState<
     { text: string; tone: "info" | "error" } | null
   >(null);
@@ -1676,7 +1669,7 @@ export default function App() {
   // Verify against the always-up 6767 intercept (which counts passthrough
   // traffic) instead of the backend whenever the backend won't be optimizing:
   // pre-install, or when the pricing gate has bypassed it (e.g. ended trial).
-  // Otherwise proxy_verify waits forever on a backend that never comes up.
+  // Otherwise the post-install rows wait forever on a backend that never comes up.
   const interceptOnlyVerify =
     paywallFirstFlow || runtimeStatus?.bypassed === true;
   const [resuming, setResuming] = useState(false);
@@ -2446,7 +2439,7 @@ export default function App() {
   }, [windowLabel, launcherStage, pricingStatus?.account?.subscriptionActive]);
 
   useEffect(() => {
-    if (windowLabel !== "launcher" || launcherStage !== "proxy_verify") {
+    if (windowLabel !== "launcher" || launcherStage !== "post_install") {
       return;
     }
 
@@ -2532,50 +2525,12 @@ export default function App() {
     };
   }, [windowLabel, launcherStage, interceptOnlyVerify]);
 
-  // The verify screen's config check runs by itself: reads config off disk
-  // plus proxy reachability, the same check `repair_client_setups` trusts
-  // hourly. A pass turns Finish into the primary action; the user never had
-  // to click "Check my setup" to learn that nothing is broken.
-  const proxyVerificationClientIds = proxyVerificationRows
-    .map((row) => row.clientId)
-    .join(",");
-  useEffect(() => {
-    if (
-      windowLabel !== "launcher" ||
-      launcherStage !== "proxy_verify" ||
-      proxyVerificationClientIds === ""
-    ) {
-      return;
-    }
-    let active = true;
-    const check = () => {
-      // Dormant tools are shown but not tested, same as the rows themselves.
-      const testable = testableProxyVerificationRows(proxyVerificationRows);
-      const targets = testable.length > 0 ? testable : proxyVerificationRows;
-      void Promise.all(
-        targets.map((row) =>
-          invoke<ClientSetupVerification>("verify_client_setup", { clientId: row.clientId })
-            .then((verification) => ({ name: row.name, verification }))
-            .catch(() => ({ name: row.name, verification: null }))
-        )
-      ).then((results) => {
-        if (active) setSetupCheck(summarizeSetupCheck(results));
-      });
-    };
-    check();
-    const interval = window.setInterval(check, 3000);
-    return () => {
-      active = false;
-      window.clearInterval(interval);
-    };
-  }, [windowLabel, launcherStage, proxyVerificationClientIds]);
-
-  // Live agent processes for the verify screen's restart callout: sessions
+  // Live agent processes for the post-install restart rows: sessions
   // started before setup keep their pre-Headroom environment, and naming them
   // turns "restart each tool" from generic advice into a concrete instruction.
   // One ps/tasklist spawn per poll, so only while this stage is showing.
   useEffect(() => {
-    if (windowLabel !== "launcher" || launcherStage !== "proxy_verify") {
+    if (windowLabel !== "launcher" || launcherStage !== "post_install") {
       return;
     }
     let active = true;
@@ -2601,7 +2556,7 @@ export default function App() {
   // entries, and an agent that starts being used mid-screen announces itself by
   // producing traffic, which flips the row regardless of its idle mark.
   useEffect(() => {
-    if (windowLabel !== "launcher" || launcherStage !== "proxy_verify") {
+    if (windowLabel !== "launcher" || launcherStage !== "post_install") {
       return;
     }
     let active = true;
@@ -2653,7 +2608,7 @@ export default function App() {
 
   // proxy_verified: every enabled client's test traffic reached the proxy.
   useEffect(() => {
-    if (windowLabel !== "launcher" || launcherStage !== "proxy_verify") return;
+    if (windowLabel !== "launcher" || launcherStage !== "post_install") return;
     if (
       proxyVerificationRows.length > 0 &&
       proxyVerificationRows.every((row) => row.state === "verified")
@@ -4170,13 +4125,13 @@ export default function App() {
         const postApplyStep = nextAutoConfigureStepAfterApply(
           getLauncherAutoConfigureDecision(latestConnectors)
         );
-        if (postApplyStep.kind !== "begin_proxy_verification") {
+        if (postApplyStep.kind !== "begin_post_install") {
           setLauncherStage("client_setup");
           return;
         }
       }
 
-      await beginProxyVerificationStep();
+      await beginPostInstallStep();
     } catch (error) {
       setConnectorsError(
         describeInvokeError(error, "Could not configure your coding tools automatically.")
@@ -4800,7 +4755,7 @@ export default function App() {
     }
   }
 
-  async function beginProxyVerificationStep() {
+  async function beginPostInstallStep() {
     let fresh = connectors;
     try {
       fresh = await fetchConnectors();
@@ -4809,9 +4764,8 @@ export default function App() {
       // fall back to cached state
     }
 
-    setLauncherStage("proxy_verify");
+    setLauncherStage("post_install");
     setProxyVerificationHint(null);
-    setSetupCheck(null);
     setProxyVerificationRows(buildInitialProxyVerificationRows(fresh));
     // Reset to null so the polling effect re-anchors on its first reachable
     // /stats reading. Setting it here would risk anchoring on a stale value
@@ -5619,7 +5573,7 @@ export default function App() {
               className="secondary-button"
               disabled={connectorsBusy}
               onClick={() => {
-                void beginProxyVerificationStep();
+                void beginPostInstallStep();
               }}
               type="button"
             >
@@ -5812,132 +5766,12 @@ export default function App() {
             className="primary-button primary-button--large primary-button--success"
             disabled={connectorsBusy || (requireSelection && enabledConnectorCount === 0)}
             onClick={() => {
-              void beginProxyVerificationStep();
+              void beginPostInstallStep();
             }}
             type="button"
           >
             Continue
           </button>
-        </div>
-      </LauncherShell>
-    );
-  }
-
-  if (
-    windowLabel === "launcher" && launcherStage === "proxy_verify"
-  ) {
-    const hasEnabledApps = proxyVerificationRows.length > 0;
-    // A dormant tool is displayed but not tested: it can never turn green, and
-    // counting it withholds the success button from a healthy install forever.
-    const testableRows = testableProxyVerificationRows(proxyVerificationRows);
-    const allVerified = testableRows.length > 0 && testableRows.every((row) => row.state === "verified");
-    const anyVerified = proxyVerificationRows.some((row) => row.state === "verified");
-    // Finish is the happy path once the config check has passed or a tool has
-    // already come through. Until then leaving is allowed but must not look
-    // like the happy path: it is the road to "Headroom didn't work" emails.
-    const canFinish = anyVerified || setupCheck?.ok === true;
-    const finishSetup = () => {
-      void invoke("complete_setup_wizard");
-      setLauncherStage("post_install");
-    };
-
-    return (
-      <LauncherShell
-        shellClassName="intro-shell intro-shell--post-install"
-        spinnerClassName="intro-shell__spinner intro-shell__spinner--post-install"
-        copyClassName="intro-shell__copy intro-shell__copy--post-install"
-        onMouseDown={handleLauncherSurfaceMouseDown}
-        version={appSemver}
-      >
-        <div className="post-install__lead">
-          <h1>Restart your tools</h1>
-          <p>
-            Tools that were already open still use their old settings, so each one needs a
-            restart. Any message afterwards, even "hi", confirms the connection.
-          </p>
-          {hasEnabledApps ? (
-            <div className="connector-list">
-              {proxyVerificationRows.map((row) => (
-                <article className="connector-item" key={row.clientId}>
-                  <div>
-                    <h3>
-                      <span className="client-logo" aria-hidden="true">
-                        {renderConnectorLogo(row.clientId)}
-                      </span>
-                      {row.name}
-                    </h3>
-                    <div className="proxy-verify-item__message">
-                      <span>
-                        {proxyVerificationRowMessage(row, runningAgentCounts[row.clientId] ?? 0)}
-                      </span>
-                      {row.state === "verified" ? (
-                        <span className="proxy-verified-pill">verified</span>
-                      ) : null}
-                    </div>
-                  </div>
-                </article>
-              ))}
-            </div>
-          ) : (
-            <p className="launcher-restart-hint">
-              No tools are enabled yet. Go back to the previous step to enable one.
-            </p>
-          )}
-          {setupCheck?.ok ? (
-            <p className="launcher-restart-hint">Headroom is set up and running.</p>
-          ) : setupCheck && !proxyVerificationHint ? (
-            // The startup hint below already explains an unreachable proxy on
-            // first launch, so the check only speaks when the hint does not.
-            <p className="install-progress__error">
-              {setupCheck.lines.join(" ")} If this does not clear, contact{" "}
-              <button
-                className="install-progress__notice-link"
-                onClick={() =>
-                  void invoke("open_external_link", { url: "mailto:support@extraheadroom.com" })}
-                type="button"
-              >
-                support@extraheadroom.com
-              </button>
-              .
-            </p>
-          ) : null}
-          {proxyVerificationHint ? (
-            <p
-              className={
-                proxyVerificationHint.tone === "error"
-                  ? "install-progress__error"
-                  : "launcher-restart-hint"
-              }
-            >
-              {proxyVerificationHint.text}
-            </p>
-          ) : null}
-        </div>
-        <div className="post-install__actions">
-          <button
-            className="secondary-button post-install__reopen-setup"
-            onClick={() => {
-              setLauncherStage("client_setup");
-            }}
-            type="button"
-          >
-            Back
-          </button>
-          {canFinish ? (
-            <button
-              className={`primary-button primary-button--large${
-                allVerified ? " primary-button--success" : ""
-              }`}
-              onClick={finishSetup}
-              type="button"
-            >
-              Finish
-            </button>
-          ) : (
-            <button className="secondary-button" onClick={finishSetup} type="button">
-              Skip for now
-            </button>
-          )}
         </div>
       </LauncherShell>
     );
@@ -6110,9 +5944,49 @@ export default function App() {
             in the background
           </h1>
           {awaitingFirstSavings ? (
-            <FirstSavingsChecklist
-              onReopenSetup={() => setLauncherStage("client_setup")}
-            />
+            <>
+              {proxyVerificationRows.length > 0 ? (
+                <div className="connector-list">
+                  {proxyVerificationRows.map((row) => (
+                    <article className="connector-item" key={row.clientId}>
+                      <div>
+                        <h3>
+                          <span className="client-logo" aria-hidden="true">
+                            {renderConnectorLogo(row.clientId)}
+                          </span>
+                          {row.name}
+                        </h3>
+                        <div className="proxy-verify-item__message">
+                          <span>
+                            {proxyVerificationRowMessage(
+                              row,
+                              runningAgentCounts[row.clientId] ?? 0
+                            )}
+                          </span>
+                          {row.state === "verified" ? (
+                            <span className="proxy-verified-pill">verified</span>
+                          ) : null}
+                        </div>
+                      </div>
+                    </article>
+                  ))}
+                </div>
+              ) : null}
+              <FirstSavingsChecklist
+                onReopenSetup={() => setLauncherStage("client_setup")}
+              />
+              {proxyVerificationHint ? (
+                <p
+                  className={
+                    proxyVerificationHint.tone === "error"
+                      ? "install-progress__error"
+                      : "launcher-restart-hint"
+                  }
+                >
+                  {proxyVerificationHint.text}
+                </p>
+              ) : null}
+            </>
           ) : (
             <>
               <p>
@@ -6147,7 +6021,7 @@ export default function App() {
           <button
             className="secondary-button post-install__reopen-setup"
             onClick={() => {
-              void beginProxyVerificationStep();
+              setLauncherStage("client_setup");
             }}
             type="button"
           >

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1623,6 +1623,9 @@ export default function App() {
   const [openConnectorWarningId, setOpenConnectorWarningId] = useState<string | null>(null);
   const [connectorsBusy, setConnectorsBusy] = useState(false);
   const [claudeInstallBusy, setClaudeInstallBusy] = useState(false);
+  // Claude Desktop on disk. It is not a client we can route (host-managed
+  // provider env), so the no-clients and no-agent copy has to say so.
+  const [claudeDesktopInstalled, setClaudeDesktopInstalled] = useState(false);
   const [connectorPhase, setConnectorPhase] = useState<"disabled" | "verifying" | "healthy">(
     () => (isConnectorTrafficVerified() ? "healthy" : "verifying")
   );
@@ -2558,6 +2561,9 @@ export default function App() {
   useEffect(() => {
     if (windowLabel !== "launcher") return;
     void invoke("prefetch_bootstrap_artifacts").catch(() => {});
+    void invoke<boolean>("claude_desktop_installed")
+      .then(setClaudeDesktopInstalled)
+      .catch(() => {});
   }, [windowLabel]);
 
   // One beacon per launcher stage the user reaches. Single source for the
@@ -5473,11 +5479,20 @@ export default function App() {
         >
           <div className="post-install__lead">
             <h1>Install a coding agent first</h1>
-            <p>
-              Headroom saves tokens by routing an AI coding tool you already use
-              through its local proxy, and no supported tool was found on this
-              machine. Install Claude Code, sign in, then check again.
-            </p>
+            {claudeDesktopInstalled ? (
+              <p className="install-progress__notice">
+                <strong>The Claude Desktop app was found, but Headroom cannot work with it.</strong>{" "}
+                Anthropic pins the Claude Code built into the desktop app to its own servers,
+                so nothing Headroom configures reaches it. Claude Code in your terminal or in
+                VS Code runs on the same subscription and works fully. Install it below.
+              </p>
+            ) : (
+              <p>
+                Headroom saves tokens by routing an AI coding tool you already use
+                through its local proxy, and no supported tool was found on this
+                machine. Install Claude Code, sign in, then check again.
+              </p>
+            )}
             <div className="install-prompt" role="status">
               <header className="install-prompt__head">
                 <span className="install-prompt__icon" aria-hidden="true">
@@ -5524,10 +5539,12 @@ export default function App() {
               Also works with ChatGPT Codex, OpenCode, and Grok. Install any of
               them, then check again.
             </p>
-            <p>
-              Note: unfortunately Headroom does not work with the Claude Desktop
-              app due to design decisions by Anthropic.
-            </p>
+            {claudeDesktopInstalled ? null : (
+              <p>
+                Note: unfortunately Headroom does not work with the Claude Desktop
+                app due to design decisions by Anthropic.
+              </p>
+            )}
             {connectorsError ? (
               <p className="install-progress__error">{connectorsError}</p>
             ) : null}
@@ -5903,6 +5920,11 @@ export default function App() {
     // entries from an upgrade start empty). Shown whether or not savings
     // already exist: a re-run after a first prompt still has tools holding
     // pre-setup settings.
+    // "Skip for now" on the no-clients screen lands here with nothing
+    // connected; the restart-and-paste instructions would be a lie.
+    const hasConnectedAgent = aggregateClientConnectors(connectors).some(
+      (connector) => connector.enabled && connector.installed
+    );
     const restartRows =
       proxyVerificationRows.length > 0 ? (
         <div className="connector-list">
@@ -5947,7 +5969,18 @@ export default function App() {
       >
         <div className="post-install__lead">
           <h1>Headroom is now running</h1>
-          {awaitingFirstSavings ? (
+          {awaitingFirstSavings && !hasConnectedAgent ? (
+            <div className="post-install__checklist">
+              <p>
+                No coding agent is connected yet, so Headroom has nothing to optimize.
+                Install Claude Code or Codex, then connect it from the Back button here or
+                later from the Headroom window.
+                {claudeDesktopInstalled
+                  ? " The Claude Desktop app does not count: Anthropic pins its built-in Claude Code to its own servers, so Headroom cannot route it."
+                  : ""}
+              </p>
+            </div>
+          ) : awaitingFirstSavings ? (
             <div className="post-install__checklist">
               <p>
                 In order to start using Headroom you first need to restart your AI Agents.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5492,8 +5492,8 @@ export default function App() {
             {claudeDesktopInstalled ? (
               <p className="install-progress__notice">
                 <strong>You have the Claude Desktop app, but Headroom cannot work with it.</strong>{" "}
-                Due to design decision by Anthropic, we are unable to inject our compression logic.
-                Instead, please use Claude Code in your terminal or in VS Code
+                Due to design decisions by Anthropic, we are unable to apply our compression logic.
+                Instead, please use Claude Code in your terminal or in VS Code.
               </p>
             ) : (
               <p>
@@ -5931,9 +5931,15 @@ export default function App() {
     // pre-setup settings.
     // "Skip for now" on the no-clients screen lands here with nothing
     // connected; the restart-and-paste instructions would be a lie.
-    const hasConnectedAgent = aggregateClientConnectors(connectors).some(
-      (connector) => connector.enabled && connector.installed
-    );
+    // An EMPTY list means "not probed yet", not "no agent": `connectors` starts
+    // empty and `beginPostInstallStep` falls back to it when `fetchConnectors`
+    // throws, so one transient IPC error would otherwise tell a correctly
+    // configured machine it has no coding agent. Claiming that needs evidence.
+    const hasConnectedAgent =
+      connectors.length === 0 ||
+      aggregateClientConnectors(connectors).some(
+        (connector) => connector.enabled && connector.installed
+      );
     const restartRows =
       proxyVerificationRows.length > 0 ? (
         <div className="connector-list">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -515,23 +515,9 @@ const STARTER_PROMPT =
 // broken indicator. What earned its place is the starter prompt: sending one
 // real prompt is the actual gap here (10% of mature signups send exactly one
 // prompt ever), so hand over something paste-able that works in any repo.
-function FirstSavingsChecklist({ onReopenSetup }: { onReopenSetup: () => void }) {
+function StarterPrompt() {
   const [copied, setCopied] = useState(false);
-  // No traffic yet usually means it isn't reaching Headroom, not that the user
-  // hasn't acted. Offer a setup re-check, but only after a grace window:
-  // proxyReachable is false for ~1min on a healthy install while the backend
-  // binds, so an immediate prompt would nag on good installs.
-  const [showTroubleshoot, setShowTroubleshoot] = useState(false);
-  useEffect(() => {
-    const timer = window.setTimeout(() => setShowTroubleshoot(true), 20000);
-    return () => window.clearTimeout(timer);
-  }, []);
   return (
-    <div className="post-install__checklist">
-      <p>
-        In order to start using Headroom you first need to restart your AI Agents.
-        Then ask them to "Say hi" or paste the prompt below to see savings appear.
-      </p>
       <div className="post-install__starter">
         <code>{STARTER_PROMPT}</code>
         <button
@@ -547,16 +533,6 @@ function FirstSavingsChecklist({ onReopenSetup }: { onReopenSetup: () => void })
           {copied ? "Copied" : "Copy prompt"}
         </button>
       </div>
-      {showTroubleshoot && (
-        <button
-          type="button"
-          className="post-install__troubleshoot"
-          onClick={onReopenSetup}
-        >
-          Nothing showing up? Re-check setup.
-        </button>
-      )}
-    </div>
   );
 }
 
@@ -5923,6 +5899,38 @@ export default function App() {
   if (
     windowLabel === "launcher" && launcherStage === "post_install"
   ) {
+    // Rows exist only when the user just came through client setup (fresh
+    // entries from an upgrade start empty). Shown whether or not savings
+    // already exist: a re-run after a first prompt still has tools holding
+    // pre-setup settings.
+    const restartRows =
+      proxyVerificationRows.length > 0 ? (
+        <div className="connector-list">
+          {proxyVerificationRows.map((row) => (
+            <article className="connector-item" key={row.clientId}>
+              <div>
+                <h3>
+                  <span className="client-logo" aria-hidden="true">
+                    {renderConnectorLogo(row.clientId)}
+                  </span>
+                  {row.name}
+                </h3>
+                <div className="proxy-verify-item__message">
+                  <span>
+                    {proxyVerificationRowMessage(
+                      row,
+                      runningAgentCounts[row.clientId] ?? 0
+                    )}
+                  </span>
+                  {row.state === "verified" ? (
+                    <span className="proxy-verified-pill">verified</span>
+                  ) : null}
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : null;
     // The tray's 5s dashboard poll keeps running under the launcher window,
     // so a first-run user who sends a prompt sees this screen flip from
     // "waiting" to their first real savings without any interaction — the
@@ -5938,47 +5946,15 @@ export default function App() {
         version={appSemver}
       >
         <div className="post-install__lead">
-          <h1>
-            Headroom is now running
-            <br />
-            in the background
-          </h1>
-          {/* Rows exist only when the user just came through client setup
-              (fresh entries from an upgrade start empty). Shown whether or
-              not savings already exist: a re-run after a first prompt still
-              has tools holding pre-setup settings. */}
-          {proxyVerificationRows.length > 0 ? (
-            <div className="connector-list">
-              {proxyVerificationRows.map((row) => (
-                <article className="connector-item" key={row.clientId}>
-                  <div>
-                    <h3>
-                      <span className="client-logo" aria-hidden="true">
-                        {renderConnectorLogo(row.clientId)}
-                      </span>
-                      {row.name}
-                    </h3>
-                    <div className="proxy-verify-item__message">
-                      <span>
-                        {proxyVerificationRowMessage(
-                          row,
-                          runningAgentCounts[row.clientId] ?? 0
-                        )}
-                      </span>
-                      {row.state === "verified" ? (
-                        <span className="proxy-verified-pill">verified</span>
-                      ) : null}
-                      </div>
-                    </div>
-                  </article>
-                ))}
-              </div>
-            ) : null}
+          <h1>Headroom is now running</h1>
           {awaitingFirstSavings ? (
-            <>
-              <FirstSavingsChecklist
-                onReopenSetup={() => setLauncherStage("client_setup")}
-              />
+            <div className="post-install__checklist">
+              <p>
+                In order to start using Headroom you first need to restart your AI Agents.
+                Then ask them to "Say hi" or paste the prompt below to see savings appear.
+              </p>
+              {restartRows}
+              <StarterPrompt />
               {proxyVerificationHint ? (
                 <p
                   className={
@@ -5990,9 +5966,10 @@ export default function App() {
                   {proxyVerificationHint.text}
                 </p>
               ) : null}
-            </>
+            </div>
           ) : (
             <>
+              {restartRows}
               <p>
                 {dashboard.launchExperience === "first_run"
                   ? "That prompt went through Headroom — your first savings are in."

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1903,6 +1903,16 @@ export default function App() {
     dashboard.launchExperience === "first_run" &&
     dashboard.lifetimeEstimatedTokensSaved <= 0 &&
     dashboard.lifetimeEstimatedSavingsUsd <= 0;
+  // Savings on record are not proof the user has done anything: an already
+  // open Claude Code session sends small non-prompt calls, and one of those
+  // put $0.01 on a clean VM before any prompt was typed, flipping this screen
+  // to "your first savings are in" under rows still saying "restart"
+  // (2026-09-10). While restart rows exist, a row turning verified is the
+  // signal that the user's own tool came through.
+  const awaitingFirstPrompt =
+    awaitingFirstSavings ||
+    (proxyVerificationRows.length > 0 &&
+      !proxyVerificationRows.some((row) => row.state === "verified"));
   // Independent of launchExperience: any savings on record at all, which is
   // what retires the setup-stall watchdog below.
   const forcedSetupStall = debugOverrides?.setupStall ?? null;
@@ -2636,7 +2646,7 @@ export default function App() {
   }, [isLastScreen]);
 
   useEffect(() => {
-    if (!isLastScreen || awaitingFirstSavings) return;
+    if (!isLastScreen || awaitingFirstPrompt) return;
     let unlisten: (() => void) | undefined;
     void getCurrentWindow()
       .onFocusChanged(({ payload: focused }) => {
@@ -2646,7 +2656,7 @@ export default function App() {
         unlisten = fn;
       });
     return () => unlisten?.();
-  }, [isLastScreen, awaitingFirstSavings]);
+  }, [isLastScreen, awaitingFirstPrompt]);
 
   const optimizationBlocked = pricingStatus
     ? pricingStatus.needsAuthentication || !pricingStatus.optimizationAllowed
@@ -5957,7 +5967,7 @@ export default function App() {
     // "waiting" to their first real savings without any interaction — the
     // payoff moment stays inside onboarding instead of being deferred to a
     // later session that a third of signups never have. While waiting,
-    // blur-autohide is disarmed (see awaitingFirstSavings above).
+    // blur-autohide is disarmed (see awaitingFirstPrompt above).
     return (
       <LauncherShell
         shellClassName="intro-shell intro-shell--post-install"
@@ -5968,7 +5978,7 @@ export default function App() {
       >
         <div className="post-install__lead">
           <h1>Headroom is now running</h1>
-          {awaitingFirstSavings && !hasConnectedAgent ? (
+          {awaitingFirstPrompt && !hasConnectedAgent ? (
             <div className="post-install__checklist">
               <p>
                 No coding agent is connected yet, so Headroom has nothing to optimize.
@@ -5979,7 +5989,7 @@ export default function App() {
                   : ""}
               </p>
             </div>
-          ) : awaitingFirstSavings ? (
+          ) : awaitingFirstPrompt ? (
             <div className="post-install__checklist">
               <p>
                 In order to start using Headroom you first need to restart your AI Agents.
@@ -6004,7 +6014,7 @@ export default function App() {
               {restartRows}
               <p>
                 {dashboard.launchExperience === "first_run"
-                  ? "That prompt went through Headroom — your first savings are in."
+                  ? "That prompt went through Headroom. Your first savings are in."
                   : "It will trim prompt bloat whenever you use a connected coding agent."}
               </p>
               <div className="post-install__metrics">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -529,8 +529,8 @@ function FirstSavingsChecklist({ onReopenSetup }: { onReopenSetup: () => void })
   return (
     <div className="post-install__checklist">
       <p>
-        Tools that were already open still use their old settings, so restart them.
-        Then paste this into one and your first savings appear here.
+        In order to start using Headroom you first need to restart your AI Agents.
+        Then ask them to "Say hi" or paste the prompt below to see savings appear.
       </p>
       <div className="post-install__starter">
         <code>{STARTER_PROMPT}</code>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5481,16 +5481,15 @@ export default function App() {
             <h1>Install a coding agent first</h1>
             {claudeDesktopInstalled ? (
               <p className="install-progress__notice">
-                <strong>The Claude Desktop app was found, but Headroom cannot work with it.</strong>{" "}
-                Anthropic pins the Claude Code built into the desktop app to its own servers,
-                so nothing Headroom configures reaches it. Claude Code in your terminal or in
-                VS Code runs on the same subscription and works fully. Install it below.
+                <strong>You have the Claude Desktop app, but Headroom cannot work with it.</strong>{" "}
+                Due to design decision by Anthropic, we are unable to inject our compression logic.
+                Instead, please use Claude Code in your terminal or in VS Code
               </p>
             ) : (
               <p>
                 Headroom saves tokens by routing an AI coding tool you already use
                 through its local proxy, and no supported tool was found on this
-                machine. Install Claude Code, sign in, then check again.
+                machine. Install Claude Code or ChatGPT Codex, sign in and then check again.
               </p>
             )}
             <div className="install-prompt" role="status">

--- a/src/lib/dashboardHelpers.ts
+++ b/src/lib/dashboardHelpers.ts
@@ -140,17 +140,25 @@ export function cacheHitPair(
 /** The all-time cache-hit pair, from the lifetime breakdown rather than a
  * window of buckets. Null when the client has never cached anything: there is
  * no hit rate to report, and `cacheHitPair` would be dividing into an empty
- * window. */
+ * window.
+ *
+ * `compressionSavingsUsd` is INPUT COMPRESSION ALONE, and must be: the
+ * denominator here is an input-cost one, so pairing it with
+ * `lifetimeEstimatedSavingsUsd` (which also carries output shaping and tool-
+ * schema deferral, neither of which removes input) made the all-time row read
+ * above the windowed rows beside it -- 17.0% against 11.6% on the same machine,
+ * measured 2026-09-10. Named for the field, not for "lifetime savings", so the
+ * broader figure cannot be passed back in by accident. */
 export function allTimeCacheHitPair(
   breakdown: SavingsBreakdown | null | undefined,
-  lifetimeEstimatedSavingsUsd: number
+  compressionSavingsUsd: number
 ) {
   if (!breakdown || breakdown.cacheReadTokens <= 0) return null;
   return cacheHitPair([
     {
       cacheSavingsUsd: breakdown.cacheSavingsUsd,
       actualCostUsd: breakdown.totalInputCostUsd,
-      estimatedSavingsUsd: lifetimeEstimatedSavingsUsd
+      estimatedSavingsUsd: compressionSavingsUsd
     }
   ]);
 }

--- a/src/lib/launcherHelpers.test.ts
+++ b/src/lib/launcherHelpers.test.ts
@@ -5,7 +5,7 @@ import {
   formatConnectorNameList,
   markIdleProxyVerificationRows,
   proxyVerificationRowMessage,
-  setupCheckSuccessMessage,
+  summarizeSetupCheck,
   testableProxyVerificationRows,
   PROXY_VERIFY_IDLE_AFTER_SECONDS,
   getClaudeConnector,
@@ -370,15 +370,15 @@ describe("what the verify row says while it waits", () => {
     message: ""
   };
 
-  it("names the stale sessions when the tool is already running", () => {
-    expect(proxyVerificationRowMessage(row, 2)).toContain("2 sessions are running");
-    expect(proxyVerificationRowMessage(row, 2)).toContain("Quit and reopen Claude Code");
-    expect(proxyVerificationRowMessage(row, 1)).toContain("1 session is running");
+  it("says the tool is holding old settings without counting sessions", () => {
+    const message = proxyVerificationRowMessage(row, 10);
+    expect(message).toContain("Quit and reopen Claude Code");
+    expect(message).not.toMatch(/\d/);
   });
 
   it("asks the user to start the tool when nothing is running", () => {
     expect(proxyVerificationRowMessage(row, 0)).toBe(
-      "Not running yet. Open Claude Code and send it any message."
+      "Open Claude Code and send it any message."
     );
   });
 
@@ -393,37 +393,41 @@ describe("what the verify row says while it waits", () => {
   });
 });
 
-describe("setupCheckSuccessMessage", () => {
-  const row = (name: string, state: "processing" | "verified" | "idle") => ({
-    clientId: name.toLowerCase(),
+describe("summarizeSetupCheck", () => {
+  const ok = (name: string, proxyReachable = true) => ({
     name,
-    state,
-    message: ""
+    verification: { clientId: name, verified: true, proxyReachable, checks: [], failures: [] }
   });
 
-  it("does not ask for a restart once every testable tool is verified", () => {
-    const message = setupCheckSuccessMessage([
-      row("Claude Code", "verified"),
-      row("ChatGPT", "idle")
+  it("passes when every tool is configured and the proxy answers", () => {
+    expect(summarizeSetupCheck([ok("Claude Code"), ok("ChatGPT")])).toEqual({ ok: true, lines: [] });
+  });
+
+  it("names the tools it could not read", () => {
+    const result = summarizeSetupCheck([ok("Claude Code"), { name: "ChatGPT", verification: null }]);
+    expect(result.ok).toBe(false);
+    expect(result.lines).toEqual(["Could not read the setup for ChatGPT."]);
+  });
+
+  it("prefixes each failure with the tool name", () => {
+    const result = summarizeSetupCheck([
+      {
+        name: "ChatGPT",
+        verification: {
+          clientId: "codex",
+          verified: false,
+          proxyReachable: true,
+          checks: [],
+          failures: ["base URL is not Headroom"]
+        }
+      }
     ]);
-    expect(message).not.toContain("quit and reopen");
-    expect(message).toContain("nothing left to do");
+    expect(result).toEqual({ ok: false, lines: ["ChatGPT: base URL is not Headroom"] });
   });
 
-  it("names only the tools still waiting", () => {
-    const message = setupCheckSuccessMessage([
-      row("Claude Code", "verified"),
-      row("Cursor", "processing")
-    ]);
-    expect(message).toContain("no prompt from Cursor");
-    expect(message).not.toContain("Claude Code");
-    // The row for Cursor already carries the instruction.
-    expect(message).not.toContain("quit and reopen");
-  });
-
-  it("says there is nothing to test when every tool is dormant", () => {
-    const message = setupCheckSuccessMessage([row("ChatGPT", "idle")]);
-    expect(message).toContain("nothing to test");
-    expect(message).not.toContain("quit and reopen");
+  it("waits calmly when the config is right but the proxy is not up yet", () => {
+    const result = summarizeSetupCheck([ok("Claude Code", false)]);
+    expect(result.ok).toBe(false);
+    expect(result.lines[0]).toContain("not answering on 127.0.0.1:6767 yet");
   });
 });

--- a/src/lib/launcherHelpers.test.ts
+++ b/src/lib/launcherHelpers.test.ts
@@ -344,6 +344,14 @@ describe("proxy verification rows the screen should not be testing", () => {
     expect(testableProxyVerificationRows(rows).map((entry) => entry.clientId)).toEqual(["codex"]);
   });
 
+  it("sinks idle rows below the ones the user still has to restart", () => {
+    const rows = markIdleProxyVerificationRows([row("codex"), row("claude_code")], {
+      claude_code: 60
+    });
+
+    expect(rows.map((entry) => entry.clientId)).toEqual(["claude_code", "codex"]);
+  });
+
   it("treats activity older than the window as idle", () => {
     const rows = markIdleProxyVerificationRows([row("codex")], {
       codex: PROXY_VERIFY_IDLE_AFTER_SECONDS + 1

--- a/src/lib/launcherHelpers.test.ts
+++ b/src/lib/launcherHelpers.test.ts
@@ -5,7 +5,6 @@ import {
   formatConnectorNameList,
   markIdleProxyVerificationRows,
   proxyVerificationRowMessage,
-  summarizeSetupCheck,
   testableProxyVerificationRows,
   PROXY_VERIFY_IDLE_AFTER_SECONDS,
   getClaudeConnector,
@@ -117,7 +116,7 @@ describe("launcher helpers", () => {
           verified: false
         }
       ])
-    ).toBe("begin_proxy_verification");
+    ).toBe("begin_post_install");
     // Codex-only: a non-Claude tool drives the same auto-configure decision.
     expect(
       getLauncherAutoConfigureDecision([
@@ -248,17 +247,17 @@ describe("launcher helpers", () => {
       });
     });
 
-    it("routes begin_proxy_verification straight to proxy verification", () => {
-      expect(nextAutoConfigureStep("begin_proxy_verification", [])).toEqual({
-        kind: "begin_proxy_verification"
+    it("routes begin_post_install straight to the post-install screen", () => {
+      expect(nextAutoConfigureStep("begin_post_install", [])).toEqual({
+        kind: "begin_post_install"
       });
     });
   });
 
   describe("nextAutoConfigureStepAfterApply", () => {
     it("advances to proxy verification when apply produced a verified setup", () => {
-      expect(nextAutoConfigureStepAfterApply("begin_proxy_verification")).toEqual({
-        kind: "begin_proxy_verification"
+      expect(nextAutoConfigureStepAfterApply("begin_post_install")).toEqual({
+        kind: "begin_post_install"
       });
     });
 
@@ -378,7 +377,7 @@ describe("what the verify row says while it waits", () => {
 
   it("asks the user to start the tool when nothing is running", () => {
     expect(proxyVerificationRowMessage(row, 0)).toBe(
-      "Open Claude Code and send it any message."
+      "Open Claude Code and send it the prompt below."
     );
   });
 
@@ -393,41 +392,3 @@ describe("what the verify row says while it waits", () => {
   });
 });
 
-describe("summarizeSetupCheck", () => {
-  const ok = (name: string, proxyReachable = true) => ({
-    name,
-    verification: { clientId: name, verified: true, proxyReachable, checks: [], failures: [] }
-  });
-
-  it("passes when every tool is configured and the proxy answers", () => {
-    expect(summarizeSetupCheck([ok("Claude Code"), ok("ChatGPT")])).toEqual({ ok: true, lines: [] });
-  });
-
-  it("names the tools it could not read", () => {
-    const result = summarizeSetupCheck([ok("Claude Code"), { name: "ChatGPT", verification: null }]);
-    expect(result.ok).toBe(false);
-    expect(result.lines).toEqual(["Could not read the setup for ChatGPT."]);
-  });
-
-  it("prefixes each failure with the tool name", () => {
-    const result = summarizeSetupCheck([
-      {
-        name: "ChatGPT",
-        verification: {
-          clientId: "codex",
-          verified: false,
-          proxyReachable: true,
-          checks: [],
-          failures: ["base URL is not Headroom"]
-        }
-      }
-    ]);
-    expect(result).toEqual({ ok: false, lines: ["ChatGPT: base URL is not Headroom"] });
-  });
-
-  it("waits calmly when the config is right but the proxy is not up yet", () => {
-    const result = summarizeSetupCheck([ok("Claude Code", false)]);
-    expect(result.ok).toBe(false);
-    expect(result.lines[0]).toContain("not answering on 127.0.0.1:6767 yet");
-  });
-});

--- a/src/lib/launcherHelpers.test.ts
+++ b/src/lib/launcherHelpers.test.ts
@@ -385,14 +385,14 @@ describe("what the verify row says while it waits", () => {
 
   it("asks the user to start the tool when nothing is running", () => {
     expect(proxyVerificationRowMessage(row, 0)).toBe(
-      "Open Claude Code and send it any message."
+      "Open Claude Code and send it a message."
     );
   });
 
-  it("says an idle tool is still set up rather than failing", () => {
+  it("asks the user to launch an idle tool rather than failing it", () => {
     const message = proxyVerificationRowMessage({ ...row, state: "idle" }, 0);
-    expect(message).toContain("nothing to test");
-    expect(message).toContain("still set up");
+    expect(message).toContain("haven't used Claude Code recently");
+    expect(message).toContain("Launch it");
   });
 
   it("confirms a verified row", () => {

--- a/src/lib/launcherHelpers.test.ts
+++ b/src/lib/launcherHelpers.test.ts
@@ -385,7 +385,7 @@ describe("what the verify row says while it waits", () => {
 
   it("asks the user to start the tool when nothing is running", () => {
     expect(proxyVerificationRowMessage(row, 0)).toBe(
-      "Open Claude Code and send it the prompt below."
+      "Open Claude Code and send it any message."
     );
   });
 

--- a/src/lib/launcherHelpers.test.ts
+++ b/src/lib/launcherHelpers.test.ts
@@ -2,10 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildInitialProxyVerificationRows,
-  formatConnectorNameList,
   markIdleProxyVerificationRows,
   proxyVerificationRowMessage,
-  testableProxyVerificationRows,
   PROXY_VERIFY_IDLE_AFTER_SECONDS,
   getClaudeConnector,
   getContactRequestValidationError,
@@ -311,20 +309,7 @@ describe("launcher helpers", () => {
   });
 });
 
-describe("formatConnectorNameList", () => {
-  // Feeds the proxy-verify skip warning, which names the connectors that never
-  // checked in. Four can be enabled at once, so the 3+ case is real.
-  it("reads naturally at every connector count", () => {
-    expect(formatConnectorNameList([])).toBe("");
-    expect(formatConnectorNameList(["Claude Code"])).toBe("Claude Code");
-    expect(formatConnectorNameList(["Claude Code", "Codex"])).toBe("Claude Code and Codex");
-    expect(formatConnectorNameList(["Claude Code", "Codex", "OpenCode"])).toBe(
-      "Claude Code, Codex and OpenCode"
-    );
-  });
-});
-
-describe("proxy verification rows the screen should not be testing", () => {
+describe("idle marking and row order", () => {
   const row = (clientId: string, state: "processing" | "verified" | "idle" = "processing") => ({
     clientId,
     name: clientId === "codex" ? "ChatGPT" : "Claude Code",
@@ -341,7 +326,6 @@ describe("proxy verification rows the screen should not be testing", () => {
     });
 
     expect(rows.map((entry) => entry.state)).toEqual(["processing", "idle"]);
-    expect(testableProxyVerificationRows(rows).map((entry) => entry.clientId)).toEqual(["codex"]);
   });
 
   it("sinks idle rows below the ones the user still has to restart", () => {

--- a/src/lib/launcherHelpers.ts
+++ b/src/lib/launcherHelpers.ts
@@ -2,7 +2,6 @@ import { aggregateClientConnectors } from "./dashboardHelpers";
 import type {
   ClaudePlanTier,
   ClientConnectorStatus,
-  ClientSetupVerification,
   CodexPlanTier,
   HeadroomSubscriptionTier,
   LaunchExperience,
@@ -11,15 +10,14 @@ import type {
 export const EMAIL_ADDRESS_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 // Linear onboarding flow shown in the launcher window:
-// install → client_setup → proxy_verify → post_install. Back buttons can jump
-// backwards. The install step doubles as the pre-install landing.
-// Paywall-first experiment (server flag, fresh installs only) reorders to:
-// install(landing) → client_setup → proxy_verify(passthrough) → paywall →
-// install(bootstrap) → post_install.
+// install → client_setup → post_install. Back buttons can jump backwards. The
+// install step doubles as the pre-install landing. The post-install screen
+// carries the per-tool "restart, then send the starter prompt" rows that used
+// to be a separate proxy_verify stage (removed 2026-09-10: the gate produced
+// the "is it broken?" support emails it was meant to prevent).
 export type LauncherStage =
   | "install"
   | "client_setup"
-  | "proxy_verify"
   | "paywall"
   | "post_install";
 
@@ -52,7 +50,7 @@ export type InstallWizardStep = (typeof INSTALL_WIZARD_STEPS)[number];
 export type LauncherAutoConfigureDecision =
   | "show_client_setup"
   | "apply_client_setup"
-  | "begin_proxy_verification";
+  | "begin_post_install";
 
 /// Step the launcher's auto-configure flow should take next, given a fresh
 /// connector probe. The component is responsible for performing the IPC
@@ -60,7 +58,7 @@ export type LauncherAutoConfigureDecision =
 export type AutoConfigureStep =
   | { kind: "show_client_setup" }
   | { kind: "apply"; clientIds: string[] }
-  | { kind: "begin_proxy_verification" };
+  | { kind: "begin_post_install" };
 
 export interface ProxyVerificationRowState {
   clientId: string;
@@ -164,7 +162,7 @@ export function getLauncherAutoConfigureDecision(
   if (installed.some((connector) => !connector.enabled)) {
     return "apply_client_setup";
   }
-  return "begin_proxy_verification";
+  return "begin_post_install";
 }
 
 /// Copy for the launcher's magic-link screen (headroom://auth). Success has no
@@ -232,23 +230,23 @@ export function nextAutoConfigureStep(
     }
     return { kind: "apply", clientIds };
   }
-  return { kind: "begin_proxy_verification" };
+  return { kind: "begin_post_install" };
 }
 
 /// Second step of the launcher's auto-configure flow: after the apply IPC
-/// resolved, decide whether to advance to proxy verification or bail back to
+/// resolved, decide whether to advance to the post-install screen or bail back to
 /// the manual setup screen. Reuses `nextAutoConfigureStep`'s decision branch
 /// since the post-apply state is just a re-evaluation of the connector probe.
 export function nextAutoConfigureStepAfterApply(
   postApplyDecision: LauncherAutoConfigureDecision
 ): AutoConfigureStep {
-  if (postApplyDecision === "begin_proxy_verification") {
-    return { kind: "begin_proxy_verification" };
+  if (postApplyDecision === "begin_post_install") {
+    return { kind: "begin_post_install" };
   }
   return { kind: "show_client_setup" };
 }
 
-/// How long an agent can go untouched before the verify screen stops asking
+/// How long an agent can go untouched before the post-install rows stop asking
 /// the user to prove it works. Long enough to cover a weekend, short enough
 /// that a tool the user has genuinely moved on from drops out.
 export const PROXY_VERIFY_IDLE_AFTER_SECONDS = 7 * 24 * 60 * 60;
@@ -280,43 +278,6 @@ export function testableProxyVerificationRows(
   return rows.filter((row) => row.state !== "idle");
 }
 
-/// The verify screen's background config check, folded into one line. It
-/// replaces a "Check my setup" button whose pass message sat next to a "Skip
-/// for now" button and read as failure anyway: two support cases in three days
-/// (2026-09-08, 2026-09-10) were healthy installs whose users could not tell.
-export function summarizeSetupCheck(
-  results: { name: string; verification: ClientSetupVerification | null }[]
-): { ok: boolean; lines: string[] } {
-  const unreadable = results.filter((result) => result.verification === null);
-  if (unreadable.length > 0) {
-    return {
-      ok: false,
-      lines: [
-        `Could not read the setup for ${formatConnectorNameList(
-          unreadable.map((result) => result.name)
-        )}.`
-      ]
-    };
-  }
-  const failures = results.flatMap(({ name, verification }) =>
-    verification && !verification.verified
-      ? verification.failures.map((failure) => `${name}: ${failure}`)
-      : []
-  );
-  if (failures.length > 0) {
-    return { ok: false, lines: failures };
-  }
-  if (!results.some(({ verification }) => verification?.proxyReachable)) {
-    return {
-      ok: false,
-      lines: [
-        "Your tools are pointed at Headroom, but it is not answering on 127.0.0.1:6767 yet. This usually clears within a minute."
-      ]
-    };
-  }
-  return { ok: true, lines: [] };
-}
-
 /// What the row says while it waits. It has to distinguish "your tool is
 /// still holding the old settings" from "you have not opened it" -- a support
 /// case (2026-09-08) sat 2h42m on a copy that could not. It does NOT count
@@ -333,9 +294,9 @@ export function proxyVerificationRowMessage(
     return `Not used on this machine recently, so there is nothing to test. ${row.name} is still set up.`;
   }
   if (runningSessions > 0) {
-    return `Still open with the old settings. Quit and reopen ${row.name}, then send it any message.`;
+    return `Still open with the old settings. Quit and reopen ${row.name}, then send it the prompt below.`;
   }
-  return `Open ${row.name} and send it any message.`;
+  return `Open ${row.name} and send it the prompt below.`;
 }
 
 export function buildInitialProxyVerificationRows(

--- a/src/lib/launcherHelpers.ts
+++ b/src/lib/launcherHelpers.ts
@@ -295,12 +295,12 @@ export function proxyVerificationRowMessage(
     return "Request received";
   }
   if (row.state === "idle") {
-    return `Not used on this machine recently, so there is nothing to test. ${row.name} is still set up.`;
+    return `Looks like you haven't used ${row.name} recently. Launch it and send it a message.`;
   }
   if (runningSessions > 0) {
-    return `Still open with the old settings. Quit and reopen ${row.name}, then send it any message.`;
+    return `Quit and reopen ${row.name}, then send it a message.`;
   }
-  return `Open ${row.name} and send it any message.`;
+  return `Open ${row.name} and send it a message.`;
 }
 
 export function buildInitialProxyVerificationRows(

--- a/src/lib/launcherHelpers.ts
+++ b/src/lib/launcherHelpers.ts
@@ -256,11 +256,14 @@ export const PROXY_VERIFY_IDLE_AFTER_SECONDS = 7 * 24 * 60 * 60;
 /// so it would hold the screen in a failed-looking state forever and tell a
 /// perfectly healthy install that its setup is broken. Ages come from
 /// `get_client_local_activity_ages`; a missing entry means "never seen".
+/// Idle rows sink to the bottom so the tool the user has to act on is first
+/// (stable sort: the name order from `buildInitialProxyVerificationRows` holds
+/// within each group).
 export function markIdleProxyVerificationRows(
   rows: ProxyVerificationRowState[],
   activityAgesSeconds: Record<string, number>
 ): ProxyVerificationRowState[] {
-  return rows.map((row) => {
+  const marked: ProxyVerificationRowState[] = rows.map((row) => {
     if (row.state === "verified") {
       return row;
     }
@@ -268,6 +271,7 @@ export function markIdleProxyVerificationRows(
     const idle = age === undefined || age > PROXY_VERIFY_IDLE_AFTER_SECONDS;
     return idle === (row.state === "idle") ? row : { ...row, state: idle ? "idle" : "processing" };
   });
+  return marked.sort((a, b) => Number(a.state === "idle") - Number(b.state === "idle"));
 }
 
 /// The rows the screen is actually testing. An idle connector is shown but not

--- a/src/lib/launcherHelpers.ts
+++ b/src/lib/launcherHelpers.ts
@@ -2,6 +2,7 @@ import { aggregateClientConnectors } from "./dashboardHelpers";
 import type {
   ClaudePlanTier,
   ClientConnectorStatus,
+  ClientSetupVerification,
   CodexPlanTier,
   HeadroomSubscriptionTier,
   LaunchExperience,
@@ -279,34 +280,48 @@ export function testableProxyVerificationRows(
   return rows.filter((row) => row.state !== "idle");
 }
 
-/// The "Check my setup" result when nothing is misconfigured. Which of the
-/// three cases it is decides what the user should do next, and the single
-/// frozen line it replaces told a user whose only tool was already verified to
-/// quit and reopen it - which reads as "so it still is not working" on a screen
-/// showing a green VERIFIED pill (2026-09-09).
-export function setupCheckSuccessMessage(rows: ProxyVerificationRowState[]): string {
-  const prefix = "Your configuration is correct and Headroom is running.";
-  const testable = testableProxyVerificationRows(rows);
-  if (testable.length === 0) {
-    return `${prefix} None of your tools have been used on this machine recently, so there is nothing to test. Headroom starts saving the moment you use one.`;
+/// The verify screen's background config check, folded into one line. It
+/// replaces a "Check my setup" button whose pass message sat next to a "Skip
+/// for now" button and read as failure anyway: two support cases in three days
+/// (2026-09-08, 2026-09-10) were healthy installs whose users could not tell.
+export function summarizeSetupCheck(
+  results: { name: string; verification: ClientSetupVerification | null }[]
+): { ok: boolean; lines: string[] } {
+  const unreadable = results.filter((result) => result.verification === null);
+  if (unreadable.length > 0) {
+    return {
+      ok: false,
+      lines: [
+        `Could not read the setup for ${formatConnectorNameList(
+          unreadable.map((result) => result.name)
+        )}.`
+      ]
+    };
   }
-  const waiting = testable.filter((row) => row.state !== "verified");
-  if (waiting.length === 0) {
-    return `${prefix} Every tool above has already reached it, so there is nothing left to do.`;
+  const failures = results.flatMap(({ name, verification }) =>
+    verification && !verification.verified
+      ? verification.failures.map((failure) => `${name}: ${failure}`)
+      : []
+  );
+  if (failures.length > 0) {
+    return { ok: false, lines: failures };
   }
-  // Deliberately does NOT repeat "quit and reopen X": the row above each tool
-  // already says that, and the screen was printing the same instruction three
-  // times (row, this line, and the skip notice).
-  return `${prefix} Nothing is broken: no prompt from ${formatConnectorNameList(
-    waiting.map((row) => row.name)
-  )} has reached it yet.`;
+  if (!results.some(({ verification }) => verification?.proxyReachable)) {
+    return {
+      ok: false,
+      lines: [
+        "Your tools are pointed at Headroom, but it is not answering on 127.0.0.1:6767 yet. This usually clears within a minute."
+      ]
+    };
+  }
+  return { ok: true, lines: [] };
 }
 
-/// What the row says while it waits. The old copy was a single frozen
-/// "Waiting for a X prompt..." that looked identical at second 0 and at hour
-/// 2, so a user with a stale terminal had no way to tell "normal" from
-/// "broken" -- and a support case (2026-09-08) sat on it for 2h42m before
-/// asking whether the product worked. It did; he needed to restart his tool.
+/// What the row says while it waits. It has to distinguish "your tool is
+/// still holding the old settings" from "you have not opened it" -- a support
+/// case (2026-09-08) sat 2h42m on a copy that could not. It does NOT count
+/// sessions: "10 sessions are running" is our vocabulary for VS Code terminal
+/// panes and only alarmed people (2026-09-10 support screenshot).
 export function proxyVerificationRowMessage(
   row: ProxyVerificationRowState,
   runningSessions: number
@@ -318,10 +333,9 @@ export function proxyVerificationRowMessage(
     return `Not used on this machine recently, so there is nothing to test. ${row.name} is still set up.`;
   }
   if (runningSessions > 0) {
-    const sessions = runningSessions === 1 ? "session is" : `sessions are`;
-    return `${runningSessions} ${sessions} running, but started before setup and still hold the old settings. Quit and reopen ${row.name}, then send it any message.`;
+    return `Still open with the old settings. Quit and reopen ${row.name}, then send it any message.`;
   }
-  return `Not running yet. Open ${row.name} and send it any message.`;
+  return `Open ${row.name} and send it any message.`;
 }
 
 export function buildInitialProxyVerificationRows(

--- a/src/lib/launcherHelpers.ts
+++ b/src/lib/launcherHelpers.ts
@@ -298,9 +298,9 @@ export function proxyVerificationRowMessage(
     return `Not used on this machine recently, so there is nothing to test. ${row.name} is still set up.`;
   }
   if (runningSessions > 0) {
-    return `Still open with the old settings. Quit and reopen ${row.name}, then send it the prompt below.`;
+    return `Still open with the old settings. Quit and reopen ${row.name}, then send it any message.`;
   }
-  return `Open ${row.name} and send it the prompt below.`;
+  return `Open ${row.name} and send it any message.`;
 }
 
 export function buildInitialProxyVerificationRows(

--- a/src/lib/launcherHelpers.ts
+++ b/src/lib/launcherHelpers.ts
@@ -274,14 +274,6 @@ export function markIdleProxyVerificationRows(
   return marked.sort((a, b) => Number(a.state === "idle") - Number(b.state === "idle"));
 }
 
-/// The rows the screen is actually testing. An idle connector is shown but not
-/// counted, so one dormant tool cannot withhold the success button.
-export function testableProxyVerificationRows(
-  rows: ProxyVerificationRowState[]
-): ProxyVerificationRowState[] {
-  return rows.filter((row) => row.state !== "idle");
-}
-
 /// What the row says while it waits. It has to distinguish "your tool is
 /// still holding the old settings" from "you have not opened it" -- a support
 /// case (2026-09-08) sat 2h42m on a copy that could not. It does NOT count
@@ -315,15 +307,4 @@ export function buildInitialProxyVerificationRows(
       state: "processing",
       message: `Waiting for a ${connector.name} prompt...`
     }));
-}
-
-/// Join connector names for the skip warning on the proxy-verify step. Up to
-/// four connectors can be enabled at once, so a plain `join(" and ")` mangles
-/// the 3+ case. `Intl.ListFormat` does this properly but needs an ES2021 lib,
-/// and one warning line is not worth raising the whole project's target.
-export function formatConnectorNameList(names: string[]): string {
-  if (names.length <= 1) {
-    return names.join("");
-  }
-  return `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
 }

--- a/src/lib/platform.test.ts
+++ b/src/lib/platform.test.ts
@@ -13,8 +13,8 @@ describe("platformPreviewNoticeFor", () => {
     expect(platformPreviewNoticeFor("linux", "experimental")).toContain("Linux");
   });
 
-  it("returns the windows message for experimental windows", () => {
-    expect(platformPreviewNoticeFor("windows", "experimental")).toContain("Windows");
+  it("returns null for windows, which is no longer a preview platform", () => {
+    expect(platformPreviewNoticeFor("windows", "stable")).toBeNull();
   });
 
   it("returns the generic message for other experimental platforms", () => {

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -7,9 +7,8 @@ export function platformPreviewNoticeFor(
   if (supportTier !== "experimental") {
     return null;
   }
-  if (platform === "linux" || platform === "windows") {
-    const name = platform === "linux" ? "Linux" : "Windows";
-    return `${name} is currently in preview.`;
+  if (platform === "linux") {
+    return "Linux is currently in preview.";
   }
   return "This platform is currently in preview.";
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -467,21 +467,6 @@ select {
   margin-top: 10px;
 }
 
-.post-install__troubleshoot {
-  margin-top: 14px;
-  border: 0;
-  background: transparent;
-  padding: 0;
-  font-size: var(--text-sm);
-  color: var(--text-muted);
-  text-decoration: underline;
-  cursor: pointer;
-}
-
-.post-install__troubleshoot:hover {
-  color: var(--accent);
-}
-
 .post-install__actions p {
   margin: 12px 0 0;
   font-size: var(--text-sm);

--- a/src/styles.css
+++ b/src/styles.css
@@ -587,7 +587,12 @@ select {
 }
 
 .install-progress-shell {
-  min-height: 84px;
+  /* Reserves the progress block's height so the install button doesn't jump
+     when the bar appears. Sized to what it actually needs (35px + its 14px
+     margin-top): at the old 84px the extra 34px pushed the pre-install state
+     to 547px inside the fixed 540px launcher window, which tripped
+     .intro-shell's scroll fallback and drew a scrollbar on first run. */
+  min-height: 52px;
   padding-bottom: 4px;
   display: flex;
   align-items: flex-end;


### PR DESCRIPTION
Stable 0.9.15 from staging rc.10. No release notes file, so latest.json ships an empty `notes` and the update stays quiet (no `headroom:loud` marker).

Contents since 0.9.14: post-install/verify screen consolidation, Sentry triage fixes (retag skip cap, bind-error diagnosis, OS-string bridging). No wheel pin change, no compression vendor change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)